### PR TITLE
Add notes about multiple bindings for the same keys + mods + mode. 

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -530,6 +530,8 @@
 # binding with the same triggers is defined. To unset a default binding, it can
 # be mapped to the `ReceiveChar` action. Alternatively, you can use `None` for
 # a no-op if you do not wish to receive input characters for that binding.
+#
+# If the same trigger is assigned to multiple actions all of them are executed at once.
 #key_bindings:
   # (Windows, Linux, and BSD only)
   #- { key: V,        mods: Control|Shift, action: Paste            }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -531,7 +531,8 @@
 # be mapped to the `ReceiveChar` action. Alternatively, you can use `None` for
 # a no-op if you do not wish to receive input characters for that binding.
 #
-# If the same trigger is assigned to multiple actions all of them are executed at once.
+# If the same trigger is assigned to multiple actions, all of them are executed
+# at once.
 #key_bindings:
   # (Windows, Linux, and BSD only)
   #- { key: V,        mods: Control|Shift, action: Paste            }


### PR DESCRIPTION
Adding a line in the alacritty.yml to mention the ability to assign multiple actions to a trigger. As requested by #3273.