### PR TITLE
Start window invisible on Windows

### DIFF
--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -252,7 +252,7 @@ impl Window {
 
         WindowBuilder::new()
             .with_title(title)
-            .with_visible(true)
+            .with_visible(false)
             .with_decorations(decorations)
             .with_transparent(true)
             .with_maximized(window_config.startup_mode() == StartupMode::Maximized)


### PR DESCRIPTION
It should make our Windows window creation follow other backends and start window invisible. However it was started visible on purpose, so I'm not sure whether it breaks something or not.

Could Windows folks test whether it breaks anything for them or not?