### PR TITLE
[WIP] Preliminary efforts to add *BSD CI

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,0 +1,32 @@
+image: freebsd/latest
+packages:
+  - devel/cmake
+  - devel/pkgconf
+  - lang/python3
+  - print/freetype2
+  - x11-fonts/fontconfig
+  - x11/libxcb
+  # - lang/rust
+sources:
+  - https://github.com/jwilm/alacritty/
+tasks:
+  - rustup: |
+      curl https://sh.rustup.rs -sSf | sh -s -- -y
+      $HOME/.cargo/bin/rustup toolchain install 1.36.0 stable nightly
+  - clippy: |
+      # $HOME/.cargo/bin/rustup component add clippy
+      cd alacritty
+      $HOME/.cargo/bin/cargo +nightly clippy --all-targets # freebsd stable 1.39.0 doesn't have clippy
+  - rustfmt: |
+      # $HOME/.cargo/bin/rustup component add rustfmt
+      cd alacritty
+      $HOME/.cargo/bin/cargo +nightly fmt -- --check || true # same with rustfmt
+  - 1-36-0: |
+      cd alacritty
+      $HOME/.cargo/bin/cargo +1.36.0 build
+  - stable: |
+      cd alacritty
+      $HOME/.cargo/bin/cargo +stable build
+  - nightly: |
+      cd alacritty
+      $HOME/.cargo/bin/cargo +nightly build || true

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,0 +1,10 @@
+image: openbsd/latest
+packages:
+  - python-3.6.9
+  - rust
+sources:
+  - https://github.com/jwilm/alacritty/
+tasks:
+  - build:
+      cd alacritty
+      cargo build


### PR DESCRIPTION
Closes #2248.

---

This is a draft for adding *BSD support to our CI, utilizing the [https://builds.sr.ht](https://builds.sr.ht) and [https://dispatch.sr.ht](https://dispatch.sr.ht) services.

As it is, there are a few problems with this (or rather, differences from Travis):
- [ ] sequential execution of tasks (all subsequent tasks are blocked until completion)
- [ ] lack of ability to restart a single, failed task
- [ ] no way to specify allowed-failures (like we do with all nightly builds under Travis)
  - I currently `|| true` all tests that would be an allowed-failure, which works but isn't as graceful, nor notifies when it fails
- [ ] dispatch.sr.ht requires full access (r/w) to all repos in order to set up the webhook (see also: https://todo.sr.ht/~sircmpwn/dispatch.sr.ht/22)
  - could maybe be worked around if dispatch.sr.ht were to provide a way to manually create a webhook?

In regards to points 1 and 2, we could just split every single task into its own file. I haven't tested if having subfolders in `.builds` would succeed, which could allow us to keep the folder from getting too hectic if we decide to move our other targets to sr.ht as well. This would also allow us to restart single tasks as well as have them all run in parallel.

---

(the following are notes and not necessarily blockers)

### FreeBSD
My current implementation uses `rustup` to install v1.36.0, stable, and nightly Rust toolchains. We could potentially drop 1.36.0 in favor of using Rust stable straight from FreeBSD's ports. This would also cull nightly, because neither package installs `rustup` for managing versions.

Example build for the curious: https://builds.sr.ht/~cole_h/job/114951

### OpenBSD
OpenBSD is a Tier 3 target for Rust, which results in no `rustup` being built for it (available from rustup.rs, at least). This means we can only CI the available version, which at the time of writing is 1.38.0.

Example build for the curious: https://builds.sr.ht/~cole_h/job/114979