### PR TITLE
Match font family & style for fontconfig fallback

### DIFF
--- a/font/src/ft/fc/mod.rs
+++ b/font/src/ft/fc/mod.rs
@@ -47,6 +47,11 @@ pub use self::pattern::{Pattern, PatternRef};
 ///
 /// The returned pattern is the result of Pattern::render_prepare.
 pub fn font_match(config: &ConfigRef, pattern: &mut PatternRef) -> Option<Pattern> {
+    if log_enabled!(log::Level::Debug) {
+        debug!("Matching font with pattern:");
+        pattern.print();
+    }
+
     pattern.config_substitute(config, MatchKind::Pattern);
     pattern.default_substitute();
 


### PR DESCRIPTION
In the previous behavior, when looking for a missing glyph, fontconfig will just return some font containing that glyph based on its own ordering preference. It doesn't try to match the user's configured font; it might not even be monospace. This is probably (at least partially) the cause of https://github.com/jwilm/alacritty/issues/1560.

This is my first time contributing in Rust, and I'm not very familiar with the structure of this project yet. So I took the simplest approach of reading back the values already loaded in FreeType. If there's an easy way to get the values directly from the user config, I'm happy to do that instead.