### PR TITLE
Fix Windows config location documontation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Windows configuration location has been moved from %USERPROFILE\alacritty.yml
-    to %APPDATA%\Roaming\alacritty\alacritty.yml
+- Windows configuration location has been moved from %USERPROFILE%\alacritty.yml
+    to %APPDATA%\alacritty\alacritty.yml
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ file, please consult the comments in the default config file.
 
 On Windows the config file is located at:
 
-`%APPDATA%\Roaming\alacritty\alacritty.yml`
+`%APPDATA%\alacritty\alacritty.yml`
 
 ## Issues (known, unknown, feature requests, etc.)
 


### PR DESCRIPTION
The path `%APPDATA%` already includes the `Roaming` folder.