### PR TITLE
Force application symlink on macOS make build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression which added a UNC path prefix to the working directory on Windows
 - CLI parameters discarded when config is reload
 - Blurred icons in KDE task switcher (alacritty.ico is now high-res)
+- Force Application symlink when packaging for macOS
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression which added a UNC path prefix to the working directory on Windows
 - CLI parameters discarded when config is reload
 - Blurred icons in KDE task switcher (alacritty.ico is now high-res)
-- Force Application symlink when packaging for macOS
+- Consecutive builds failing on macOS due to preexisting `/Application` symlink
 
 ## 0.4.1
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ $(APP_NAME): $(TARGET) $(APP_TEMPLATE)
 dmg: | $(DMG_NAME) ## Pack Alacritty.app into .dmg
 $(DMG_NAME): $(APP_NAME)
 	@echo "Packing disk image..."
-	@ln -s /Applications $(DMG_DIR)/Applications
+	@ln -sf /Applications $(DMG_DIR)/Applications
 	@hdiutil create $(DMG_DIR)/$(DMG_NAME) \
 		-volname "Alacritty" \
 		-fs HFS+ \


### PR DESCRIPTION
macOS packaging would fail on repeat builds due to the existence of the Application symlink. Forcing its creation allows for repeat builds without manually clearing the link.
