### PR TITLE
Fix selection expansion across full-width glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inconsistent fontconfig fallback
 - Backspace deleting characters while IME is open on macOS
 - Handling of OpenType variable fonts
+- Expansion of block-selection with partially selected full-width glyphs
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inconsistent fontconfig fallback
 - Backspace deleting characters while IME is open on macOS
 - Handling of OpenType variable fonts
-- Expansion of block-selection with partially selected full-width glyphs
+- Expansion of block-selection on partially selected full-width glyphs
 
 ### Removed
 

--- a/alacritty/src/url.rs
+++ b/alacritty/src/url.rs
@@ -42,7 +42,7 @@ impl Url {
     }
 
     pub fn end(&self) -> Point {
-        self.lines[self.lines.len() - 1].end.sub(self.num_cols, self.end_offset as usize, false)
+        self.lines[self.lines.len() - 1].end.sub(self.num_cols, self.end_offset as usize)
     }
 }
 
@@ -83,7 +83,7 @@ impl Urls {
         let end = point;
 
         // Reset URL when empty cells have been skipped
-        if point != Point::default() && Some(point.sub(num_cols, 1, false)) != self.last_point {
+        if point != Point::default() && Some(point.sub(num_cols, 1)) != self.last_point {
             self.reset();
         }
 

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -44,15 +44,13 @@ impl<L> Point<L> {
 
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn sub(mut self, num_cols: usize, rhs: usize, absolute_indexing: bool) -> Point<L>
+    pub fn sub(mut self, num_cols: usize, rhs: usize) -> Point<L>
     where
         L: Copy + Default + Into<Line> + Add<usize, Output = L> + Sub<usize, Output = L>,
     {
         let line_changes =
             f32::ceil(rhs.saturating_sub(self.col.0) as f32 / num_cols as f32) as usize;
-        if absolute_indexing {
-            self.line = self.line + line_changes;
-        } else if self.line.into() > Line(line_changes) {
+        if self.line.into() > Line(line_changes) {
             self.line = self.line - line_changes;
         } else {
             self.line = Default::default();
@@ -63,18 +61,11 @@ impl<L> Point<L> {
 
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn add(mut self, num_cols: usize, rhs: usize, absolute_indexing: bool) -> Point<L>
+    pub fn add(mut self, num_cols: usize, rhs: usize) -> Point<L>
     where
-        L: Copy + Default + Into<Line> + Add<usize, Output = L> + Sub<usize, Output = L>,
+        L: Add<usize, Output = L> + Sub<usize, Output = L>,
     {
-        let line_changes = (rhs + self.col.0) / num_cols;
-        if !absolute_indexing {
-            self.line = self.line + line_changes;
-        } else if self.line.into() > Line(line_changes) {
-            self.line = self.line - line_changes;
-        } else {
-            self.line = Default::default();
-        }
+        self.line = self.line + (rhs + self.col.0) / num_cols;
         self.col = Column((self.col.0 + rhs) % num_cols);
         self
     }

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -44,33 +44,38 @@ impl<L> Point<L> {
 
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn sub(mut self, num_cols: usize, length: usize, absolute_indexing: bool) -> Point<L>
+    pub fn sub(mut self, num_cols: usize, rhs: usize, absolute_indexing: bool) -> Point<L>
     where
-        L: Copy + Add<usize, Output = L> + Sub<usize, Output = L>,
+        L: Copy + Default + Into<Line> + Add<usize, Output = L> + Sub<usize, Output = L>,
     {
-        let line_changes = f32::ceil(length.saturating_sub(self.col.0) as f32 / num_cols as f32);
+        let line_changes =
+            f32::ceil(rhs.saturating_sub(self.col.0) as f32 / num_cols as f32) as usize;
         if absolute_indexing {
-            self.line = self.line + line_changes as usize;
+            self.line = self.line + line_changes;
+        } else if self.line.into() > Line(line_changes) {
+            self.line = self.line - line_changes;
         } else {
-            self.line = self.line - line_changes as usize;
+            self.line = Default::default();
         }
-        self.col = Column((num_cols + self.col.0 - length % num_cols) % num_cols);
+        self.col = Column((num_cols + self.col.0 - rhs % num_cols) % num_cols);
         self
     }
 
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn add(mut self, num_cols: usize, length: usize, absolute_indexing: bool) -> Point<L>
+    pub fn add(mut self, num_cols: usize, rhs: usize, absolute_indexing: bool) -> Point<L>
     where
-        L: Copy + Add<usize, Output = L> + Sub<usize, Output = L>,
+        L: Copy + Default + Into<Line> + Add<usize, Output = L> + Sub<usize, Output = L>,
     {
-        let line_changes = (length + self.col.0) / num_cols;
-        if absolute_indexing {
+        let line_changes = (rhs + self.col.0) / num_cols;
+        if !absolute_indexing {
+            self.line = self.line + line_changes;
+        } else if self.line.into() > Line(line_changes) {
             self.line = self.line - line_changes;
         } else {
-            self.line = self.line + line_changes;
+            self.line = Default::default();
         }
-        self.col = Column((self.col.0 + length) % num_cols);
+        self.col = Column((self.col.0 + rhs) % num_cols);
         self
     }
 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1062,6 +1062,7 @@ impl<T> Term<T> {
 
         // If wide char is not part of the selection, but leading spacer is, include it
         if line_length == self.grid.num_cols()
+            && line_length.0 >= 2
             && grid_line[line_length - 1].flags.contains(Flags::WIDE_CHAR_SPACER)
             && !grid_line[line_length - 2].flags.contains(Flags::WIDE_CHAR)
             && include_wrapped_wide

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -299,33 +299,30 @@ impl<'a, C> RenderableCellsIter<'a, C> {
 
         // Check if wide char's spacers are selected
         if cell.flags.contains(Flags::WIDE_CHAR) {
-            let prevprev = point.sub(num_cols, 2, false);
-            let prev = point.sub(num_cols, 1, false);
-            let next = point.add(num_cols, 1, false);
+            let prevprev = point.sub(num_cols, 2);
+            let prev = point.sub(num_cols, 1);
+            let next = point.add(num_cols, 1);
 
             // Check trailing spacer
-            return selection.contains(next.col, next.line)
+            selection.contains(next.col, next.line)
                 // Check line-wrapping, leading spacer
                 || (self.grid[&prev].flags.contains(Flags::WIDE_CHAR_SPACER)
                     && !self.grid[&prevprev].flags.contains(Flags::WIDE_CHAR)
-                    && selection.contains(prev.col, prev.line));
-        }
-
-        // Check if spacer's wide char is selected
-        if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-            let prev = point.sub(num_cols, 1, false);
+                    && selection.contains(prev.col, prev.line))
+        } else if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+            // Check if spacer's wide char is selected
+            let prev = point.sub(num_cols, 1);
 
             if self.grid[&prev].flags.contains(Flags::WIDE_CHAR) {
                 // Check previous cell for trailing spacer
-                return self.is_selected(prev);
+                self.is_selected(prev)
             } else {
                 // Check next cell for line-wrapping, leading spacer
-                let next = point.add(num_cols, 1, false);
-                return self.is_selected(next);
+                self.is_selected(point.add(num_cols, 1))
             }
+        } else {
+            false
         }
-
-        false
     }
 }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1065,8 +1065,7 @@ impl<T> Term<T> {
         }
 
         // If wide char is not part of the selection, but leading spacer is, include it
-        if line_length >= Column(2)
-            && line_end == line_length
+        if line_end == self.grid.num_cols()
             && grid_line[line_end - 1].flags.contains(Flags::WIDE_CHAR_SPACER)
             && !grid_line[line_end - 2].flags.contains(Flags::WIDE_CHAR)
             && include_wrapped_wide

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -984,7 +984,7 @@ impl<T> Term<T> {
 
         if is_block {
             for line in (end.line + 1..=start.line).rev() {
-                res += &(self.line_to_string(line, start.col..end.col, start.col.0 == 0) + "\n");
+                res += &(self.line_to_string(line, start.col..end.col, start.col.0 != 0) + "\n");
             }
             res += &self.line_to_string(end.line, start.col..end.col, true);
         } else {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1018,8 +1018,7 @@ impl<T> Term<T> {
         let mut text = String::new();
 
         let grid_line = &self.grid[line];
-        let line_length = grid_line.line_length();
-        let line_end = min(line_length, cols.end + 1);
+        let line_length = min(grid_line.line_length(), cols.end + 1);
 
         // Include wide char when trailing spacer is selected
         if grid_line[cols.start].flags.contains(Flags::WIDE_CHAR_SPACER) {
@@ -1027,7 +1026,7 @@ impl<T> Term<T> {
         }
 
         let mut tab_mode = false;
-        for col in IndexRange::from(cols.start..line_end) {
+        for col in IndexRange::from(cols.start..line_length) {
             let cell = grid_line[col];
 
             // Skip over cells until next tab-stop once a tab was found
@@ -1055,16 +1054,16 @@ impl<T> Term<T> {
         }
 
         if cols.end >= self.cols() - 1
-            && (line_end == Column(0)
-                || !self.grid[line][line_end - 1].flags.contains(Flags::WRAPLINE))
+            && (line_length.0 == 0
+                || !self.grid[line][line_length - 1].flags.contains(Flags::WRAPLINE))
         {
             text.push('\n');
         }
 
         // If wide char is not part of the selection, but leading spacer is, include it
-        if line_end == self.grid.num_cols()
-            && grid_line[line_end - 1].flags.contains(Flags::WIDE_CHAR_SPACER)
-            && !grid_line[line_end - 2].flags.contains(Flags::WIDE_CHAR)
+        if line_length == self.grid.num_cols()
+            && grid_line[line_length - 1].flags.contains(Flags::WIDE_CHAR_SPACER)
+            && !grid_line[line_length - 2].flags.contains(Flags::WIDE_CHAR)
             && include_wrapped_wide
         {
             text.push(self.grid[line - 1][Column(0)].c);


### PR DESCRIPTION
Instead of trying to expand the start and end of a selection across
full-width glyphs, the selection should now only go from its origin to
the end without any kind of expansion.

Instead, the expansion is now done where the cells are actually checked
for their selection status, expanding across the entire full-width glyph
whenever any part of it is selected.

Fixes #3106.