### PR TITLE
Remove copypasta dependency from alacritty_terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ version = "0.5.0-dev"
 dependencies = [
  "alacritty_terminal 0.5.0-dev",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "copypasta 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "embed-resource 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -47,7 +48,6 @@ version = "0.5.0-dev"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "copypasta 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "font 0.1.0",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -22,6 +22,7 @@ notify = "4"
 parking_lot = "0.10.2"
 font = { path = "../font" }
 urlocator = "0.1.3"
+copypasta = { version = "0.7.0", default-features = false }
 
 [build-dependencies]
 gl_generator = "0.14.0"
@@ -48,8 +49,8 @@ embed-resource = "1.3"
 
 [features]
 default = ["wayland", "x11", "winpty"]
-x11 = ["alacritty_terminal/x11"]
-wayland = ["alacritty_terminal/wayland"]
+x11 = ["copypasta/x11"]
+wayland = ["copypasta/wayland"]
 winpty = ["alacritty_terminal/winpty"]
 # Enabling this feature makes shaders automatically reload when changed
 live-shader-reload = []

--- a/alacritty/src/clipboard.rs
+++ b/alacritty/src/clipboard.rs
@@ -1,0 +1,110 @@
+// Copyright 2016 Joe Wilm, The Alacritty Project Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+use std::ffi::c_void;
+
+use log::{debug, warn};
+
+use alacritty_terminal::clipboard::ClipboardType;
+
+use copypasta::nop_clipboard::NopClipboardContext;
+#[cfg(all(not(any(target_os = "macos", windows)), feature = "wayland"))]
+use copypasta::wayland_clipboard;
+#[cfg(all(not(any(target_os = "macos", windows)), feature = "x11"))]
+use copypasta::x11_clipboard::{Primary as X11SelectionClipboard, X11ClipboardContext};
+#[cfg(any(feature = "x11", target_os = "macos", windows))]
+use copypasta::ClipboardContext;
+use copypasta::ClipboardProvider;
+
+pub struct Clipboard {
+    clipboard: Box<dyn ClipboardProvider>,
+    selection: Option<Box<dyn ClipboardProvider>>,
+}
+
+impl Clipboard {
+    #[cfg(any(target_os = "macos", windows))]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(not(any(target_os = "macos", windows)))]
+    pub fn new(_display: Option<*mut c_void>) -> Self {
+        #[cfg(feature = "wayland")]
+        {
+            if let Some(display) = _display {
+                let (selection, clipboard) =
+                    unsafe { wayland_clipboard::create_clipboards_from_external(display) };
+                return Self {
+                    clipboard: Box::new(clipboard),
+                    selection: Some(Box::new(selection)),
+                };
+            }
+        }
+
+        #[cfg(feature = "x11")]
+        return Self {
+            clipboard: Box::new(ClipboardContext::new().unwrap()),
+            selection: Some(Box::new(X11ClipboardContext::<X11SelectionClipboard>::new().unwrap())),
+        };
+
+        #[cfg(not(feature = "x11"))]
+        return Self::new_nop();
+    }
+
+    /// Use for tests, ref-tests, and to handle missing clipboard provider, when build with either
+    /// only `wayland` or `x11 features.
+    #[allow(dead_code)]
+    pub fn new_nop() -> Self {
+        Self { clipboard: Box::new(NopClipboardContext::new().unwrap()), selection: None }
+    }
+}
+
+impl Default for Clipboard {
+    fn default() -> Self {
+        #[cfg(any(feature = "x11", target_os = "macos", windows))]
+        return Self { clipboard: Box::new(ClipboardContext::new().unwrap()), selection: None };
+        #[cfg(not(any(feature = "x11", target_os = "macos", windows)))]
+        return Self::new_nop();
+    }
+}
+
+impl Clipboard {
+    pub fn store(&mut self, ty: ClipboardType, text: impl Into<String>) {
+        let clipboard = match (ty, &mut self.selection) {
+            (ClipboardType::Selection, Some(provider)) => provider,
+            (ClipboardType::Selection, None) => return,
+            _ => &mut self.clipboard,
+        };
+
+        clipboard.set_contents(text.into()).unwrap_or_else(|err| {
+            warn!("Unable to store text in clipboard: {}", err);
+        });
+    }
+
+    pub fn load(&mut self, ty: ClipboardType) -> String {
+        let clipboard = match (ty, &mut self.selection) {
+            (ClipboardType::Selection, Some(provider)) => provider,
+            _ => &mut self.clipboard,
+        };
+
+        match clipboard.get_contents() {
+            Err(err) => {
+                debug!("Unable to load text from clipboard: {}", err);
+                String::new()
+            },
+            Ok(text) => text,
+        }
+    }
+}

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -36,7 +36,6 @@ use log::{error, info};
 #[cfg(windows)]
 use winapi::um::wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS};
 
