### PR TITLE
Update font crate to 2018 edition

### DIFF
--- a/font/Cargo.toml
+++ b/font/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 description = "Font rendering using the best available solution per platform"
 license = "Apache-2.0"
+edition = "2018"
 
 [dependencies]
 euclid = "0.20"

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -18,8 +18,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::ptr;
 
-use {Slant, Style, Weight};
-
 use core_foundation::array::{CFArray, CFIndex};
 use core_foundation::string::CFString;
 use core_graphics::base::kCGImageAlphaPremultipliedFirst;
@@ -42,12 +40,14 @@ use core_text::font_descriptor::{CTFontDescriptor, CTFontOrientation};
 
 use euclid::{Point2D, Rect, Size2D};
 
-use super::{BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph};
+use log::{trace, warn};
 
 pub mod byte_order;
 use byte_order::kCGBitmapByteOrder32Host;
 
-use super::Size;
+use super::{
+    BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph, Size, Slant, Style, Weight,
+};
 
 /// Font descriptor
 ///
@@ -124,7 +124,7 @@ impl ::std::fmt::Display for Error {
     }
 }
 
-impl ::Rasterize for Rasterizer {
+impl crate::Rasterize for Rasterizer {
     type Err = Error;
 
     fn new(device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Rasterizer, Error> {

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -45,7 +45,7 @@ use euclid::{Point2D, Rect, Size2D};
 use super::{BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph};
 
 pub mod byte_order;
-use self::byte_order::kCGBitmapByteOrder32Host;
+use byte_order::kCGBitmapByteOrder32Host;
 
 use super::Size;
 

--- a/font/src/directwrite/mod.rs
+++ b/font/src/directwrite/mod.rs
@@ -13,10 +13,7 @@
 // limitations under the License.
 //
 //! Rasterization powered by DirectWrite
-extern crate dwrote;
-use self::dwrote::{
-    FontCollection, FontStretch, FontStyle, FontWeight, GlyphOffset, GlyphRunAnalysis,
-};
+use dwrote::{FontCollection, FontStretch, FontStyle, FontWeight, GlyphOffset, GlyphRunAnalysis};
 
 use super::{
     BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph, Size, Slant, Style, Weight,

--- a/font/src/ft/fc/char_set.rs
+++ b/font/src/ft/fc/char_set.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 use std::ptr::NonNull;
 
-use foreign_types::ForeignTypeRef;
+use foreign_types::{foreign_type, ForeignTypeRef};
 
 use super::ffi::FcCharSetCreate;
 use super::ffi::{FcCharSet, FcCharSetAddChar, FcCharSetDestroy};

--- a/font/src/ft/fc/config.rs
+++ b/font/src/ft/fc/config.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use foreign_types::ForeignTypeRef;
+use foreign_types::{foreign_type, ForeignTypeRef};
 
 use super::ffi::{FcConfig, FcConfigDestroy, FcConfigGetCurrent, FcConfigGetFonts};
 use super::{FontSetRef, SetName};

--- a/font/src/ft/fc/font_set.rs
+++ b/font/src/ft/fc/font_set.rs
@@ -14,7 +14,8 @@
 use std::ops::Deref;
 use std::ptr::NonNull;
 
-use foreign_types::{ForeignType, ForeignTypeRef};
+use foreign_types::{foreign_type, ForeignType, ForeignTypeRef};
+use log::trace;
 
 use super::{ConfigRef, ObjectSetRef, PatternRef};
 

--- a/font/src/ft/fc/mod.rs
+++ b/font/src/ft/fc/mod.rs
@@ -19,29 +19,29 @@ use foreign_types::{ForeignType, ForeignTypeRef};
 
 use fontconfig::fontconfig as ffi;
 
-use self::ffi::FcResultNoMatch;
-use self::ffi::{FcFontList, FcFontMatch, FcFontSort};
-use self::ffi::{FcMatchFont, FcMatchPattern, FcMatchScan};
-use self::ffi::{FcSetApplication, FcSetSystem};
-use self::ffi::{FC_SLANT_ITALIC, FC_SLANT_OBLIQUE, FC_SLANT_ROMAN};
-use self::ffi::{FC_WEIGHT_BLACK, FC_WEIGHT_BOLD, FC_WEIGHT_EXTRABLACK, FC_WEIGHT_EXTRABOLD};
-use self::ffi::{FC_WEIGHT_BOOK, FC_WEIGHT_MEDIUM, FC_WEIGHT_REGULAR, FC_WEIGHT_SEMIBOLD};
-use self::ffi::{FC_WEIGHT_EXTRALIGHT, FC_WEIGHT_LIGHT, FC_WEIGHT_THIN};
+use ffi::FcResultNoMatch;
+use ffi::{FcFontList, FcFontMatch, FcFontSort};
+use ffi::{FcMatchFont, FcMatchPattern, FcMatchScan};
+use ffi::{FcSetApplication, FcSetSystem};
+use ffi::{FC_SLANT_ITALIC, FC_SLANT_OBLIQUE, FC_SLANT_ROMAN};
+use ffi::{FC_WEIGHT_BLACK, FC_WEIGHT_BOLD, FC_WEIGHT_EXTRABLACK, FC_WEIGHT_EXTRABOLD};
+use ffi::{FC_WEIGHT_BOOK, FC_WEIGHT_MEDIUM, FC_WEIGHT_REGULAR, FC_WEIGHT_SEMIBOLD};
+use ffi::{FC_WEIGHT_EXTRALIGHT, FC_WEIGHT_LIGHT, FC_WEIGHT_THIN};
 
 pub mod config;
-pub use self::config::{Config, ConfigRef};
+pub use config::{Config, ConfigRef};
 
 pub mod font_set;
-pub use self::font_set::{FontSet, FontSetRef};
+pub use font_set::{FontSet, FontSetRef};
 
 pub mod object_set;
-pub use self::object_set::{ObjectSet, ObjectSetRef};
+pub use object_set::{ObjectSet, ObjectSetRef};
 
 pub mod char_set;
-pub use self::char_set::{CharSet, CharSetRef};
+pub use char_set::{CharSet, CharSetRef};
 
 pub mod pattern;
-pub use self::pattern::{Pattern, PatternRef};
+pub use pattern::{Pattern, PatternRef};
 
 /// Find the font closest matching the provided pattern.
 ///

--- a/font/src/ft/fc/object_set.rs
+++ b/font/src/ft/fc/object_set.rs
@@ -16,7 +16,7 @@ use std::ptr::NonNull;
 use libc::c_char;
 
 use super::ffi::{FcObjectSet, FcObjectSetAdd, FcObjectSetCreate, FcObjectSetDestroy};
-use foreign_types::ForeignTypeRef;
+use foreign_types::{foreign_type, ForeignTypeRef};
 
 foreign_type! {
     pub unsafe type ObjectSet {

--- a/font/src/ft/fc/pattern.rs
+++ b/font/src/ft/fc/pattern.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use std::ptr::{self, NonNull};
 use std::str;
 
-use foreign_types::{ForeignType, ForeignTypeRef};
+use foreign_types::{foreign_type, ForeignType, ForeignTypeRef};
 use libc::{c_char, c_double, c_int};
 
 use super::ffi::FcResultMatch;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -22,6 +22,7 @@ use freetype::freetype_sys;
 use freetype::tt_os2::TrueTypeOS2Table;
 use freetype::{self, Library};
 use libc::c_uint;
+use log::{debug, trace};
 
 pub mod fc;
 

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -20,31 +20,6 @@
 
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
 
-#[cfg(not(any(target_os = "macos", windows)))]
-extern crate fontconfig;
-#[cfg(not(any(target_os = "macos", windows)))]
-extern crate freetype;
-
-#[cfg(target_os = "macos")]
-extern crate core_foundation;
-#[cfg(target_os = "macos")]
-extern crate core_foundation_sys;
-#[cfg(target_os = "macos")]
-extern crate core_graphics;
-#[cfg(target_os = "macos")]
-extern crate core_text;
-#[cfg(target_os = "macos")]
-extern crate euclid;
-
-extern crate libc;
-
-#[cfg(not(any(target_os = "macos", windows)))]
-#[macro_use]
-extern crate foreign_types;
-
-#[cfg_attr(not(windows), macro_use)]
-extern crate log;
-
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul};
@@ -59,7 +34,7 @@ pub use ft::{Error, FreeTypeRasterizer as Rasterizer};
 #[cfg(windows)]
 pub mod directwrite;
 #[cfg(windows)]
-pub use crate::directwrite::{DirectWriteRasterizer as Rasterizer, Error};
+pub use directwrite::{DirectWriteRasterizer as Rasterizer, Error};
 
 // If target is macos, reexport everything from darwin
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
I've updated the font crate to 2018 edition, which will ease some of the path pain working on #3127.

All I've done is:
- Set the edition in `Cargo.toml`
- Remove all `extern crate` declarations
- Remove all `self::` where unneeded
- Add macro imports where needed
