### PR TITLE
Replace `.nth(0)` with `.next()`

### DIFF
--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -338,8 +338,7 @@ impl Descriptor {
         let fallbacks = if load_fallbacks {
             descriptors_for_family("Menlo")
                 .into_iter()
-                .filter(|d| d.font_name == "Menlo-Regular")
-                .nth(0)
+                .find(|d| d.font_name == "Menlo-Regular")
                 .map(|descriptor| {
                     let menlo = ct_new_from_descriptor(&descriptor.ct_descriptor, size);
 

--- a/font/src/ft/fc/pattern.rs
+++ b/font/src/ft/fc/pattern.rs
@@ -518,7 +518,7 @@ impl PatternRef {
     }
 
     pub fn get_width(&self) -> Option<Width> {
-        unsafe { self.get_integer(b"width\0").nth(0).map(Width::from) }
+        unsafe { self.get_integer(b"width\0").next().map(Width::from) }
     }
 
     pub fn rgba(&self) -> RgbaPropertyIter {

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -251,7 +251,7 @@ impl FreeTypeRasterizer {
     }
 
     fn face_from_pattern(&mut self, pattern: &fc::Pattern) -> Result<Option<FontKey>, Error> {
-        if let (Some(path), Some(index)) = (pattern.file(0), pattern.index().nth(0)) {
+        if let (Some(path), Some(index)) = (pattern.file(0), pattern.index().next()) {
             if let Some(key) = self.keys.get(&path) {
                 return Ok(Some(*key));
             }
@@ -547,7 +547,7 @@ impl FreeTypeRasterizer {
         let config = fc::Config::get_current();
         match fc::font_match(config, &mut pattern) {
             Some(pattern) => {
-                if let (Some(path), Some(_)) = (pattern.file(0), pattern.index().nth(0)) {
+                if let (Some(path), Some(_)) = (pattern.file(0), pattern.index().next()) {
                     match self.keys.get(&path) {
                         // We've previously loaded this font, so don't
                         // load it again.


### PR DESCRIPTION
Clippy says that `.next()` is more readable than `.nth(0)`, and I am
inclined to agree.

https://rust-lang.github.io/rust-clippy/master/index.html#iter_nth_zero