### PR TITLE
Implement handling for OS escape code 7

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -6,7 +6,6 @@ use std::env;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -204,9 +203,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         #[allow(unused_mut)]  // mut used only on unix
         let mut working_directory = self.terminal.current_directory()
-            .map(|p| p.to_str())
-            .unwrap_or(None)
-            .map(|s| s.to_string());
+            .map(|p| p.to_owned());
 
         #[cfg(unix)]
         {
@@ -223,8 +220,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             }
         }
 
-        let args = match working_directory {
-            Some(s) => vec!["--working-directory".into(), s],
+        let args = match &working_directory {
+            Some(path) => vec!["--working-directory".as_ref(), path.as_os_str()],
             None => vec![]
         };
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2011,7 +2011,7 @@ impl<T: EventListener> ansi::Handler for Term<T> {
     #[inline]
     fn set_current_directory(&mut self, path: PathBuf) {
         trace!("Setting working directory {:?}", path);
-        self.current_directory = Some(path.to_owned());
+        self.current_directory = Some(path);
     }
 }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -15,6 +15,7 @@
 //! Exports the `Term` type which is a high-level API for the Grid
 use std::cmp::{max, min};
 use std::ops::{Index, IndexMut, Range};
+use std::path::{PathBuf, Path};
 use std::time::{Duration, Instant};
 use std::{io, mem, ptr};
 
@@ -752,6 +753,9 @@ pub struct Term<T> {
     /// Stack of saved window titles. When a title is popped from this stack, the `title` for the
     /// term is set, and the Glutin window's title attribute is changed through the event listener.
     title_stack: Vec<String>,
+
+    /// Current directory
+    current_directory: Option<PathBuf>
 }
 
 /// Terminal size info
@@ -879,6 +883,7 @@ impl<T> Term<T> {
             is_focused: true,
             title: config.window.title.clone(),
             title_stack: Vec::new(),
+            current_directory: None
         }
     }
 
@@ -1179,6 +1184,10 @@ impl<T> Term<T> {
 
     pub fn clipboard(&mut self) -> &mut Clipboard {
         &mut self.clipboard
+    }
+
+    pub fn current_directory(&self) -> Option<&Path> {
+        self.current_directory.as_ref().map(|pb| pb.as_ref())
     }
 }
 
@@ -1997,6 +2006,12 @@ impl<T: EventListener> ansi::Handler for Term<T> {
             trace!("Title '{}' popped from stack", popped);
             self.set_title(&popped);
         }
+    }
+
+    #[inline]
+    fn set_current_directory(&mut self, path: PathBuf) {
+        trace!("Setting working directory {:?}", path);
+        self.current_directory = Some(path.to_owned());
     }
 }
 


### PR DESCRIPTION
This OS escape code is used by libvte (on unix) and Terminal.app on macOS to inform the terminal emulator about the working directory.

By adding an OSC 7 message to the prompt (i.e. as libvte and Terminal.app do) Alacritty can be updated about the working directory of a child process, even on Windows. This technique also works for subshells, e.g. 

    Alacritty -> bash -> bash

Checking `/proc` can only get the cwd of the "root" bash instance which Alacritty itself spawned, but this OSC 7 message can work for any depth of subshell as long as that subshell is sending the message (normally as part of its prompt).

Relevant iterm2 issue where they added support: https://gitlab.com/gnachman/iterm2/issues/3939
The Windows Terminal guys are also considering handling this: https://github.com/microsoft/terminal/issues/3158

So in theory, this has the potential to fix #1979 for all platforms without `/proc`, but requires the user to customise their prompt a little. If you are in favour of merging this PR, I will add documentation for customising the prompt.

Fixes #1979.