### PR TITLE
Add support for running commands on BEL

### DIFF
--- a/alacritty_terminal/src/config/bell.rs
+++ b/alacritty_terminal/src/config/bell.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use crate::config::bindings::CommandWrapper;
 use crate::config::failure_default;
 use crate::term::color::Rgb;
 
@@ -28,7 +29,7 @@ impl Default for BellConfig {
             animation: Default::default(),
             duration: Default::default(),
             color: default_visual_bell_color(),
-            bell_command: None,
+            command: None,
         }
     }
 }

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Deserializer};
 
+mod bell;
 mod bindings;
 mod colors;
 mod debug;
@@ -27,20 +28,19 @@ mod mouse;
 mod scrolling;
 #[cfg(test)]
 mod test;
-mod visual_bell;
 mod window;
 
 use crate::ansi::CursorStyle;
 use crate::input::{Binding, KeyBinding, MouseBinding};
 
-pub use crate::config::bindings::Key;
+pub use crate::config::bell::{BellConfig, VisualBellAnimation};
+pub use crate::config::bindings::{CommandWrapper, Key};
 pub use crate::config::colors::Colors;
 pub use crate::config::debug::Debug;
 pub use crate::config::font::{Font, FontDescription};
 pub use crate::config::monitor::Monitor;
 pub use crate::config::mouse::{ClickHandler, Mouse};
 pub use crate::config::scrolling::Scrolling;
-pub use crate::config::visual_bell::{VisualBellAnimation, VisualBellConfig};
 pub use crate::config::window::{Decorations, Dimensions, StartupMode, WindowConfig};
 
 pub static DEFAULT_ALACRITTY_CONFIG: &str =
@@ -99,9 +99,13 @@ pub struct Config {
     #[serde(default, deserialize_with = "failure_default")]
     pub config_path: Option<PathBuf>,
 
-    /// Visual bell configuration
+    /// Bell configuration
     #[serde(default, deserialize_with = "failure_default")]
-    pub visual_bell: VisualBellConfig,
+    pub bell: BellConfig,
+
+    // TODO: DEPRECATED
+    #[serde(default, deserialize_with = "failure_default")]
+    visual_bell: BellConfig,
 
     /// Use dynamic title
     #[serde(default, deserialize_with = "failure_default")]

--- a/alacritty_terminal/src/config/visual_bell.rs
+++ b/alacritty_terminal/src/config/visual_bell.rs
@@ -5,7 +5,7 @@ use crate::term::color::Rgb;
 
 #[serde(default)]
 #[derive(Debug, Deserialize, PartialEq, Eq)]
-pub struct VisualBellConfig {
+pub struct BellConfig {
     /// Visual bell animation function
     #[serde(deserialize_with = "failure_default")]
     pub animation: VisualBellAnimation,
@@ -17,19 +17,23 @@ pub struct VisualBellConfig {
     /// Visual bell flash color
     #[serde(deserialize_with = "failure_default")]
     pub color: Rgb,
+
+    #[serde(deserialize_with = "failure_default")]
+    pub command: Option<CommandWrapper>,
 }
 
-impl Default for VisualBellConfig {
-    fn default() -> VisualBellConfig {
-        VisualBellConfig {
+impl Default for BellConfig {
+    fn default() -> BellConfig {
+        BellConfig {
             animation: Default::default(),
             duration: Default::default(),
             color: default_visual_bell_color(),
+            bell_command: None,
         }
     }
 }
 
-impl VisualBellConfig {
+impl BellConfig {
     /// Visual bell duration in milliseconds
     #[inline]
     pub fn duration(&self) -> Duration {

--- a/alacritty_terminal/src/display.rs
+++ b/alacritty_terminal/src/display.rs
@@ -438,7 +438,7 @@ impl Display {
     pub fn draw(&mut self, terminal: &FairMutex<Term>, config: &Config) {
         let mut terminal = terminal.lock();
         let size_info = *terminal.size_info();
-        let visual_bell_intensity = terminal.visual_bell.intensity();
+        let visual_bell_intensity = terminal.bell.intensity();
         let background_color = terminal.background_color();
         let metrics = self.glyph_cache.font_metrics();
 
@@ -450,7 +450,7 @@ impl Display {
         let message_buffer = terminal.message_buffer_mut().message();
 
         // Clear dirty flag
-        terminal.dirty = !terminal.visual_bell.completed();
+        terminal.dirty = !terminal.bell.completed();
 
         if let Some(title) = terminal.get_next_title() {
             self.window.set_title(&title);

--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -709,7 +709,7 @@ impl QuadRenderer {
         }
 
         // Draw visual bell
-        let color = config.visual_bell.color;
+        let color = config.bell.color;
         let rect = Rect::new(0., 0., props.width, props.height);
         self.render_rect(&rect, color, visual_bell_intensity as f32, props);
 


### PR DESCRIPTION
Adds a new configuration option under `visual_bell` called
`bell_command` that reuses the command formatting of the keybindings.

This allows for things like playing a notification sound.
See https://github.com/jwilm/alacritty/issues/1528#issuecomment-425691029

Closes #1528 