-use alacritty_terminal::clipboard::Clipboard;
 use alacritty_terminal::event::Event;
 use alacritty_terminal::event_loop::{self, EventLoop, Msg};
 #[cfg(target_os = "macos")]
@@ -48,6 +47,7 @@ use alacritty_terminal::term::Term;
 use alacritty_terminal::tty;
 
 mod cli;
+mod clipboard;
 mod config;
 mod cursor;
 mod display;
@@ -149,18 +149,12 @@ fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), 
 
     info!("PTY dimensions: {:?} x {:?}", display.size_info.lines(), display.size_info.cols());
 
-    // Create new native clipboard.
-    #[cfg(not(any(target_os = "macos", windows)))]
-    let clipboard = Clipboard::new(display.window.wayland_display());
-    #[cfg(any(target_os = "macos", windows))]
-    let clipboard = Clipboard::new();
-
     // Create the terminal.
     //
     // This object contains all of the state about what's being displayed. It's
     // wrapped in a clonable mutex since both the I/O loop and display need to
     // access it.
-    let terminal = Term::new(&config, &display.size_info, clipboard, event_proxy.clone());
+    let terminal = Term::new(&config, &display.size_info, event_proxy.clone());
     let terminal = Arc::new(FairMutex::new(terminal));
 
     // Create the PTY.

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -22,7 +22,6 @@ log = "0.4"
 unicode-width = "0.1"
 base64 = "0.11.0"
 terminfo = "0.7.1"
