### PR TITLE
Fix backspace deleting chars when IME is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize of bitmap fonts
 - Crash when using bitmap font with `embeddedbitmap` set to `false`
 - Inconsistent fontconfig fallback
+- Backspace deleting characters while IME is open on macOS
 
 ### Removed
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -287,7 +287,6 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         PageDown; Action::Esc("\x1b[6~".into());
         PageDown, ModifiersState::SHIFT, +TermMode::ALT_SCREEN; Action::Esc("\x1b[6;2~".into());
         Tab,  ModifiersState::SHIFT; Action::Esc("\x1b[Z".into());
-        Back; Action::Esc("\x7f".into());
         Back, ModifiersState::ALT; Action::Esc("\x1b\x7f".into());
         Insert; Action::Esc("\x1b[2~".into());
         Delete; Action::Esc("\x1b[3~".into());
@@ -406,6 +405,7 @@ fn common_keybindings() -> Vec<KeyBinding> {
         Add,      ModifiersState::CTRL;  Action::IncreaseFontSize;
         Subtract, ModifiersState::CTRL;  Action::DecreaseFontSize;
         Minus,    ModifiersState::CTRL;  Action::DecreaseFontSize;
+        Back; Action::Esc("\x7f".into());
     )
 }
 


### PR DESCRIPTION
Fixes #1606.
