### PR TITLE
Improved Numpad Enter support

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -319,7 +319,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         F18; Action::Esc("\x1b[32~".into());
         F19; Action::Esc("\x1b[33~".into());
         F20; Action::Esc("\x1b[34~".into());
-        NumpadEnter; Action::Esc("\n".into());
+        NumpadEnter; Action::Esc("\x0d".into());
     );
 
     //   Code     Modifiers


### PR DESCRIPTION
The default binding for NumpadEnter doesn't work in some cases like `vifm` or `fzf`.
With this change Numpad Enter is perfectly fine everywhere (as far as I tested).