-copypasta = { version = "0.7.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17.0"
@@ -42,9 +41,7 @@ mio-anonymous-pipes = "0.1"
 objc = "0.2.2"
 
 [features]
-default = ["x11", "wayland", "winpty"]
-x11 = ["copypasta/x11"]
-wayland = ["copypasta/wayland"]
+default = ["winpty"]
 nightly = []
 bench = []
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -320,11 +320,11 @@ pub trait Handler {
     /// Reset an indexed color to original value.
     fn reset_color(&mut self, _: usize) {}
 
-    /// Set the clipboard.
-    fn set_clipboard(&mut self, _: u8, _: &[u8]) {}
+    /// Request to set a clipboard.
+    fn request_clipboard_set(&mut self, _: u8, _: &[u8]) {}
 
-    /// Write clipboard data to child.
-    fn write_clipboard<W: io::Write>(&mut self, _: u8, _: &mut W, _: &str) {}
+    /// Request to paste to a child.
+    fn request_clipboard_write(&mut self, _: u8, _: &str) {}
 
     /// Run the decaln routine.
     fn decaln(&mut self) {}
@@ -905,8 +905,8 @@ where
 
                 let clipboard = params[1].get(0).unwrap_or(&b'c');
                 match params[2] {
-                    b"?" => self.handler.write_clipboard(*clipboard, writer, terminator),
-                    base64 => self.handler.set_clipboard(*clipboard, base64),
+                    b"?" => self.handler.request_clipboard_write(*clipboard, terminator),
+                    base64 => self.handler.request_clipboard_set(*clipboard, base64),
                 }
             },
 

--- a/alacritty_terminal/src/clipboard.rs
+++ b/alacritty_terminal/src/clipboard.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Joe Wilm, The Alacritty Project Contributors
+// Copyright 2020 Christian Duerr, The Alacritty Project Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,101 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-use std::ffi::c_void;
-
-use log::{debug, warn};
-
-use copypasta::nop_clipboard::NopClipboardContext;
-#[cfg(all(not(any(target_os = "macos", windows)), feature = "wayland"))]
-use copypasta::wayland_clipboard;
-#[cfg(all(not(any(target_os = "macos", windows)), feature = "x11"))]
-use copypasta::x11_clipboard::{Primary as X11SelectionClipboard, X11ClipboardContext};
-#[cfg(any(feature = "x11", target_os = "macos", windows))]
-use copypasta::ClipboardContext;
-use copypasta::ClipboardProvider;
-
-pub struct Clipboard {
-    clipboard: Box<dyn ClipboardProvider>,
-    selection: Option<Box<dyn ClipboardProvider>>,
-}
-
-impl Clipboard {
-    #[cfg(any(target_os = "macos", windows))]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    #[cfg(not(any(target_os = "macos", windows)))]
-    pub fn new(_display: Option<*mut c_void>) -> Self {
-        #[cfg(feature = "wayland")]
-        {
-            if let Some(display) = _display {
-                let (selection, clipboard) =
-                    unsafe { wayland_clipboard::create_clipboards_from_external(display) };
-                return Self {
-                    clipboard: Box::new(clipboard),
-                    selection: Some(Box::new(selection)),
-                };
-            }
-        }
-
-        #[cfg(feature = "x11")]
-        return Self {
-            clipboard: Box::new(ClipboardContext::new().unwrap()),
-            selection: Some(Box::new(X11ClipboardContext::<X11SelectionClipboard>::new().unwrap())),
-        };
-
-        #[cfg(not(feature = "x11"))]
-        return Self::new_nop();
-    }
-
-    // Use for tests and ref-tests.
-    pub fn new_nop() -> Self {
-        Self { clipboard: Box::new(NopClipboardContext::new().unwrap()), selection: None }
-    }
-}
-
-impl Default for Clipboard {
-    fn default() -> Self {
-        #[cfg(any(feature = "x11", target_os = "macos", windows))]
-        return Self { clipboard: Box::new(ClipboardContext::new().unwrap()), selection: None };
-        #[cfg(not(any(feature = "x11", target_os = "macos", windows)))]
-        return Self::new_nop();
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClipboardType {
     Clipboard,
     Selection,
-}
-
-impl Clipboard {
-    pub fn store(&mut self, ty: ClipboardType, text: impl Into<String>) {
-        let clipboard = match (ty, &mut self.selection) {
-            (ClipboardType::Selection, Some(provider)) => provider,
-            (ClipboardType::Selection, None) => return,
-            _ => &mut self.clipboard,
-        };
-
-        clipboard.set_contents(text.into()).unwrap_or_else(|err| {
-            warn!("Unable to store text in clipboard: {}", err);
-        });
-    }
-
-    pub fn load(&mut self, ty: ClipboardType) -> String {
-        let clipboard = match (ty, &mut self.selection) {
-            (ClipboardType::Selection, Some(provider)) => provider,
-            _ => &mut self.clipboard,
-        };
-
-        match clipboard.get_contents() {
-            Err(err) => {
-                debug!("Unable to load text from clipboard: {}", err);
-                String::new()
-            },
-            Ok(text) => text,
-        }
-    }
 }

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -1,19 +1,53 @@
+// Copyright 2020 Christian Duerr, The Alacritty Project Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::borrow::Cow;
 use std::path::PathBuf;
 
+use crate::clipboard::ClipboardType;
 use crate::message_bar::Message;
 use crate::term::SizeInfo;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone)]
 pub enum Event {
     DPRChanged(f64, (u32, u32)),
     ConfigReload(PathBuf),
     MouseCursorDirty,
     Message(Message),
     Title(String),
+    ClipboardStore(ClipboardType, String),
+    ClipboardLoad(ClipboardType, std::sync::Arc<dyn Fn(&str) -> String + Sync + Send + 'static>),
     Wakeup,
     Urgent,
     Exit,
+}
+
+impl std::fmt::Debug for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::DPRChanged(scale, size) => write!(f, "DPRChanged({}, {:?})", scale, size),
+            Event::ConfigReload(path) => write!(f, "ConfigReload({:?})", path),
+            Event::MouseCursorDirty => write!(f, "MouseCursorDirty"),
+            Event::Message(msg) => write!(f, "Message({:?})", msg),
+            Event::Title(title) => write!(f, "Title({})", title),
+            Event::ClipboardStore(ty, text) => write!(f, "ClipboardStore({:?},{})", ty, text),
+            Event::ClipboardLoad(ty, _) => write!(f, "ClipboardLoad({:?})", ty),
+            Event::Wakeup => write!(f, "Wakeup"),
+            Event::Urgent => write!(f, "Urgent"),
+            Event::Exit => write!(f, "Exit"),
+        }
+    }
 }
 
 /// Byte sequences are sent to a `Notify` in response to some events.

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -385,7 +385,6 @@ impl Selection {
 mod tests {
     use super::*;
 
-    use crate::clipboard::Clipboard;
     use crate::config::MockConfig;
     use crate::event::{Event, EventListener};
     use crate::index::{Column, Line, Point, Side};
@@ -406,7 +405,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock)
+        Term::new(&MockConfig::default(), &size, Mock)
     }
 
     /// Test case of single cell selection.

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -25,7 +25,7 @@ use unicode_width::UnicodeWidthChar;
 use crate::ansi::{
     self, Attr, CharsetIndex, Color, CursorStyle, Handler, NamedColor, StandardCharset, TermInfo,
 };
