### PR TITLE
[wip] Sodiumjoe/607 multiple windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1863,7 +1863,7 @@ pub trait OnConfigReload {
     fn on_config_reload(&mut self);
 }
 
-impl OnConfigReload for ::display::Notifier {
+impl OnConfigReload for ::window::Notifier {
     fn on_config_reload(&mut self) {
         self.notify();
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,6 +24,9 @@ use {LogicalPosition, LogicalSize, MouseCursor, PhysicalSize};
 
 use cli::Options;
 use config::{Decorations, WindowConfig};
+use display::OnResize;
+use event_loop::WindowNotifier;
+use term::SizeInfo;
 
 /// Default text for the window's title bar, if not overriden.
 ///
@@ -361,6 +364,10 @@ impl Window {
         None
     }
 
+    pub fn notifier(&self) -> Notifier {
+        Notifier(self.create_window_proxy())
+    }
+
     /// Hide the window
     pub fn hide(&self) {
         self.window.hide();
@@ -444,5 +451,26 @@ impl Proxy {
     /// be waiting on user input.
     pub fn wakeup_event_loop(&self) {
         self.inner.wakeup().unwrap();
+    }
+}
+
+impl OnResize for Window {
+    #[inline]
+    fn on_resize(&mut self, size: &SizeInfo) {
+        self.resize(PhysicalSize::new(size.width as f64, size.height as f64));
+    }
+}
+
+pub struct Notifier(Proxy);
+
+impl Notifier {
+    pub fn notify(&self) {
+        self.0.wakeup_event_loop();
+    }
+}
+
+impl WindowNotifier for Notifier {
+    fn notify(&self) {
+        self.notify()
     }
 }


### PR DESCRIPTION
This is working off of `mkeeler:glutin-0.17-upgrade`, so just the last two commits are mine. You can check out just the relevant diff [here](https://github.com/mkeeler/alacritty/compare/glutin-0.17-upgrade...sodiumjoe:sodiumjoe/607-multiple-windows?expand=1).

I've basically been just trying to factor things (in a cargo-culty way) so that it's possible to create multiple windows without changing any logic. This compiles and runs, and will even create two windows (if hardcoded in).

But I seem to be missing something, because even with just one window, there are some issues.
1. sometimes the terminal doesn't update
2. certain keys are triggered twice (like backspace)

I haven't tried to get the second window working in earnest yet, but I'll describe what happens in case it helps diagnose the single window case. One window seems to work just like the single-window case, but the second window at first renders with just the blank background color, and on any interaction becomes transparent. It seems to still take window events, like resize events and keyboard input, but it doesn't display anything. With both windows attached to a tmux session, I can see keyboard input from the second window take effect in the first window, but not immediately, only after interacting with the second window.

I'd like to get the single window case working properly before trying to get multiple windows working and I'm kinda stuck, so I'm hoping someone else can take a look and see if I missed something obvious or point me at some better debugging methods. I've tried with `--print-events`, and the events there appear to be totally normal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jwilm/alacritty/1589)
<!-- Reviewable:end -->
