### PR TITLE
Remove unsetting of dirty flag on key press xxx

### DIFF
--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -630,7 +630,6 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         self.ctx.write_to_pty(bytes);
 
         *self.ctx.received_count() += 1;
-        self.ctx.terminal_mut().dirty = false;
     }
 
     /// Reset mouse cursor based on modifier and terminal state.


### PR DESCRIPTION
There's no reason why we should ever manually set the terminal to not be
dirty, since this can lead to a lot of other logic being affected. This
also does not have any benefit and was likely added in the event loop
rework as a bug (probably should have been dirty = true).
