### PR TITLE
Add debug log for missing config

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 #[cfg(windows)]
 use dirs;
-use log::{error, warn};
+use log::{error, warn, debug};
 use serde_yaml;
 #[cfg(not(windows))]
 use xdg;
@@ -121,6 +121,8 @@ pub fn installed_config() -> Option<PathBuf> {
                     return Some(fallback);
                 }
             }
+
+            debug!(target: LOG_TARGET_CONFIG, "No configuration file found");
             None
         })
 }

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 #[cfg(windows)]
 use dirs;
-use log::{error, warn, debug};
+use log::{error, warn};
 use serde_yaml;
 #[cfg(not(windows))]
 use xdg;
@@ -122,7 +122,6 @@ pub fn installed_config() -> Option<PathBuf> {
                 }
             }
 
-            debug!(target: LOG_TARGET_CONFIG, "No configuration file found");
             None
         })
 }

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -121,7 +121,6 @@ pub fn installed_config() -> Option<PathBuf> {
                     return Some(fallback);
                 }
             }
-
             None
         })
 }

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -128,9 +128,11 @@ fn main() {
 /// config change monitor, and runs the main display loop.
 fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), Box<dyn Error>> {
     info!("Welcome to Alacritty");
-    if let Some(config_path) = &config.config_path {
-        info!("Configuration loaded from \"{}\"", config_path.display());
-    };
+
+    match &config.config_path {
+        Some(config_path) => info!("Configuration loaded from \"{}\"", config_path.display()),
+        None => info!("No configuration file found"),
+    }
 
     // Set environment variables
     tty::setup_env(&config);


### PR DESCRIPTION
We currently log whenever we fall back to the default config because of
an error in the config itself. We also log when the config was
successfully loaded and where it was loaded from. The only scenario
where no config related message is logged is when there is no
configuration file present.

Logging this case should make it easier to debug issues like #3240,
without requiring any knowledge from maintainers about this edgecase.
