### PR TITLE
Track and report damage to compatible compositors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Escape sequence to save and restore window title from stack
 - Alternate scroll escape sequence (`CSI ? 1007 h` / `CSI ? 1007 l`)
 - Print name of launch command if Alacritty failed to execute it
+- Track and report damage to supported compositors (primarily Wayland)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Escape sequence to save and restore window title from stack
 - Alternate scroll escape sequence (`CSI ? 1007 h` / `CSI ? 1007 l`)
 - Print name of launch command if Alacritty failed to execute it
-- Track and report damage to supported compositors (primarily Wayland)
+- Track and report damage to compatible compositors (primarily Wayland)
 
 ### Changed
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -394,7 +394,7 @@ impl Display {
                 Some(
                     terminal
                         .get_damage()
-                        .iter()
+                        .into_iter()
                         .map(|d| {
                             // Make end coordinates be lower right corner instead of upper
                             // left. Also add one more to end_x to compensate for the

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -14,8 +14,7 @@
 
 //! The display subsystem including window management, font rasterization, and
 //! GPU drawing.
-use std::cmp::min;
-use std::cmp::max;
+use std::cmp::{max, min};
 use std::f64;
 use std::fmt;
 use std::time::Instant;
@@ -391,35 +390,43 @@ impl Display {
                 Some(vec![Rect { x: 0, y: 0, width, height }])
             } else {
                 // Fetch and clear damage
-                Some(terminal.get_damage()
-                    .iter()
-                    .map(|d| {
-                        // Make end coordinates be lower right corner instead of upper
-                        // left. Also add one more to end_x to compensate for the
-                        // possibility of the end position being a double width
-                        // character.
-                        let (x, y, end_x, end_y) =
-                            (d.x as u32, d.y as u32, (d.end_x + 2) as u32, (d.end_y + 1) as u32);
+                Some(
+                    terminal
+                        .get_damage()
+                        .iter()
+                        .map(|d| {
+                            // Make end coordinates be lower right corner instead of upper
+                            // left. Also add one more to end_x to compensate for the
+                            // possibility of the end position being a double width
+                            // character.
+                            let (x, y, end_x, end_y) = (
+                                d.x as u32,
+                                d.y as u32,
+                                (d.end_x + 2) as u32,
+                                (d.end_y + 1) as u32
+                            );
 
-                        // Then, convert the grid to a rect in gl coordinates
-                        let rect = Rect {
-                            x: x * cell_width + padding_x,
-                            y: height - end_y * cell_height - padding_y,
-                            width: (end_x - x) * cell_width,
-                            height: (end_y - y) * cell_height,
-                        };
+                            // Then, convert the grid to a rect in gl coordinates
+                            let rect = Rect {
+                                x: x * cell_width + padding_x,
+                                y: height - end_y * cell_height - padding_y,
+                                width: (end_x - x) * cell_width,
+                                height: (end_y - y) * cell_height,
+                            };
 
-                        // And finally, add half a cell of horizontal, quarter of a
-                        // cell of vertical padding to cover overdraw.
-                        let x = rect.x.saturating_sub(cell_width / 2);
-                        let y = rect.y.saturating_sub(cell_height / 4);
-                        Rect {
-                            x: x,
-                            y: y,
-                            width: min(width-x, rect.width + cell_width),
-                            height: min(height-y, rect.height + cell_height / 2),
-                        }
-                    }).collect())
+                            // And finally, add half a cell of horizontal, quarter of a
+                            // cell of vertical padding to cover overdraw.
+                            let x = rect.x.saturating_sub(cell_width / 2);
+                            let y = rect.y.saturating_sub(cell_height / 4);
+                            Rect {
+                                x,
+                                y,
+                                width: min(width - x, rect.width + cell_width),
+                                height: min(height - y, rect.height + cell_height / 2),
+                            }
+                        })
+                        .collect(),
+                )
             }
         } else {
             None

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -380,7 +380,8 @@ impl Display {
 
         // Check grid damage
         let damage: Option<Vec<Rect>> = if self.damage_supported {
-            let (width, height, cell_width, cell_height, padding_x, padding_y) = size_info.to_u32();
+            let (width, height, cell_width, cell_height, padding_x, padding_y) =
+                size_info.into_u32();
 
             if self.fully_damaged {
                 // We need to fully damaged, so let's clear damage and stop
@@ -403,7 +404,7 @@ impl Display {
                                 d.x as u32,
                                 d.y as u32,
                                 (d.end_x + 2) as u32,
-                                (d.end_y + 1) as u32
+                                (d.end_y + 1) as u32,
                             );
 
                             // Then, convert the grid to a rect in gl coordinates

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -393,8 +393,7 @@ impl Display {
                 size_info.into_u32();
 
             if self.fully_damaged || visual_bell_animating || config.render_timer() {
-                // We need to fully damaged, so let's clear damage and stop
-                // here.
+                // We need to fully damage, so let's clear damage and stop here
                 terminal.reset_damage();
                 self.fully_damaged = false;
                 None

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -400,13 +400,13 @@ impl Display {
                 Some(vec![Rect { x: 0, y: 0, width, height }])
             } else {
                 // Fetch and clear damage
-                let (full, line_damage) = terminal.get_damage();
-                if full {
+                let term_damage = terminal.get_damage();
+                if term_damage.damage_all {
                     terminal.reset_damage();
                     Some(vec![Rect { x: 0, y: 0, width, height }])
                 } else {
-                    let mut rects = Vec::with_capacity(line_damage.len());
-                    for line in line_damage.iter_mut() {
+                    let mut rects = Vec::with_capacity(term_damage.line_damage.len());
+                    for line in term_damage.line_damage.iter_mut() {
                         if line.left > line.right {
                             continue;
                         }
@@ -442,6 +442,7 @@ impl Display {
                         });
                         line.reset(cols);
                     }
+                    term_damage.damage_all = false;
                     terminal.damage_cursor();
                     Some(rects)
                 }

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -20,6 +20,7 @@ use std::fmt;
 use std::time::Instant;
 
 use glutin::dpi::{PhysicalPosition, PhysicalSize};
+use glutin::event::{Event as GlutinEvent};
 use glutin::event_loop::EventLoop;
 use glutin::Rect;
 use log::{debug, info};
@@ -370,20 +371,27 @@ impl Display {
         mut terminal: MutexGuard<'_, Term<T>>,
         message_buffer: &MessageBuffer,
         config: &Config,
+        event_queue: &mut Vec<GlutinEvent<Event>>,
     ) {
         let grid_cells: Vec<RenderableCell> = terminal.renderable_cells(config).collect();
+        let visual_bell_animating = terminal.visual_bell.animating();
         let visual_bell_intensity = terminal.visual_bell.intensity();
         let background_color = terminal.background_color();
         let metrics = self.glyph_cache.font_metrics();
         let glyph_cache = &mut self.glyph_cache;
         let size_info = self.size_info;
 
+        // Request immediate re-draw if visual bell animation is not finished
+        if visual_bell_animating {
+            event_queue.push(GlutinEvent::UserEvent(Event::Wakeup));
+        }
+
         // Check grid damage
         let damage: Option<Vec<Rect>> = if self.damage_supported {
             let (width, height, cell_width, cell_height, padding_x, padding_y) =
                 size_info.into_u32();
 
-            if self.fully_damaged {
+            if self.fully_damaged || visual_bell_animating {
                 // We need to fully damaged, so let's clear damage and stop
                 // here.
                 terminal.clear_damage();

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -404,8 +404,8 @@ impl Display {
                     terminal.reset_damage();
                     None
                 } else {
-                    let mut rects = Vec::with_capacity(term_damage.line_damage.len());
-                    for line in term_damage.line_damage.iter_mut() {
+                    let mut rects = Vec::with_capacity(term_damage.lines.len());
+                    for line in term_damage.lines.iter_mut() {
                         if line.is_undamaged() {
                             continue;
                         }

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -392,18 +392,18 @@ impl Display {
             let (width, height, cell_width, cell_height, padding_x, padding_y) =
                 size_info.into_u32();
 
-            if self.fully_damaged || visual_bell_animating {
+            if self.fully_damaged || visual_bell_animating || config.render_timer() {
                 // We need to fully damaged, so let's clear damage and stop
                 // here.
                 terminal.reset_damage();
                 self.fully_damaged = false;
-                Some(vec![Rect { x: 0, y: 0, width, height }])
+                None
             } else {
                 // Fetch and clear damage
                 let term_damage = terminal.get_damage();
                 if term_damage.damage_all {
                     terminal.reset_damage();
-                    Some(vec![Rect { x: 0, y: 0, width, height }])
+                    None
                 } else {
                     let mut rects = Vec::with_capacity(term_damage.line_damage.len());
                     for line in term_damage.line_damage.iter_mut() {

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -386,7 +386,7 @@ impl Display {
             if self.fully_damaged {
                 // We need to fully damaged, so let's clear damage and stop
                 // here.
-                terminal.get_damage();
+                terminal.clear_damage();
                 self.fully_damaged = false;
                 Some(vec![Rect { x: 0, y: 0, width, height }])
             } else {

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -407,7 +407,7 @@ impl Display {
                 } else {
                     let mut rects = Vec::with_capacity(term_damage.line_damage.len());
                     for line in term_damage.line_damage.iter_mut() {
-                        if line.left > line.right {
+                        if line.is_undamaged() {
                             continue;
                         }
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -428,13 +428,8 @@ impl<N: Notify> Processor<N> {
             if terminal.dirty {
                 terminal.dirty = false;
 
-                // Request immediate re-draw if visual bell animation is not finished yet
-                if !terminal.visual_bell.completed() {
-                    event_queue.push(GlutinEvent::UserEvent(Event::Wakeup));
-                }
-
                 // Redraw screen
-                self.display.draw(terminal, &self.message_buffer, &self.config);
+                self.display.draw(terminal, &self.message_buffer, &self.config, &mut event_queue);
             }
         });
 

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -27,7 +27,7 @@ use glutin::platform::unix::{EventLoopWindowTargetExtUnix, WindowBuilderExtUnix,
 #[cfg(not(target_os = "macos"))]
 use glutin::window::Icon;
 use glutin::window::{CursorIcon, Fullscreen, Window as GlutinWindow, WindowBuilder, WindowId};
-use glutin::{self, ContextBuilder, PossiblyCurrent, WindowedContext};
+use glutin::{self, ContextBuilder, PossiblyCurrent, Rect, WindowedContext};
 #[cfg(not(target_os = "macos"))]
 use image::ImageFormat;
 #[cfg(not(any(target_os = "macos", windows)))]
@@ -382,6 +382,14 @@ impl Window {
 
     pub fn swap_buffers(&self) {
         self.windowed_context.swap_buffers().expect("swap buffers");
+    }
+
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) {
+        self.windowed_context.swap_buffers_with_damage(rects).expect("swap buffers with damage");
+    }
+
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        self.windowed_context.swap_buffers_with_damage_supported()
     }
 
     pub fn resize(&self, size: PhysicalSize) {

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -215,6 +215,9 @@ pub trait Handler {
     /// Linefeed
     fn linefeed(&mut self) {}
 
+    /// Linefeed and carriage return
+    fn linefeed_carriage_return(&mut self) {}
+
     /// Ring the bell
     ///
     /// Hopefully this is never implemented

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -124,7 +124,7 @@ impl Linear {
         Linear(point.line * columns.0 + point.col.0)
     }
 
-    pub fn to_point(self, columns: Column) -> Point<Line> {
+    pub fn into_point(self, columns: Column) -> Point<Line> {
         let line = Line(self.0 / columns.0);
         let col = Column(self.0 % columns.0);
         Point { col, line }

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -123,6 +123,12 @@ impl Linear {
     pub fn from_point(columns: Column, point: Point<usize>) -> Self {
         Linear(point.line * columns.0 + point.col.0)
     }
+
+    pub fn to_point(self, columns: Column) -> Point<Line> {
+        let line = Line(self.0 / columns.0);
+        let col = Column(self.0 % columns.0);
+        Point { col, line }
+    }
 }
 
 impl fmt::Display for Linear {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -698,11 +698,11 @@ pub struct LineDamage {
 }
 
 impl LineDamage {
-    /// Create a new invalid LineDamage, which has left=columns+1 and right=0.
+    /// Create a new, undamaged LineDamage. where left=columns+1 and right=0.
     /// This ensures that later update with min/max of any valid column
     /// automatically creates a valid line damage without needing any
     /// conditionals.
-    fn new(line: Line, columns: Column) -> LineDamage {
+    fn undamaged(line: Line, columns: Column) -> LineDamage {
         LineDamage{
             left: columns+1,
             right: Column(0),
@@ -710,6 +710,7 @@ impl LineDamage {
         }
     }
 
+    /// Return the LineDamage to its undamaged state.
     #[inline(always)]
     pub fn reset(&mut self, columns: Column) {
         self.left = columns+1;
@@ -732,7 +733,7 @@ impl Damage {
             columns: columns,
         };
         for line in 0..lines.0 {
-            damage.line_damage.push(LineDamage::new(Line(line), columns));
+            damage.line_damage.push(LineDamage::undamaged(Line(line), columns));
         }
         damage
     }
@@ -762,7 +763,7 @@ impl Damage {
         self.columns = columns;
         self.line_damage = Vec::with_capacity(lines.0);
         for line in 0..lines.0 {
-            self.line_damage.push(LineDamage::new(Line(line), columns));
+            self.line_damage.push(LineDamage::undamaged(Line(line), columns));
         }
         self.full_damage = true;
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1021,7 +1021,8 @@ impl<T> Term<T> {
     }
 
     /// Damage the current cursor position. Must be done after a call to
-    /// Term::get_damage.
+    /// Term::get_damage, in order to ensure that damage tracking has a valid
+    /// starting point.
     pub fn damage_cursor(&mut self) {
         self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
     }
@@ -1029,6 +1030,9 @@ impl<T> Term<T> {
     /// Reset the current damage without reading it.
     pub fn reset_damage(&mut self) {
         self.damage.clear_damage();
+
+        // Damage state has been cleared. Damage the current cursor position to
+        // provide a valid starting point.
         self.damage_cursor();
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -752,8 +752,8 @@ impl Damage {
 
     #[inline(always)]
     fn clear_damage(&mut self) {
-        for l in &mut self.line_damage {
-            l.reset(self.columns);
+        for line in &mut self.line_damage {
+            line.reset(self.columns);
         }
         self.full_damage = false;
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -946,7 +946,7 @@ impl<T> Term<T> {
         &self,
         cols: index::Column,
         selection: &Option<Selection>,
-    ) -> Option<(Column, Line, Column, Line)> {
+    ) -> Option<(Point, Point)> {
         match selection {
             Some(ref selection) => match selection.to_span(self) {
                 Some(span) => {
@@ -973,7 +973,7 @@ impl<T> Term<T> {
                         (Column(0), cols - 1)
                     };
 
-                    Some((start_col, Line(start.line), end_col, Line(end.line)))
+                    Some((Point::new(Line(start.line), start_col), Point::new(Line(end.line), end_col)))
                 }
                 None => None,
             }
@@ -994,28 +994,28 @@ impl<T> Term<T> {
             //
             // Selections
             //
-            if let Some(sel_damage) = self.calculate_selection_damage(cols, &self.grid.selection) {
-                for line in (sel_damage.1).0..=(sel_damage.3).0 {
-                    self.damage.expand_line_damage(Line(line), sel_damage.0, sel_damage.2)
+            if let Some((upper_left, lower_right)) = self.calculate_selection_damage(cols, &self.grid.selection) {
+                for line in upper_left.line.0..=lower_right.line.0 {
+                    self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
             }
-            if let Some(sel_damage) = self.calculate_selection_damage(cols, &self.last_selection) {
-                for line in (sel_damage.1).0..=(sel_damage.3).0 {
-                    self.damage.expand_line_damage(Line(line), sel_damage.0, sel_damage.2)
+            if let Some((upper_left, lower_right)) = self.calculate_selection_damage(cols, &self.last_selection) {
+                for line in upper_left.line.0..=lower_right.line.0 {
+                    self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
             }
 
             //
             // URL highlights
             //
-            if let Some(hl_damage) = self.calculate_highlight_damage(cols, &self.grid.url_highlight) {
-                for line in (hl_damage.1).0..=(hl_damage.3).0 {
-                    self.damage.expand_line_damage(Line(line), hl_damage.0, hl_damage.2)
+            if let Some((upper_left, lower_right)) = self.calculate_highlight_damage(cols, &self.grid.url_highlight) {
+                for line in upper_left.line.0..=lower_right.line.0 {
+                    self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
             }
-            if let Some(hl_damage) = self.calculate_highlight_damage(cols, &self.last_highlight) {
-                for line in (hl_damage.1).0..=(hl_damage.3).0 {
-                    self.damage.expand_line_damage(Line(line), hl_damage.0, hl_damage.2)
+            if let Some((upper_left, lower_right)) = self.calculate_highlight_damage(cols, &self.last_highlight) {
+                for line in upper_left.line.0..=lower_right.line.0 {
+                    self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
             }
         }
@@ -1455,7 +1455,7 @@ impl<T> Term<T> {
         &self,
         cols: index::Column,
         highlight: &Option<RangeInclusive<index::Linear>>,
-    ) -> Option<(Column, Line, Column, Line)> {
+    ) -> Option<(Point, Point)> {
         match highlight {
             Some(highlight) => {
                 let (start, end) = highlight.clone().into_inner();
@@ -1467,7 +1467,7 @@ impl<T> Term<T> {
                     (Column(0), cols - 1)
                 };
 
-                Some((start_col, start.line, end_col, end.line))
+                Some((Point::new(start.line, start_col), Point::new(end.line, end_col)))
             }
             None => None,
         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1061,7 +1061,7 @@ impl<T> Term<T> {
     pub fn get_damage(&mut self) -> Vec<DamageRect> {
         let cols = self.grid.num_cols();
 
-        let mut damage_list = std::mem::replace(&mut self.damage_list, Vec::new());
+        let mut damage_list = std::mem::replace(&mut self.damage_list, Vec::with_capacity(10));
 
         let damage = if self.damage.is_close_to_line(self.cursor.point.line) {
             DamageRect::bounding_rect_with_point(&self.damage, &self.cursor.point)

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -762,11 +762,6 @@ impl Damage {
         }
         self.damage_all = true;
     }
-
-    #[allow(dead_code)]
-    fn damaged_lines(&self) -> usize {
-        self.lines.iter().map(|x| if x.is_undamaged() { 0 } else { 1 }).sum()
-    }
 }
 
 pub struct Term<T> {
@@ -1092,6 +1087,7 @@ impl<T> Term<T> {
 
         let colors = color::List::from(&config.colors);
 
+        // Create a damage tracker that has the default cursor position damaged
         let mut damage = Damage::new(num_lines, num_cols);
         damage.expand_line(Line(0), Column(0), Column(0));
 
@@ -2510,7 +2506,13 @@ mod tests {
     use crate::grid::{Grid, Scroll};
     use crate::index::{Column, Line, Point, Side, Linear};
     use crate::selection::Selection;
-    use crate::term::{cell, Cell, SizeInfo, Term};
+    use crate::term::{cell, Cell, SizeInfo, Term, Damage};
+
+    impl Damage {
+        fn damaged_lines(&self) -> usize {
+            self.lines.iter().map(|x| if x.is_undamaged() { 0 } else { 1 }).sum()
+        }
+    }
 
     struct Mock;
     impl EventListener for Mock {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -607,16 +607,16 @@ impl VisualBell {
         self.intensity_at_instant(Instant::now())
     }
 
-    /// Check whether or not the visual bell has completed "ringing".
-    pub fn completed(&mut self) -> bool {
+    /// Check whether or not the visual bell is "ringing".
+    pub fn animating(&mut self) -> bool {
         match self.start_time {
             Some(earlier) => {
                 if Instant::now().duration_since(earlier) >= self.duration {
                     self.start_time = None;
                 }
-                false
+                true
             },
-            None => true,
+            None => false,
         }
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -740,9 +740,9 @@ impl Damage {
 
     #[inline(always)]
     fn expand_line_damage(&mut self, line: Line, left: Column, right: Column) {
-        let l = self.line_damage.get_mut(line.0).unwrap();
-        l.left = min(left, l.left);
-        l.right = max(right, l.right);
+        let line = self.line_damage.get_mut(line.0).unwrap();
+        line.left = min(left, line.left);
+        line.right = max(right, line.right);
     }
 
     #[inline(always)]

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2171,8 +2171,8 @@ impl<T: EventListener> ansi::Handler for Term<T> {
         let col = min(self.cursor.point.col, self.grid.num_cols() - 1);
 
         self.damage = DamageRect::bounding_rect(&self.damage, &DamageRect {
-            x: min(self.cursor.point.col.0, col.0),
-            y: min(self.cursor.point.line.0, line.0),
+            x: col.0,
+            y: line.0,
             end_x: max(self.cursor.point.col.0, col.0),
             end_y: max(self.cursor.point.line.0, line.0),
         });

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1721,13 +1721,13 @@ impl<T: EventListener> ansi::Handler for Term<T> {
             (Line(0), self.grid.num_lines() - 1)
         };
 
-        let new_line = min(line + y_offset, max_y);
-        let new_col = min(col, self.grid.num_cols() - 1);
+        let line = min(line + y_offset, max_y);
+        let col = min(col, self.grid.num_cols() - 1);
 
-        self.update_damage(new_line, new_col);
+        self.update_damage(line, col);
 
-        self.cursor.point.line = new_line;
-        self.cursor.point.col = new_col;
+        self.cursor.point.line = line;
+        self.cursor.point.col = col;
         self.input_needs_wrap = false;
     }
 
@@ -2147,18 +2147,18 @@ impl<T: EventListener> ansi::Handler for Term<T> {
         let source = if self.alt { &self.cursor_save_alt } else { &self.cursor_save };
 
         self.cursor = *source;
-        let new_line = min(self.cursor.point.line, self.grid.num_lines() - 1);
-        let new_col = min(self.cursor.point.col, self.grid.num_cols() - 1);
+        let line = min(self.cursor.point.line, self.grid.num_lines() - 1);
+        let col = min(self.cursor.point.col, self.grid.num_cols() - 1);
 
         self.damage = DamageRect::bounding_rect(&self.damage, &DamageRect {
-            x: min(self.cursor.point.col.0, new_col.0),
-            y: min(self.cursor.point.line.0, new_line.0),
-            end_x: max(self.cursor.point.col.0, new_col.0),
-            end_y: max(self.cursor.point.line.0, new_line.0),
+            x: min(self.cursor.point.col.0, col.0),
+            y: min(self.cursor.point.line.0, line.0),
+            end_x: max(self.cursor.point.col.0, col.0),
+            end_y: max(self.cursor.point.line.0, line.0),
         });
 
-        self.cursor.point.line = new_line;
-        self.cursor.point.col = new_col;
+        self.cursor.point.line = line;
+        self.cursor.point.col = col;
     }
 
     #[inline]

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1493,12 +1493,12 @@ impl<T> Term<T> {
             let (start, end) = highlight.clone().into_inner();
             let (start, end) = (start.into_point(cols), end.into_point(cols));
 
-            let d = if start.line == end.line {
+            let damage = if start.line == end.line {
                 DamageRect { x: start.col.0, y: start.line.0, end_x: end.col.0, end_y: end.line.0 }
             } else {
                 DamageRect { x: 0, y: start.line.0, end_x: cols.0 - 1, end_y: end.line.0 }
             };
-            damage_list.push(d);
+            damage_list.push(damage);
         }
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -910,7 +910,7 @@ impl<T> Term<T> {
         &self.grid.selection
     }
 
-    fn add_selection(
+    fn damage_selection(
         &self,
         cols: index::Column,
         selection: &Option<Selection>,
@@ -1071,10 +1071,10 @@ impl<T> Term<T> {
         };
         damage_list.push(damage);
 
-        self.add_selection(cols, &self.last_selection, &mut damage_list);
-        self.add_selection(cols, &self.grid.selection, &mut damage_list);
-        self.add_highlight(cols, &self.last_highlight, &mut damage_list);
-        self.add_highlight(cols, &self.grid.url_highlight, &mut damage_list);
+        self.damage_selection(cols, &self.last_selection, &mut damage_list);
+        self.damage_selection(cols, &self.grid.selection, &mut damage_list);
+        self.damage_highlight(cols, &self.last_highlight, &mut damage_list);
+        self.damage_highlight(cols, &self.grid.url_highlight, &mut damage_list);
 
         self.damage = DamageRect::from_point(&self.cursor.point);
         self.last_selection = self.grid.selection.clone();
@@ -1463,7 +1463,7 @@ impl<T> Term<T> {
         self.event_proxy.send_event(Event::Exit);
     }
 
-    pub fn add_highlight(
+    pub fn damage_highlight(
         &self,
         cols: index::Column,
         highlight: &Option<RangeInclusive<index::Linear>>,

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -703,17 +703,13 @@ impl LineDamage {
     /// automatically creates a valid line damage without needing any
     /// conditionals.
     fn undamaged(line: Line, num_cols: Column) -> LineDamage {
-        LineDamage{
-            left: num_cols+1,
-            right: Column(0),
-            line,
-        }
+        LineDamage { left: num_cols + 1, right: Column(0), line }
     }
 
     /// Return the LineDamage to its undamaged state.
     #[inline(always)]
     pub fn reset(&mut self, num_cols: Column) {
-        self.left = num_cols+1;
+        self.left = num_cols + 1;
         self.right = Column(0);
     }
 
@@ -734,11 +730,8 @@ pub struct Damage {
 impl Damage {
     #[inline(always)]
     fn new(lines: Line, num_cols: Column) -> Damage {
-        let mut damage = Damage{
-            line_damage: Vec::with_capacity(lines.0),
-            damage_all: false,
-            num_cols: num_cols,
-        };
+        let mut damage =
+            Damage { line_damage: Vec::with_capacity(lines.0), damage_all: false, num_cols };
         for line in 0..lines.0 {
             damage.line_damage.push(LineDamage::undamaged(Line(line), num_cols));
         }
@@ -973,10 +966,13 @@ impl<T> Term<T> {
                         (Column(0), cols - 1)
                     };
 
-                    Some((Point::new(Line(start.line), start_col), Point::new(Line(end.line), end_col)))
-                }
+                    Some((
+                        Point::new(Line(start.line), start_col),
+                        Point::new(Line(end.line), end_col),
+                    ))
+                },
                 None => None,
-            }
+            },
             None => None,
         }
     }
@@ -984,36 +980,46 @@ impl<T> Term<T> {
     /// Finalize and retrieve current damage. Note that the user is responsible
     /// for calling LineDamage::reset on every line returned for efficiency.
     pub fn get_damage(&mut self) -> &mut Damage {
-        self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+        self.damage.expand_line_damage(
+            self.cursor.point.line,
+            self.cursor.point.col,
+            self.cursor.point.col,
+        );
 
         self.damage.damage_all |= self.mode.contains(TermMode::INSERT);
 
         if !self.damage.damage_all {
             let cols = self.grid.num_cols();
 
-            //
             // Selections
             //
-            if let Some((upper_left, lower_right)) = self.calculate_selection_damage(cols, &self.grid.selection) {
+            if let Some((upper_left, lower_right)) =
+                self.calculate_selection_damage(cols, &self.grid.selection)
+            {
                 for line in upper_left.line.0..=lower_right.line.0 {
                     self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
             }
-            if let Some((upper_left, lower_right)) = self.calculate_selection_damage(cols, &self.last_selection) {
+            if let Some((upper_left, lower_right)) =
+                self.calculate_selection_damage(cols, &self.last_selection)
+            {
                 for line in upper_left.line.0..=lower_right.line.0 {
                     self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
             }
 
-            //
             // URL highlights
             //
-            if let Some((upper_left, lower_right)) = self.calculate_highlight_damage(cols, &self.grid.url_highlight) {
+            if let Some((upper_left, lower_right)) =
+                self.calculate_highlight_damage(cols, &self.grid.url_highlight)
+            {
                 for line in upper_left.line.0..=lower_right.line.0 {
                     self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
             }
-            if let Some((upper_left, lower_right)) = self.calculate_highlight_damage(cols, &self.last_highlight) {
+            if let Some((upper_left, lower_right)) =
+                self.calculate_highlight_damage(cols, &self.last_highlight)
+            {
                 for line in upper_left.line.0..=lower_right.line.0 {
                     self.damage.expand_line_damage(Line(line), upper_left.col, lower_right.col)
                 }
@@ -1029,7 +1035,11 @@ impl<T> Term<T> {
     /// Term::get_damage, in order to ensure that damage tracking has a valid
     /// starting point.
     pub fn damage_cursor(&mut self) {
-        self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+        self.damage.expand_line_damage(
+            self.cursor.point.line,
+            self.cursor.point.col,
+            self.cursor.point.col,
+        );
     }
 
     /// Reset the current damage without reading it.
@@ -1451,7 +1461,7 @@ impl<T> Term<T> {
         self.event_proxy.send_event(Event::Exit);
     }
 
-   fn calculate_highlight_damage(
+    fn calculate_highlight_damage(
         &self,
         cols: index::Column,
         highlight: &Option<RangeInclusive<index::Linear>>,
@@ -1468,7 +1478,7 @@ impl<T> Term<T> {
                 };
 
                 Some((Point::new(start.line, start_col), Point::new(end.line, end_col)))
-            }
+            },
             None => None,
         }
     }
@@ -1708,13 +1718,16 @@ impl<T: EventListener> ansi::Handler for Term<T> {
         let line = min(line + y_offset, max_y);
         let col = min(col, self.grid.num_cols() - 1);
 
-        self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+        self.damage.expand_line_damage(
+            self.cursor.point.line,
+            self.cursor.point.col,
+            self.cursor.point.col,
+        );
         self.damage.expand_line_damage(line, col, col);
 
         self.cursor.point.line = line;
         self.cursor.point.col = col;
         self.input_needs_wrap = false;
-
     }
 
     #[inline]
@@ -1863,7 +1876,11 @@ impl<T: EventListener> ansi::Handler for Term<T> {
         if self.cursor.point.col > Column(0) {
             self.cursor.point.col -= 1;
 
-            self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col + 1);
+            self.damage.expand_line_damage(
+                self.cursor.point.line,
+                self.cursor.point.col,
+                self.cursor.point.col + 1,
+            );
             self.input_needs_wrap = false;
         }
     }
@@ -1886,9 +1903,17 @@ impl<T: EventListener> ansi::Handler for Term<T> {
             // scroll_up updates damage itself
             self.scroll_up(Line(1));
         } else if next < self.grid.num_lines() {
-            self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+            self.damage.expand_line_damage(
+                self.cursor.point.line,
+                self.cursor.point.col,
+                self.cursor.point.col,
+            );
             self.cursor.point.line += 1;
-            self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+            self.damage.expand_line_damage(
+                self.cursor.point.line,
+                self.cursor.point.col,
+                self.cursor.point.col,
+            );
         }
     }
 
@@ -1901,7 +1926,11 @@ impl<T: EventListener> ansi::Handler for Term<T> {
             // scroll_up updates damage itself
             self.scroll_up(Line(1));
         } else if next < self.grid.num_lines() {
-            self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+            self.damage.expand_line_damage(
+                self.cursor.point.line,
+                self.cursor.point.col,
+                self.cursor.point.col,
+            );
             self.cursor.point.line = next;
             self.damage.expand_line_damage(self.cursor.point.line, Column(0), Column(0));
         }
@@ -2076,7 +2105,11 @@ impl<T: EventListener> ansi::Handler for Term<T> {
         let line = min(self.cursor.point.line, self.grid.num_lines() - 1);
         let col = min(self.cursor.point.col, self.grid.num_cols() - 1);
 
-        self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+        self.damage.expand_line_damage(
+            self.cursor.point.line,
+            self.cursor.point.col,
+            self.cursor.point.col,
+        );
         self.damage.expand_line_damage(line, col, col);
 
         self.cursor.point.line = line;
@@ -2111,7 +2144,11 @@ impl<T: EventListener> ansi::Handler for Term<T> {
                 for cell in &mut row[..] {
                     cell.reset(&template);
                 }
-                self.damage.expand_line_damage(self.cursor.point.line, Column(0), self.grid.num_cols());
+                self.damage.expand_line_damage(
+                    self.cursor.point.line,
+                    Column(0),
+                    self.grid.num_cols(),
+                );
             },
         }
     }
@@ -2238,9 +2275,17 @@ impl<T: EventListener> ansi::Handler for Term<T> {
         if self.cursor.point.line == self.scroll_region.start {
             self.scroll_down(Line(1));
         } else {
-            self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+            self.damage.expand_line_damage(
+                self.cursor.point.line,
+                self.cursor.point.col,
+                self.cursor.point.col,
+            );
             self.cursor.point.line -= min(self.cursor.point.line, Line(1));
-            self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
+            self.damage.expand_line_damage(
+                self.cursor.point.line,
+                self.cursor.point.col,
+                self.cursor.point.col,
+            );
         }
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -698,13 +698,13 @@ pub struct LineDamage {
 }
 
 impl LineDamage {
-    /// Create a new, undamaged LineDamage. where left=columns+1 and right=0.
+    /// Create a new, undamaged LineDamage. where left=num_cols+1 and right=0.
     /// This ensures that later update with min/max of any valid column
     /// automatically creates a valid line damage without needing any
     /// conditionals.
-    fn undamaged(line: Line, columns: Column) -> LineDamage {
+    fn undamaged(line: Line, num_cols: Column) -> LineDamage {
         LineDamage{
-            left: columns+1,
+            left: num_cols+1,
             right: Column(0),
             line,
         }
@@ -712,8 +712,8 @@ impl LineDamage {
 
     /// Return the LineDamage to its undamaged state.
     #[inline(always)]
-    pub fn reset(&mut self, columns: Column) {
-        self.left = columns+1;
+    pub fn reset(&mut self, num_cols: Column) {
+        self.left = num_cols+1;
         self.right = Column(0);
     }
 }
@@ -721,19 +721,19 @@ impl LineDamage {
 struct Damage {
     line_damage: Vec<LineDamage>,
     damage_all: bool,
-    columns: Column,
+    num_cols: Column,
 }
 
 impl Damage {
     #[inline(always)]
-    fn new(lines: Line, columns: Column) -> Damage {
+    fn new(lines: Line, num_cols: Column) -> Damage {
         let mut damage = Damage{
             line_damage: Vec::with_capacity(lines.0),
             damage_all: false,
-            columns: columns,
+            num_cols: num_cols,
         };
         for line in 0..lines.0 {
-            damage.line_damage.push(LineDamage::undamaged(Line(line), columns));
+            damage.line_damage.push(LineDamage::undamaged(Line(line), num_cols));
         }
         damage
     }
@@ -748,17 +748,17 @@ impl Damage {
     #[inline(always)]
     fn clear_damage(&mut self) {
         for line in &mut self.line_damage {
-            line.reset(self.columns);
+            line.reset(self.num_cols);
         }
         self.damage_all = false;
     }
 
     #[inline(always)]
-    fn resize_damage(&mut self, lines: Line, columns: Column) {
-        self.columns = columns;
+    fn resize_damage(&mut self, lines: Line, num_cols: Column) {
+        self.num_cols = num_cols;
         self.line_damage = Vec::with_capacity(lines.0);
         for line in 0..lines.0 {
-            self.line_damage.push(LineDamage::undamaged(Line(line), columns));
+            self.line_damage.push(LineDamage::undamaged(Line(line), num_cols));
         }
         self.damage_all = true;
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2104,7 +2104,11 @@ impl<T: EventListener> ansi::Handler for Term<T> {
                 for cell in &mut row[col..] {
                     cell.reset(&template);
                 }
-                self.damage.expand_line_damage(self.cursor.point.line, col, self.grid.num_cols());
+                self.damage.expand_line_damage(
+                    self.cursor.point.line,
+                    col,
+                    self.grid.num_cols() - 1,
+                );
             },
             ansi::LineClearMode::Left => {
                 let row = &mut self.grid[self.cursor.point.line];
@@ -2121,7 +2125,7 @@ impl<T: EventListener> ansi::Handler for Term<T> {
                 self.damage.expand_line_damage(
                     self.cursor.point.line,
                     Column(0),
-                    self.grid.num_cols(),
+                    self.grid.num_cols() - 1,
                 );
             },
         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -718,9 +718,10 @@ impl LineDamage {
     }
 }
 
-struct Damage {
-    line_damage: Vec<LineDamage>,
-    damage_all: bool,
+/// Damage is used to track damage within a Term.
+pub struct Damage {
+    pub line_damage: Vec<LineDamage>,
+    pub damage_all: bool,
     num_cols: Column,
 }
 
@@ -976,13 +977,12 @@ impl<T> Term<T> {
 
     /// Finalize and retrieve current damage. Note that the user is responsible
     /// for calling LineDamage::reset on every line returned for efficiency.
-    pub fn get_damage(&mut self) -> (bool, &mut Vec<LineDamage>) {
+    pub fn get_damage(&mut self) -> &mut Damage {
         self.damage.expand_line_damage(self.cursor.point.line, self.cursor.point.col, self.cursor.point.col);
 
-        let full = self.damage.damage_all ||
-            self.mode.contains(TermMode::INSERT);
+        self.damage.damage_all |= self.mode.contains(TermMode::INSERT);
 
-        if !full {
+        if !self.damage.damage_all {
             let cols = self.grid.num_cols();
 
             //
@@ -1016,8 +1016,7 @@ impl<T> Term<T> {
 
         self.last_selection = self.grid.selection.clone();
         self.last_highlight = self.grid.url_highlight.clone();
-        self.damage.damage_all = false;
-        (full, &mut self.damage.line_damage)
+        &mut self.damage
     }
 
     /// Damage the current cursor position. Must be done after a call to

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -716,6 +716,12 @@ impl LineDamage {
         self.left = num_cols+1;
         self.right = Column(0);
     }
+
+    /// Return whether this line remains undamaged.
+    #[inline(always)]
+    pub fn is_undamaged(&self) -> bool {
+        self.left > self.right
+    }
 }
 
 /// Damage is used to track damage within a Term.

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1083,6 +1083,14 @@ impl<T> Term<T> {
         damage_list
     }
 
+    /// Clears damage.
+    pub fn clear_damage(&mut self) {
+        self.damage = DamageRect::from_point(&self.cursor.point);
+        self.last_selection = self.grid.selection.clone();
+        self.last_highlight = self.grid.url_highlight.clone();
+        self.damage_list.clear();
+    }
+
     /// Add a new position to the current damage, creating and consolidating
     /// damage rects as needed.
     fn update_damage(&mut self, line: Line, col: Column) {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -687,7 +687,7 @@ impl VisualBell {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct DamageRect {
     pub x: usize,
     pub y: usize,
@@ -1066,7 +1066,7 @@ impl<T> Term<T> {
         let damage = if self.damage.is_close_to_line(self.cursor.point.line) {
             DamageRect::bounding_rect_with_point(&self.damage, &self.cursor.point)
         } else {
-            damage_list.push(self.damage.clone());
+            damage_list.push(self.damage);
             DamageRect::from_point(&self.cursor.point)
         };
         damage_list.push(damage);


### PR DESCRIPTION
Implement damage tracking and reporting.

This allows compositors to only process damaged (that is, updated) regions of our window buffer, which for larger window sizes (think 4k) should significantly reduce compositing workload under compositors that support/honor it, which is good for performance and battery life.

On Wayland, clients are expected to report always report correct damage, so this makes us a good (or at least, better) citizen there. It can also aid remote desktop (waypipe, RDP, VNC, ...) and other types of screencopy by having damage bubble up correctly.

Damage tracking has been implemented in a somewhat naïve fashion, but I believe it is a fair start.

Note that this currently depends on a fork of glutin where support has been added.

Fixes #3186.