### PR TITLE
Remove fs::canonicalize from Windows pty startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Font size resetting when Alacritty is moved between screens
 - Limited payload length in clipboard escape (used for Tmux copy/paste)
 - Alacritty not ignoring keyboard events for changing WM focus on X11
+- Regression which added a UNC path prefix to the working directory on Windows
 
 ## 0.4.1
 

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -203,10 +203,7 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) ->
     }
 
     let cmdline = win32_string(&cmdline(&config));
-    let cwd = config
-        .working_directory
-        .as_ref()
-        .map(|pb| win32_string(&pb.as_path().canonicalize().unwrap()));
+    let cwd = config.working_directory.as_ref().map(win32_string);
 
     let mut proc_info: PROCESS_INFORMATION = Default::default();
     unsafe {

--- a/alacritty_terminal/src/tty/windows/winpty.rs
+++ b/alacritty_terminal/src/tty/windows/winpty.rs
@@ -42,14 +42,13 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) ->
     let (conin, conout) = (agent.conin_name(), agent.conout_name());
 
     let cmdline = cmdline(&config);
-    let cwd = config.working_directory.as_ref().map(|pb| pb.as_path().canonicalize().unwrap());
 
     // Spawn process
     let spawnconfig = SpawnConfig::new(
         SpawnFlags::AUTO_SHUTDOWN | SpawnFlags::EXIT_AFTER_SHUTDOWN,
         None, // appname
         Some(&cmdline),
-        cwd.as_ref().map(|p| p.as_ref()),
+        config.working_directory.as_ref().map(|p| p.as_path()),
         None, // Env
     )
     .unwrap();


### PR DESCRIPTION
I was looking further at #3198

`std::fs::canonicalize()` is the call responsible for creating the UNC paths. But I think we don't actually need to canonicalize paths for either of the the ConPTY or WinPTY backends. For example, I tested both with relative paths and they work fine.

So I suggest that rather than making some dance with `canonicalize()` followed by working out how to remove the UNC prefix ourselves, we just faithfully pass the user's input `working_directory` on to the PTY. In that case if there's a problem, that's entirely at the hands of the user's config or command line options.

Related but not necessary for this PR: I also thought it would be wise to check that the `working_directory` in the user's config file is an absolute path. (Relative paths in the config don't seem to be meaningful to me.)

I haven't yet updated the changelog; will write an appropriate message if you agree that this is the right solution for #3198 

Closes #3198 