-use crate::clipboard::{Clipboard, ClipboardType};
+use crate::clipboard::ClipboardType;
 use crate::config::{Config, VisualBellAnimation};
 use crate::event::{Event, EventListener};
 use crate::grid::{
@@ -790,9 +790,6 @@ pub struct Term<T> {
     /// Style of the vi mode cursor.
     vi_mode_cursor_style: Option<CursorStyle>,
 
-    /// Clipboard access coupled to the active window.
-    clipboard: Clipboard,
-
     /// Proxy for sending events to the event loop.
     event_proxy: T,
 
@@ -821,12 +818,7 @@ impl<T> Term<T> {
         self.dirty = true;
     }
 
-    pub fn new<C>(
-        config: &Config<C>,
-        size: &SizeInfo,
-        clipboard: Clipboard,
-        event_proxy: T,
-    ) -> Term<T> {
+    pub fn new<C>(config: &Config<C>, size: &SizeInfo, event_proxy: T) -> Term<T> {
         let num_cols = size.cols();
         let num_lines = size.lines();
 
@@ -860,7 +852,6 @@ impl<T> Term<T> {
             default_cursor_style: config.cursor.style,
             vi_mode_cursor_style: config.cursor.vi_mode_style,
             dynamic_title: config.dynamic_title(),
-            clipboard,
             event_proxy,
             is_focused: true,
             title: None,
@@ -1164,11 +1155,6 @@ impl<T> Term<T> {
         T: EventListener,
     {
         self.event_proxy.send_event(Event::Exit);
-    }
-
-    #[inline]
-    pub fn clipboard(&mut self) -> &mut Clipboard {
-        &mut self.clipboard
     }
 
     /// Toggle the vi mode.
@@ -1815,9 +1801,9 @@ impl<T: EventListener> Handler for Term<T> {
         self.color_modified[index] = false;
     }
 
-    /// Set the clipboard.
+    /// Request to set a clipboard.
     #[inline]
-    fn set_clipboard(&mut self, clipboard: u8, base64: &[u8]) {
+    fn request_clipboard_set(&mut self, clipboard: u8, base64: &[u8]) {
         let clipboard_type = match clipboard {
             b'c' => ClipboardType::Clipboard,
             b'p' | b's' => ClipboardType::Selection,
@@ -1826,24 +1812,29 @@ impl<T: EventListener> Handler for Term<T> {
 
         if let Ok(bytes) = base64::decode(base64) {
             if let Ok(text) = str::from_utf8(&bytes) {
-                self.clipboard.store(clipboard_type, text);
+                self.event_proxy.send_event(Event::ClipboardStore(clipboard_type, text.to_owned()));
             }
         }
     }
 
-    /// Write clipboard data to child.
+    /// Request to paste to a child.
     #[inline]
-    fn write_clipboard<W: io::Write>(&mut self, clipboard: u8, writer: &mut W, terminator: &str) {
+    fn request_clipboard_write(&mut self, clipboard: u8, terminator: &str) {
         let clipboard_type = match clipboard {
             b'c' => ClipboardType::Clipboard,
             b'p' | b's' => ClipboardType::Selection,
             _ => return,
         };
 
-        let text = self.clipboard.load(clipboard_type);
-        let base64 = base64::encode(&text);
-        let escape = format!("\x1b]52;{};{}{}", clipboard as char, base64, terminator);
-        let _ = writer.write_all(escape.as_bytes());
+        let terminator = terminator.to_owned();
+
+        self.event_proxy.send_event(Event::ClipboardLoad(
+            clipboard_type,
+            std::sync::Arc::new(move |text| {
+                let base64 = base64::encode(&text);
+                format!("\x1b]52;{};{}{}", clipboard as char, base64, terminator)
+            }),
+        ));
     }
 
     #[inline]
@@ -2208,7 +2199,6 @@ mod tests {
     use std::mem;
 
     use crate::ansi::{self, CharsetIndex, Handler, StandardCharset};
-    use crate::clipboard::Clipboard;
     use crate::config::MockConfig;
     use crate::event::{Event, EventListener};
     use crate::grid::{Grid, Scroll};
@@ -2232,7 +2222,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
         let mut grid: Grid<Cell> = Grid::new(Line(3), Column(5), 0, Cell::default());
         for i in 0..5 {
             for j in 0..2 {
@@ -2288,7 +2278,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
         let mut grid: Grid<Cell> = Grid::new(Line(1), Column(5), 0, Cell::default());
         for i in 0..5 {
             grid[Line(0)][Column(i)].c = 'a';
@@ -2317,7 +2307,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
         let mut grid: Grid<Cell> = Grid::new(Line(3), Column(3), 0, Cell::default());
         for l in 0..3 {
             if l != 1 {
@@ -2362,7 +2352,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
         let cursor = Point::new(Line(0), Column(0));
         term.configure_charset(CharsetIndex::G0, StandardCharset::SpecialCharacterAndLineDrawing);
         term.input('a');
@@ -2381,7 +2371,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
 
         // Add one line of scrollback.
         term.grid.scroll_up(&(Line(0)..Line(1)), Line(1), Cell::default());
@@ -2411,7 +2401,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2439,7 +2429,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2473,7 +2463,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2501,7 +2491,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2535,7 +2525,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock);
+        let mut term = Term::new(&MockConfig::default(), &size, Mock);
 
         // Title None by default.
         assert_eq!(term.title, None);
@@ -2589,7 +2579,6 @@ mod benches {
     use std::fs;
     use std::mem;
 
-    use crate::clipboard::Clipboard;
     use crate::config::MockConfig;
     use crate::event::{Event, EventListener};
     use crate::grid::Grid;
@@ -2630,7 +2619,7 @@ mod benches {
 
         let config = MockConfig::default();
 
-        let mut terminal = Term::new(&config, &size, Clipboard::new_nop(), Mock);
+        let mut terminal = Term::new(&config, &size, Mock);
         mem::swap(&mut terminal.grid, &mut grid);
 
         b.iter(|| {

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -412,7 +412,6 @@ fn is_boundary<T>(term: &Term<T>, point: Point<usize>, left: bool) -> bool {
 mod tests {
     use super::*;
 
-    use crate::clipboard::Clipboard;
     use crate::config::MockConfig;
     use crate::event::Event;
     use crate::index::{Column, Line};
@@ -433,7 +432,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock)
+        Term::new(&MockConfig::default(), &size, Mock)
     }
 
     #[test]

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -6,7 +6,6 @@ use std::io::{self, Read};
 use std::path::Path;
 
 use alacritty_terminal::ansi;
-use alacritty_terminal::clipboard::Clipboard;
 use alacritty_terminal::config::MockConfig;
 use alacritty_terminal::event::{Event, EventListener};
 use alacritty_terminal::index::Column;
@@ -98,7 +97,7 @@ fn ref_test(dir: &Path) {
     let mut config = MockConfig::default();
     config.scrolling.set_history(ref_config.history_size);
 
-    let mut terminal = Term::new(&config, &size, Clipboard::new_nop(), Mock);
+    let mut terminal = Term::new(&config, &size, Mock);
     let mut parser = ansi::Processor::new();
 
     for byte in recording {


### PR DESCRIPTION
Remove the copypasta dependency used by alacritty_terminal,
which pulls some gui libraries like xcb.