### PR TITLE
Default `draw_bold_text_with_bright_colors` to `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `WINIT_HIDPI_FACTOR` environment variable to `WINIT_X11_SCALE_FACTOR`
 - Print an error instead of crashing, when startup working directory is invalid
 - Line selection will now expand across wrapped lines
+- The default value for `draw_bold_text_with_bright_colors` is now `false`
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -180,7 +180,7 @@
   #use_thin_strokes: true
 
 # If `true`, bold text is drawn using the bright color variants.
-#draw_bold_text_with_bright_colors: true
+#draw_bold_text_with_bright_colors: false
 
 # Colors (Tomorrow Night Bright)
 #colors:

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -60,7 +60,7 @@ pub struct Config<T> {
 
     /// Should draw bold text with brighter colors instead of bold font
     #[serde(default, deserialize_with = "failure_default")]
-    draw_bold_text_with_bright_colors: DefaultTrueBool,
+    draw_bold_text_with_bright_colors: bool,
 
     #[serde(default, deserialize_with = "failure_default")]
     pub colors: Colors,
@@ -149,7 +149,7 @@ impl<T> Config<T> {
 
     #[inline]
     pub fn draw_bold_text_with_bright_colors(&self) -> bool {
-        self.draw_bold_text_with_bright_colors.0
+        self.draw_bold_text_with_bright_colors
     }
 
     /// Should show render timer


### PR DESCRIPTION
The option has some "historical" background, for example it could break
ncurses applications like alsamixer, however the default to `true`
seems strange nowadays, because it makes impossible to draw bold text in
a "normal" color. Some other terminals (e.g. vte, kitty) also started default to
`false` here.

We're not removing the option, but just flipping a bit, and knowing that users
tend to copy paste our config in a past, will likely continue to have it
defaulted to `true` in their configuration files. The only problem is the users
who don't have this option in a config file now or new users, however the change
in color is noticeable and it also stated very clear in our configuration file,
so it shouldn't be a problem to flip things back.

Implements #2779

I think keeping this around isn't a good idea, so let's just push it.