### PR TITLE
Reduce InstanceData footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Incorrect window location with negative `window.position` config options
+- Slow rendering performance with HiDPI displays, especially on macOS
 
 ## 0.5.0
 

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -15,7 +15,7 @@
 in vec2 TexCoords;
 flat in vec3 fg;
 flat in vec4 bg;
-flat in int colored;
+flat in int multicolor;
 uniform int backgroundPass;
 
 layout(location = 0, index = 0) out vec4 color;
@@ -32,7 +32,7 @@ void main()
         alphaMask = vec4(1.0);
         color = vec4(bg.rgb, 1.0);
     } else {
-        if (colored != 0) {
+        if (multicolor != 0) {
             // Color glyphs, like emojis.
             vec4 glyphColor = texture(mask, TexCoords);
             alphaMask = vec4(glyphColor.a);

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -31,7 +31,7 @@ void main()
         alphaMask = vec4(1.0);
         color = vec4(bg.rgb, 1.0);
     } else {
-        if (fg.a != 0.) {
+        if (fg.a != 0.0) {
             // Color glyphs, like emojis.
             vec4 glyphColor = texture(mask, TexCoords);
             alphaMask = vec4(glyphColor.a);

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -13,9 +13,8 @@
 // limitations under the License.
 #version 330 core
 in vec2 TexCoords;
-flat in vec3 fg;
+flat in vec4 fg;
 flat in vec4 bg;
-flat in int multicolor;
 uniform int backgroundPass;
 
 layout(location = 0, index = 0) out vec4 color;
@@ -32,7 +31,7 @@ void main()
         alphaMask = vec4(1.0);
         color = vec4(bg.rgb, 1.0);
     } else {
-        if (multicolor != 0) {
+        if (fg.a != 0.) {
             // Color glyphs, like emojis.
             vec4 glyphColor = texture(mask, TexCoords);
             alphaMask = vec4(glyphColor.a);
@@ -47,7 +46,7 @@ void main()
             // Regular text glyphs.
             vec3 textColor = texture(mask, TexCoords).rgb;
             alphaMask = vec4(textColor, textColor.r);
-            color = vec4(fg, 1.0);
+            color = vec4(fg.rgb, 1.0);
         }
     }
 }

--- a/alacritty/res/text.v.glsl
+++ b/alacritty/res/text.v.glsl
@@ -21,16 +21,15 @@ layout (location = 1) in vec4 glyph;
 // uv mapping.
 layout (location = 2) in vec4 uv;
 
-// Text fg color.
+// Text foreground rgb packed together with multicolor flag.
 layout (location = 3) in vec4 textColor;
 
 // Background color.
 layout (location = 4) in vec4 backgroundColor;
 
 out vec2 TexCoords;
-flat out vec3 fg;
+flat out vec4 fg;
 flat out vec4 bg;
-flat out int multicolor;
 
 // Terminal properties
 uniform vec2 cellDim;
@@ -71,6 +70,5 @@ void main()
     }
 
     bg = vec4(backgroundColor.rgb / 255.0, backgroundColor.a);
-    fg = textColor.rgb / 255.0;
-    multicolor = int(textColor.a);
+    fg = vec4(textColor.rgb / 255.0, textColor.a);
 }

--- a/alacritty/res/text.v.glsl
+++ b/alacritty/res/text.v.glsl
@@ -22,18 +22,15 @@ layout (location = 1) in vec4 glyph;
 layout (location = 2) in vec4 uv;
 
 // Text fg color.
-layout (location = 3) in vec3 textColor;
+layout (location = 3) in vec4 textColor;
 
 // Background color.
 layout (location = 4) in vec4 backgroundColor;
 
-// Set to 1 if the glyph colors should be kept.
-layout (location = 5) in int coloredGlyph;
-
 out vec2 TexCoords;
 flat out vec3 fg;
 flat out vec4 bg;
-flat out int colored;
+flat out int multicolor;
 
 // Terminal properties
 uniform vec2 cellDim;
@@ -74,6 +71,6 @@ void main()
     }
 
     bg = vec4(backgroundColor.rgb / 255.0, backgroundColor.a);
-    fg = textColor / vec3(255.0, 255.0, 255.0);
-    colored = coloredGlyph;
+    fg = textColor.rgb / 255.0;
+    multicolor = int(textColor.a);
 }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -407,9 +407,9 @@ struct InstanceData {
     uv_width: f32,
     uv_height: f32,
     // Color.
-    r: u8,
-    g: u8,
-    b: u8,
+    r: f32,
+    g: f32,
+    b: f32,
     // Background color.
     bg_r: u8,
     bg_g: u8,
@@ -484,9 +484,9 @@ impl Batch {
             uv_width: glyph.uv_width,
             uv_height: glyph.uv_height,
 
-            r: cell.fg.r,
-            g: cell.fg.g,
-            b: cell.fg.b,
+            r: f32::from(cell.fg.r),
+            g: f32::from(cell.fg.g),
+            b: f32::from(cell.fg.b),
 
             bg_r: cell.bg.r,
             bg_g: cell.bg.g,
@@ -622,14 +622,14 @@ impl QuadRenderer {
             gl::VertexAttribPointer(
                 3,
                 3,
-                gl::UNSIGNED_BYTE,
+                gl::FLOAT,
                 gl::FALSE,
                 size_of::<InstanceData>() as i32,
                 size as *const _,
             );
             gl::EnableVertexAttribArray(3);
             gl::VertexAttribDivisor(3, 1);
-            size += 3 * size_of::<u8>();
+            size += 3 * size_of::<f32>();
             // Background color.
             gl::VertexAttribPointer(
                 4,

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -124,7 +124,7 @@ pub struct RectShaderProgram {
 #[derive(Copy, Debug, Clone)]
 pub struct Glyph {
     tex_id: GLuint,
-    multicolor: i8,
+    multicolor: u8,
     top: i16,
     left: i16,
     width: i16,
@@ -407,16 +407,16 @@ struct InstanceData {
     uv_width: f32,
     uv_height: f32,
     // Color.
-    r: f32,
-    g: f32,
-    b: f32,
+    r: u8,
+    g: u8,
+    b: u8,
+    // Flag indicating that a glyph uses multiple colors; like an Emoji.
+    multicolor: u8,
     // Background color.
     bg_r: u8,
     bg_g: u8,
     bg_b: u8,
     bg_a: u8,
-    // Flag indicating that glyph uses multiple colors, like an Emoji.
-    multicolor: i8,
 }
 
 #[derive(Debug)]
@@ -484,9 +484,9 @@ impl Batch {
             uv_width: glyph.uv_width,
             uv_height: glyph.uv_height,
 
-            r: f32::from(cell.fg.r),
-            g: f32::from(cell.fg.g),
-            b: f32::from(cell.fg.b),
+            r: cell.fg.r,
+            g: cell.fg.g,
+            b: cell.fg.b,
 
             bg_r: cell.bg.r,
             bg_g: cell.bg.g,
@@ -615,14 +615,11 @@ impl QuadRenderer {
             // UV offset.
             add_attr!(4, gl::FLOAT, f32);
 
-            // Color.
-            add_attr!(3, gl::FLOAT, f32);
+            // Color and multicolor flag.
+            add_attr!(4, gl::UNSIGNED_BYTE, u8);
 
             // Background color.
             add_attr!(4, gl::UNSIGNED_BYTE, u8);
-
-            // Multicolor flag.
-            add_attr!(1, gl::BYTE, i8);
 
             // Rectangle setup.
             gl::GenVertexArrays(1, &mut rect_vao);
@@ -1613,7 +1610,7 @@ impl Atlas {
 
         Glyph {
             tex_id: self.id,
-            multicolor: multicolor as i8,
+            multicolor: multicolor as u8,
             top: glyph.top as i16,
             left: glyph.left as i16,
             width: width as i16,

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1098,14 +1098,14 @@ fn load_glyph(
         Err(AtlasInsertError::GlyphTooLarge) => Glyph {
             tex_id: atlas[*current_atlas].id,
             multicolor: 0,
-            top: 0 as _,
-            left: 0 as _,
-            width: 0 as _,
-            height: 0 as _,
-            uv_bot: 0 as _,
-            uv_left: 0 as _,
-            uv_width: 0 as _,
-            uv_height: 0 as _,
+            top: 0,
+            left: 0,
+            width: 0,
+            height: 0,
+            uv_bot: 0.,
+            uv_left: 0.,
+            uv_width: 0.,
+            uv_height: 0.,
         },
     }
 }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -616,6 +616,10 @@ impl QuadRenderer {
             add_attr!(4, gl::FLOAT, f32);
 
             // Color and multicolor flag.
+            //
+            // These are packed together because of an OpenGL driver issue on macOS, which caused a
+            // `vec3(u8)` text color and a `u8` multicolor flag to increase the rendering time by a
+            // huge margin.
             add_attr!(4, gl::UNSIGNED_BYTE, u8);
 
             // Background color.


### PR DESCRIPTION
The InstanceData type in the rendering subsystem was previously 16
floats which occupied a total of 64 bytes per instance. This meant that
for every character or background cell drawn, 64 bytes were sent to the
GPU. In the case of a 400x100 cell grid, a total of 2.5MB would be sent.

This patch reduces InstanceData's size to 26 bytes, a 60% improvement!
Using the above example for comparison, a worst case of 1MB would be
transferred.

The motivation for this patch comes from macOS. Once the terminal grid
would reach a certain size, performance experienced a sharp and dramatic
drop (render times would go from ~3ms to ~16ms). I don't want to
speculate too much on the underlying issue, but suffice it to say that
this patch alleviates the problem in my testing.

If this patch looks familiar, it's because it was just landed a few days ago in #643! It ended up being reverted due to #648. There's clearly some more work needed in order to land this properly, so it has returned in a new PR to continue development.