### PR TITLE
Add modal keyboard motion mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ os:
   - osx
 
 rust:
-  - 1.37.0
+  - 1.39.0
   - stable
   - nightly
 
@@ -30,22 +30,22 @@ matrix:
     - name: "Clippy Linux"
       os: linux
       env: CLIPPY=true
-      rust: 1.37.0
+      rust: 1.39.0
     - name: "Clippy OSX"
       os: osx
       env: CLIPPY=true
-      rust: 1.37.0
+      rust: 1.39.0
     - name: "Clippy Windows"
       os: windows
       env: CLIPPY=true
-      rust: 1.37.0-x86_64-pc-windows-msvc
+      rust: 1.39.0-x86_64-pc-windows-msvc
     - name: "Rustfmt"
       os: linux
       env: RUSTFMT=true
       rust: nightly
-    - name: "Windows 1.37.0"
+    - name: "Windows 1.39.0"
       os: windows
-      rust: 1.37.0-x86_64-pc-windows-msvc
+      rust: 1.39.0-x86_64-pc-windows-msvc
     - name: "Windows Stable"
       os: windows
       rust: stable-x86_64-pc-windows-msvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Default Command+N keybinding for SpawnNewInstance on macOS
+- Vi mode for copying text and opening links
+
+### Changed
+
+- Block cursor is no longer inverted at the start/end of a selection
 
 ## 0.4.2-dev
 
@@ -22,10 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Live config reload for `window.title`
 
-### Added
-
-- Vi mode for copying text and opening links
-
 ### Changed
 
 - Pressing additional modifiers for mouse bindings will no longer trigger them
@@ -36,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mirror OSC query terminators instead of always using BEL
 - Increased Beam, Underline, and Hollow Block cursors' line widths
 - Dynamic title is not disabled anymore when `window.title` is set in config
-- Block cursor is no longer inverted at the start/end of a selection
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Keyboard cursor motion mode for copying text and opening links
+- Vi mode for copying text and opening links
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Live config reload for `window.title`
 
+### Added
+
+- Modal keyboard cursor motion mode for copying text
+
 ### Changed
 
 - Pressing additional modifiers for mouse bindings will no longer trigger them
@@ -32,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mirror OSC query terminators instead of always using BEL
 - Increased Beam, Underline, and Hollow Block cursors' line widths
 - Dynamic title is not disabled anymore when `window.title` is set in config
+- Block cursor is no longer inverted at the start/end of a selection
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Modal keyboard cursor motion mode for copying text
+- Keyboard cursor motion mode for copying text and opening links
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ and
 [easy](https://github.com/alacritty/alacritty/issues?q=is%3Aopen+is%3Aissue+label%3A%22D+-+easy%22)
 issues.
 
-Please note that the minimum supported version of Alacritty is Rust 1.37.0. All patches are expected
+Please note that the minimum supported version of Alacritty is Rust 1.39.0. All patches are expected
 to work with the minimum supported version.
 
 ### Testing

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -187,11 +187,13 @@
 
   # Cursor colors
   #
-  # Colors which should be used to draw the terminal cursor. If these are unset,
-  # the cursor color will be the inverse of the cell color.
+  # Colors which should be used to draw the terminal cursors. If these are
+  # unset, the cursor color will be the inverse of the cell color.
   #cursor:
   #  text: '#000000'
   #  cursor: '#ffffff'
+  #  keyboard_motion_text: '#000000'
+  #  keyboard_motion_cursor: '#ffffff'
 
   # Selection colors
   #
@@ -297,6 +299,14 @@
   #   - _ Underline
   #   - | Beam
   #style: Block
+
+  # Keyboard motion cursor style
+  #
+  # If the keyboard motion cursor style is `None` or not specified, it will fall
+  # back to the style of the active value of the normal cursor.
+  #
+  # See `cursor.style` for available options.
+  #keyboard_motion_style: None
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.
@@ -435,27 +445,24 @@
 #
 # - `action`: Execute a predefined action
 #
-#   - Copy
-#   - Paste
-#   - PasteSelection
-#   - IncreaseFontSize
-#   - DecreaseFontSize
-#   - ResetFontSize
-#   - ScrollPageUp
-#   - ScrollPageDown
-#   - ScrollLineUp
-#   - ScrollLineDown
-#   - ScrollToTop
-#   - ScrollToBottom
 #   - ClearHistory
-#   - Hide
-#   - Minimize
-#   - Quit
-#   - ToggleFullscreen
-#   - SpawnNewInstance
 #   - ClearLogNotice
-#   - ReceiveChar
-#   - None
+#   - SpawnNewInstance
+#   - None, ReceiveChar
+#   - Hide, Minimize, Quit, ToggleFullscreen
+#   - Copy, Paste, PasteSelection
+#   - IncreaseFontSize, DecreaseFontSize, ResetFontSize
+#   - ScrollPageUp, ScrollPageDown, ScrollHalfPageUp, ScrollHalfPageDown,
+#     ScrollLineUp, ScrollLineDown, ScrollToTop, ScrollToBottom
+#   - ToggleKeyboardMode, ToggleNormalSelection, ToggleLineSelection,
+#     ToggleBlockSelection, KeyboardMotionClick, KeyboardMotionUp,
+#     KeyboardMotionDown, KeyboardMotionLeft, KeyboardMotionRight,
+#     KeyboardMotionStart, KeyboardMotionEnd, KeyboardMotionHigh,
+#     KeyboardMotionMiddle, KeyboardMotionLow, KeyboardMotionSemanticLeft,
+#     KeyboardMotionSemanticRight, KeyboardMotionSemanticLeftEnd,
+#     KeyboardMotionSemanticRightEnd, KeyboardMotionWordRight,
+#     KeyboardMotionWordLeft, KeyboardMotionWordRightEnd,
+#     KeyboardMotionWordLeftEnd, KeyboardMotionBracket
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -193,11 +193,11 @@
   #  text: '#000000'
   #  cursor: '#ffffff'
 
-  # Keyboard motion cursor colors
+  # Vi mode cursor colors
   #
-  # Colors for the cursor when the keyboard motion mode is active. If these are
-  # unset, the cursor color will be the inverse of the cell color.
-  #keyboard_motion_cursor:
+  # Colors for the cursor when the vi mode is active. If these are unset, the
+  # cursor color will be the inverse of the cell color.
+  #vi_mode_cursor:
   #  text: '#000000'
   #  cursor: '#ffffff'
 
@@ -306,13 +306,13 @@
   #   - | Beam
   #style: Block
 
-  # Keyboard motion cursor style
+  # Vi mode cursor style
   #
-  # If the keyboard motion cursor style is `None` or not specified, it will fall
-  # back to the style of the active value of the normal cursor.
+  # If the vi mode cursor style is `None` or not specified, it will fall back to
+  # the style of the active value of the normal cursor.
   #
   # See `cursor.style` for available options.
-  #keyboard_motion_style: None
+  #vi_mode_style: None
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.
@@ -451,7 +451,7 @@
 #
 # - `action`: Execute a predefined action
 #
-#   - ToggleKeyboardMode
+#   - ToggleViMode
 #   - Copy
 #   - Paste
 #   - PasteSelection
@@ -478,7 +478,7 @@
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space
 #
-# - `keyboard_motion`: Execute a keyboard motion mode command
+# - `vi_mode`: Execute a vi mode command
 #
 #   - Open
 #   - Up
@@ -555,48 +555,48 @@
   #- { key: Home,      mods: Shift,   action: ScrollToTop,    mode: ~Alt       }
   #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt       }
 
-  # Keyboard Motion Mode
-  #- { key: Space,  mods: Shift|Control, mode: KeyboardMotion, action: ScrollToBottom     }
-  #- { key: Space,  mods: Shift|Control,                       action: ToggleKeyboardMode }
-  #- { key: Escape,                mode: KeyboardMotion, action: ScrollToBottom     }
-  #- { key: Escape,                mode: KeyboardMotion, action: ToggleKeyboardMode }
-  #- { key: I,                     mode: KeyboardMotion, action: ScrollToBottom     }
-  #- { key: I,                     mode: KeyboardMotion, action: ToggleKeyboardMode }
-  #- { key: Y,      mods: Control, mode: KeyboardMotion, action: ScrollLineUp       }
-  #- { key: E,      mods: Control, mode: KeyboardMotion, action: ScrollLineDown     }
-  #- { key: G,                     mode: KeyboardMotion, action: ScrollToTop        }
-  #- { key: G,      mods: Shift,   mode: KeyboardMotion, action: ScrollToBottom     }
-  #- { key: B,      mods: Control, mode: KeyboardMotion, action: ScrollPageUp       }
-  #- { key: F,      mods: Control, mode: KeyboardMotion, action: ScrollPageDown     }
-  #- { key: U,      mods: Control, mode: KeyboardMotion, action: ScrollHalfPageUp   }
-  #- { key: D,      mods: Control, mode: KeyboardMotion, action: ScrollHalfPageDown }
-  #- { key: Y,                     mode: KeyboardMotion, action: Copy               }
-  #- { key: V,                     keyboard_motion: ToggleNormalSelection   }
-  #- { key: V,      mods: Shift,   keyboard_motion: ToggleLineSelection     }
-  #- { key: V,      mods: Control, keyboard_motion: ToggleBlockSelection    }
-  #- { key: V,      mods: Alt,     keyboard_motion: ToggleSemanticSelection }
-  #- { key: Return,                keyboard_motion: Open                    }
-  #- { key: K,                     keyboard_motion: Up                      }
-  #- { key: J,                     keyboard_motion: Down                    }
-  #- { key: H,                     keyboard_motion: Left                    }
-  #- { key: L,                     keyboard_motion: Right                   }
-  #- { key: Up,                    keyboard_motion: Up                      }
-  #- { key: Down,                  keyboard_motion: Down                    }
-  #- { key: Left,                  keyboard_motion: Left                    }
-  #- { key: Right,                 keyboard_motion: Right                   }
-  #- { key: Key0,                  keyboard_motion: First                   }
-  #- { key: Key4,   mods: Shift,   keyboard_motion: Last                    }
-  #- { key: Key6,   mods: Shift,   keyboard_motion: FirstOccupied           }
-  #- { key: H,      mods: Shift,   keyboard_motion: High                    }
-  #- { key: M,      mods: Shift,   keyboard_motion: Middle                  }
-  #- { key: L,      mods: Shift,   keyboard_motion: Low                     }
-  #- { key: B,                     keyboard_motion: SemanticLeft            }
-  #- { key: W,                     keyboard_motion: SemanticRight           }
-  #- { key: E,                     keyboard_motion: SemanticRightEnd        }
-  #- { key: B,      mods: Shift,   keyboard_motion: WordLeft                }
-  #- { key: W,      mods: Shift,   keyboard_motion: WordRight               }
-  #- { key: E,      mods: Shift,   keyboard_motion: WordRightEnd            }
-  #- { key: Key5,   mods: Shift,   keyboard_motion: Bracket                 }
+  # Vi Mode
+  #- { key: Space,  mods: Shift|Control, mode: ViMode, action: ScrollToBottom     }
+  #- { key: Space,  mods: Shift|Control,               action: ToggleViMode       }
+  #- { key: Escape,                      mode: ViMode, action: ScrollToBottom     }
+  #- { key: Escape,                      mode: ViMode, action: ToggleViMode       }
+  #- { key: I,                           mode: ViMode, action: ScrollToBottom     }
+  #- { key: I,                           mode: ViMode, action: ToggleViMode       }
+  #- { key: Y,      mods: Control,       mode: ViMode, action: ScrollLineUp       }
+  #- { key: E,      mods: Control,       mode: ViMode, action: ScrollLineDown     }
+  #- { key: G,                           mode: ViMode, action: ScrollToTop        }
+  #- { key: G,      mods: Shift,         mode: ViMode, action: ScrollToBottom     }
+  #- { key: B,      mods: Control,       mode: ViMode, action: ScrollPageUp       }
+  #- { key: F,      mods: Control,       mode: ViMode, action: ScrollPageDown     }
+  #- { key: U,      mods: Control,       mode: ViMode, action: ScrollHalfPageUp   }
+  #- { key: D,      mods: Control,       mode: ViMode, action: ScrollHalfPageDown }
+  #- { key: Y,                           mode: ViMode, action: Copy               }
+  #- { key: V,                     vi_mode: ToggleNormalSelection   }
+  #- { key: V,      mods: Shift,   vi_mode: ToggleLineSelection     }
+  #- { key: V,      mods: Control, vi_mode: ToggleBlockSelection    }
+  #- { key: V,      mods: Alt,     vi_mode: ToggleSemanticSelection }
+  #- { key: Return,                vi_mode: Open                    }
+  #- { key: K,                     vi_mode: Up                      }
+  #- { key: J,                     vi_mode: Down                    }
+  #- { key: H,                     vi_mode: Left                    }
+  #- { key: L,                     vi_mode: Right                   }
+  #- { key: Up,                    vi_mode: Up                      }
+  #- { key: Down,                  vi_mode: Down                    }
+  #- { key: Left,                  vi_mode: Left                    }
+  #- { key: Right,                 vi_mode: Right                   }
+  #- { key: Key0,                  vi_mode: First                   }
+  #- { key: Key4,   mods: Shift,   vi_mode: Last                    }
+  #- { key: Key6,   mods: Shift,   vi_mode: FirstOccupied           }
+  #- { key: H,      mods: Shift,   vi_mode: High                    }
+  #- { key: M,      mods: Shift,   vi_mode: Middle                  }
+  #- { key: L,      mods: Shift,   vi_mode: Low                     }
+  #- { key: B,                     vi_mode: SemanticLeft            }
+  #- { key: W,                     vi_mode: SemanticRight           }
+  #- { key: E,                     vi_mode: SemanticRightEnd        }
+  #- { key: B,      mods: Shift,   vi_mode: WordLeft                }
+  #- { key: W,      mods: Shift,   vi_mode: WordRight               }
+  #- { key: E,      mods: Shift,   vi_mode: WordRightEnd            }
+  #- { key: Key5,   mods: Shift,   vi_mode: Bracket                 }
 
   # (Windows, Linux, and BSD only)
   #- { key: V,        mods: Control|Shift, action: Paste            }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -626,7 +626,6 @@
   #- { key: W,      mods: Command,         action: Quit             }
   #- { key: N,      mods: Command,         action: SpawnNewInstance }
   #- { key: F,      mods: Command|Control, action: ToggleFullscreen }
-<<<<<<< HEAD
 
   #- { key: Paste,                    action: Paste                            }
   #- { key: Copy,                     action: Copy                             }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -455,14 +455,15 @@
 #   - ScrollPageUp, ScrollPageDown, ScrollHalfPageUp, ScrollHalfPageDown,
 #     ScrollLineUp, ScrollLineDown, ScrollToTop, ScrollToBottom
 #   - ToggleKeyboardMode, ToggleNormalSelection, ToggleLineSelection,
-#     ToggleBlockSelection, KeyboardMotionClick, KeyboardMotionUp,
-#     KeyboardMotionDown, KeyboardMotionLeft, KeyboardMotionRight,
-#     KeyboardMotionStart, KeyboardMotionEnd, KeyboardMotionHigh,
-#     KeyboardMotionMiddle, KeyboardMotionLow, KeyboardMotionSemanticLeft,
-#     KeyboardMotionSemanticRight, KeyboardMotionSemanticLeftEnd,
-#     KeyboardMotionSemanticRightEnd, KeyboardMotionWordRight,
-#     KeyboardMotionWordLeft, KeyboardMotionWordRightEnd,
-#     KeyboardMotionWordLeftEnd, KeyboardMotionBracket
+#     ToggleBlockSelection, ClearSelection, KeyboardMotionClick,
+#     KeyboardMotionUp, KeyboardMotionDown, KeyboardMotionLeft,
+#     KeyboardMotionRight, KeyboardMotionStart, KeyboardMotionEnd,
+#     KeyboardMotionHigh, KeyboardMotionMiddle, KeyboardMotionLow,
+#     KeyboardMotionSemanticLeft, KeyboardMotionSemanticRight,
+#     KeyboardMotionSemanticLeftEnd, KeyboardMotionSemanticRightEnd,
+#     KeyboardMotionWordRight, KeyboardMotionWordLeft,
+#     KeyboardMotionWordRightEnd, KeyboardMotionWordLeftEnd,
+#     KeyboardMotionBracket
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -455,7 +455,7 @@
 #   - ScrollPageUp, ScrollPageDown, ScrollHalfPageUp, ScrollHalfPageDown,
 #     ScrollLineUp, ScrollLineDown, ScrollToTop, ScrollToBottom
 #   - ToggleKeyboardMode, ToggleNormalSelection, ToggleLineSelection,
-#     ToggleBlockSelection, ClearSelection, KeyboardMotionClick,
+#     ToggleBlockSelection, ClearSelection, KeyboardMotionLaunchUrl,
 #     KeyboardMotionUp, KeyboardMotionDown, KeyboardMotionLeft,
 #     KeyboardMotionRight, KeyboardMotionStart, KeyboardMotionEnd,
 #     KeyboardMotionHigh, KeyboardMotionMiddle, KeyboardMotionLow,

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -187,11 +187,16 @@
 
   # Cursor colors
   #
-  # Colors which should be used to draw the terminal cursors. If these are
+  # Colors which should be used to draw the terminal cursor. If these are
   # unset, the cursor color will be the inverse of the cell color.
   #cursor:
   #  text: '#000000'
   #  cursor: '#ffffff'
+
+  # Keyboard motion cursor colors
+  #
+  # Colors for the cursor when the keyboard motion mode is active.  If these are
+  # unset, the cursor color will be the inverse of the cell color.
   #keyboard_motion_cursor:
   #  text: '#000000'
   #  cursor: '#ffffff'

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -466,6 +466,7 @@
 #   - ToggleFullscreen
 #   - SpawnNewInstance
 #   - ClearLogNotice
+#   - ClearSelection
 #   - ReceiveChar
 #   - None
 #
@@ -474,30 +475,29 @@
 #
 # - `keyboard_motion`: Execute a keyboard motion mode command
 #
-#   - ToggleNormalSelection
-#   - ToggleLineSelection,
-#   - ToggleBlockSelection
-#   - ToggleSemanticSelection
-#   - ClearSelection,
-#   - LaunchUrl
+#   - Open
 #   - Up
-#   - Down,
+#   - Down
 #   - Left
 #   - Right
-#   - Start,
+#   - Start
 #   - End
 #   - High
-#   - Middle,
+#   - Middle
 #   - Low
-#   - SemanticLeft,
+#   - SemanticLeft
 #   - SemanticRight
-#   - SemanticLeftEnd,
+#   - SemanticLeftEnd
 #   - SemanticRightEnd
-#   - WordRight,
+#   - WordRight
 #   - WordLeft
-#   - WordRightEnd,
+#   - WordRightEnd
 #   - WordLeftEnd
 #   - Bracket
+#   - ToggleNormalSelection
+#   - ToggleLineSelection
+#   - ToggleBlockSelection
+#   - ToggleSemanticSelection
 #
 # - `command`: Fork and execute a specified command plus arguments
 #
@@ -569,7 +569,7 @@
   #- { key: V,      mods: Shift,   keyboard_motion: ToggleLineSelection     }
   #- { key: V,      mods: Control, keyboard_motion: ToggleBlockSelection    }
   #- { key: V,      mods: Alt,     keyboard_motion: ToggleSemanticSelection }
-  #- { key: Return,                keyboard_motion: LaunchUrl               }
+  #- { key: Return,                keyboard_motion: Open                    }
   #- { key: K,                     keyboard_motion: Up                      }
   #- { key: J,                     keyboard_motion: Down                    }
   #- { key: H,                     keyboard_motion: Left                    }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -557,8 +557,7 @@
   # Vi Mode
   #- { key: Space,  mods: Shift|Control, mode: Vi, action: ScrollToBottom          }
   #- { key: Space,  mods: Shift|Control,           action: ToggleViMode            }
-  #- { key: Escape,                      mode: Vi, action: ScrollToBottom          }
-  #- { key: Escape,                      mode: Vi, action: ToggleViMode            }
+  #- { key: Escape,                      mode: Vi, action: ClearSelection          }
   #- { key: I,                           mode: Vi, action: ScrollToBottom          }
   #- { key: I,                           mode: Vi, action: ToggleViMode            }
   #- { key: Y,      mods: Control,       mode: Vi, action: ScrollLineUp            }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -510,6 +510,57 @@
 # If the same trigger is assigned to multiple actions, all of them are executed
 # at once.
 #key_bindings:
+  #- { key: Paste,                    action: Paste                            }
+  #- { key: Copy,                     action: Copy                             }
+  #- { key: L,         mods: Control, action: ClearLogNotice                   }
+  #- { key: L,         mods: Control, chars: "\x0c"                            }
+  #- { key: PageUp,    mods: Shift,   action: ScrollPageUp,   mode: ~Alt       }
+  #- { key: PageDown,  mods: Shift,   action: ScrollPageDown, mode: ~Alt       }
+  #- { key: Home,      mods: Shift,   action: ScrollToTop,    mode: ~Alt       }
+  #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt       }
+
+  # Keyboard Motion
+  #- { key: Escape, Control, mode: KeyboardMotion, ScrollToBottom                 }
+  #- { key: Escape, Control                        ToggleKeyboardMode             }
+  #- { key: Escape           mode: KeyboardMotion, ScrollToBottom                 }
+  #- { key: Escape           mode: KeyboardMotion, ToggleKeyboardMode             }
+  #- { key: I                mode: KeyboardMotion, ScrollToBottom                 }
+  #- { key: I                mode: KeyboardMotion, ToggleKeyboardMode             }
+  #- { key: V                mode: KeyboardMotion, ToggleNormalSelection          }
+  #- { key: V,      Shift,   mode: KeyboardMotion, ToggleLineSelection            }
+  #- { key: V,      Control, mode: KeyboardMotion, ToggleBlockSelection           }
+  #- { key: V,      Alt,     mode: KeyboardMotion, ToggleSemanticSelection        }
+  #- { key: Y,      Control, mode: KeyboardMotion, ScrollLineUp                   }
+  #- { key: E,      Control, mode: KeyboardMotion, ScrollLineDown                 }
+  #- { key: G                mode: KeyboardMotion, ScrollToTop                    }
+  #- { key: G,      Shift,   mode: KeyboardMotion, ScrollToBottom                 }
+  #- { key: B,      Control, mode: KeyboardMotion, ScrollPageUp                   }
+  #- { key: F,      Control, mode: KeyboardMotion, ScrollPageDown                 }
+  #- { key: U,      Control, mode: KeyboardMotion, ScrollHalfPageUp               }
+  #- { key: D,      Control, mode: KeyboardMotion, ScrollHalfPageDown             }
+  #- { key: Return           mode: KeyboardMotion, KeyboardMotionLaunchUrl        }
+  #- { key: K                mode: KeyboardMotion, KeyboardMotionUp               }
+  #- { key: J                mode: KeyboardMotion, KeyboardMotionDown             }
+  #- { key: H                mode: KeyboardMotion, KeyboardMotionLeft             }
+  #- { key: L                mode: KeyboardMotion, KeyboardMotionRight            }
+  #- { key: Up               mode: KeyboardMotion, KeyboardMotionUp               }
+  #- { key: Down             mode: KeyboardMotion, KeyboardMotionDown             }
+  #- { key: Left             mode: KeyboardMotion, KeyboardMotionLeft             }
+  #- { key: Right            mode: KeyboardMotion, KeyboardMotionRight            }
+  #- { key: Key0             mode: KeyboardMotion, KeyboardMotionStart            }
+  #- { key: Key4,   Shift,   mode: KeyboardMotion, KeyboardMotionEnd              }
+  #- { key: H,      Shift,   mode: KeyboardMotion, KeyboardMotionHigh             }
+  #- { key: M,      Shift,   mode: KeyboardMotion, KeyboardMotionMiddle           }
+  #- { key: L,      Shift,   mode: KeyboardMotion, KeyboardMotionLow              }
+  #- { key: B                mode: KeyboardMotion, KeyboardMotionSemanticLeft     }
+  #- { key: W                mode: KeyboardMotion, KeyboardMotionSemanticRight    }
+  #- { key: E                mode: KeyboardMotion, KeyboardMotionSemanticRightEnd }
+  #- { key: B,      Shift,   mode: KeyboardMotion, KeyboardMotionWordLeft         }
+  #- { key: W,      Shift,   mode: KeyboardMotion, KeyboardMotionWordRight        }
+  #- { key: E,      Shift,   mode: KeyboardMotion, KeyboardMotionWordRightEnd     }
+  #- { key: Key5,   Shift,   mode: KeyboardMotion, KeyboardMotionBracket          }
+  #- { key: Y                mode: KeyboardMotion, Copy                           }
+
   # (Windows, Linux, and BSD only)
   #- { key: V,        mods: Control|Shift, action: Paste            }
   #- { key: C,        mods: Control|Shift, action: Copy             }
@@ -538,6 +589,7 @@
   #- { key: W,      mods: Command,         action: Quit             }
   #- { key: N,      mods: Command,         action: SpawnNewInstance }
   #- { key: F,      mods: Command|Control, action: ToggleFullscreen }
+<<<<<<< HEAD
 
   #- { key: Paste,                    action: Paste                            }
   #- { key: Copy,                     action: Copy                             }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -192,8 +192,9 @@
   #cursor:
   #  text: '#000000'
   #  cursor: '#ffffff'
-  #  keyboard_motion_text: '#000000'
-  #  keyboard_motion_cursor: '#ffffff'
+  #keyboard_motion_cursor:
+  #  text: '#000000'
+  #  cursor: '#ffffff'
 
   # Selection colors
   #
@@ -455,15 +456,15 @@
 #   - ScrollPageUp, ScrollPageDown, ScrollHalfPageUp, ScrollHalfPageDown,
 #     ScrollLineUp, ScrollLineDown, ScrollToTop, ScrollToBottom
 #   - ToggleKeyboardMode, ToggleNormalSelection, ToggleLineSelection,
-#     ToggleBlockSelection, ClearSelection, KeyboardMotionLaunchUrl,
-#     KeyboardMotionUp, KeyboardMotionDown, KeyboardMotionLeft,
-#     KeyboardMotionRight, KeyboardMotionStart, KeyboardMotionEnd,
-#     KeyboardMotionHigh, KeyboardMotionMiddle, KeyboardMotionLow,
-#     KeyboardMotionSemanticLeft, KeyboardMotionSemanticRight,
-#     KeyboardMotionSemanticLeftEnd, KeyboardMotionSemanticRightEnd,
-#     KeyboardMotionWordRight, KeyboardMotionWordLeft,
-#     KeyboardMotionWordRightEnd, KeyboardMotionWordLeftEnd,
-#     KeyboardMotionBracket
+#     ToggleBlockSelection, ToggleSemanticSelection, ClearSelection,
+#     KeyboardMotionLaunchUrl, KeyboardMotionUp, KeyboardMotionDown,
+#     KeyboardMotionLeft, KeyboardMotionRight, KeyboardMotionStart,
+#     KeyboardMotionEnd, KeyboardMotionHigh, KeyboardMotionMiddle,
+#     KeyboardMotionLow, KeyboardMotionSemanticLeft,
+#     KeyboardMotionSemanticRight, KeyboardMotionSemanticLeftEnd,
+#     KeyboardMotionSemanticRightEnd, KeyboardMotionWordRight,
+#     KeyboardMotionWordLeft, KeyboardMotionWordRightEnd,
+#     KeyboardMotionWordLeftEnd, KeyboardMotionBracket
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -556,8 +556,8 @@
   #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt       }
 
   # Keyboard Motion Mode
-  #- { key: Escape, mods: Control, mode: KeyboardMotion, action: ScrollToBottom     }
-  #- { key: Escape, mods: Control,                       action: ToggleKeyboardMode }
+  #- { key: Space,  mods: Shift|Control, mode: KeyboardMotion, action: ScrollToBottom     }
+  #- { key: Space,  mods: Shift|Control,                       action: ToggleKeyboardMode }
   #- { key: Escape,                mode: KeyboardMotion, action: ScrollToBottom     }
   #- { key: Escape,                mode: KeyboardMotion, action: ToggleKeyboardMode }
   #- { key: I,                     mode: KeyboardMotion, action: ScrollToBottom     }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -195,7 +195,7 @@
 
   # Keyboard motion cursor colors
   #
-  # Colors for the cursor when the keyboard motion mode is active.  If these are
+  # Colors for the cursor when the keyboard motion mode is active. If these are
   # unset, the cursor color will be the inverse of the cell color.
   #keyboard_motion_cursor:
   #  text: '#000000'
@@ -485,8 +485,9 @@
 #   - Down
 #   - Left
 #   - Right
-#   - Start
-#   - End
+#   - First
+#   - Last
+#   - FirstOccupied
 #   - High
 #   - Middle
 #   - Low
@@ -554,7 +555,7 @@
   #- { key: Home,      mods: Shift,   action: ScrollToTop,    mode: ~Alt       }
   #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt       }
 
-  # Keyboard Motion
+  # Keyboard Motion Mode
   #- { key: Escape, mods: Control, mode: KeyboardMotion, action: ScrollToBottom     }
   #- { key: Escape, mods: Control,                       action: ToggleKeyboardMode }
   #- { key: Escape,                mode: KeyboardMotion, action: ScrollToBottom     }
@@ -583,8 +584,9 @@
   #- { key: Down,                  keyboard_motion: Down                    }
   #- { key: Left,                  keyboard_motion: Left                    }
   #- { key: Right,                 keyboard_motion: Right                   }
-  #- { key: Key0,                  keyboard_motion: Start                   }
-  #- { key: Key4,   mods: Shift,   keyboard_motion: End                     }
+  #- { key: Key0,                  keyboard_motion: First                   }
+  #- { key: Key4,   mods: Shift,   keyboard_motion: Last                    }
+  #- { key: Key6,   mods: Shift,   keyboard_motion: FirstOccupied           }
   #- { key: H,      mods: Shift,   keyboard_motion: High                    }
   #- { key: M,      mods: Shift,   keyboard_motion: Middle                  }
   #- { key: L,      mods: Shift,   keyboard_motion: Low                     }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -446,28 +446,58 @@
 #
 # - `action`: Execute a predefined action
 #
+#   - ToggleKeyboardMode
+#   - Copy
+#   - Paste
+#   - PasteSelection
+#   - IncreaseFontSize
+#   - DecreaseFontSize
+#   - ResetFontSize
+#   - ScrollPageUp
+#   - ScrollPageDown
+#   - ScrollLineUp
+#   - ScrollLineDown
+#   - ScrollToTop
+#   - ScrollToBottom
 #   - ClearHistory
-#   - ClearLogNotice
+#   - Hide
+#   - Minimize
+#   - Quit
+#   - ToggleFullscreen
 #   - SpawnNewInstance
-#   - None, ReceiveChar
-#   - Hide, Minimize, Quit, ToggleFullscreen
-#   - Copy, Paste, PasteSelection
-#   - IncreaseFontSize, DecreaseFontSize, ResetFontSize
-#   - ScrollPageUp, ScrollPageDown, ScrollHalfPageUp, ScrollHalfPageDown,
-#     ScrollLineUp, ScrollLineDown, ScrollToTop, ScrollToBottom
-#   - ToggleKeyboardMode, ToggleNormalSelection, ToggleLineSelection,
-#     ToggleBlockSelection, ToggleSemanticSelection, ClearSelection,
-#     KeyboardMotionLaunchUrl, KeyboardMotionUp, KeyboardMotionDown,
-#     KeyboardMotionLeft, KeyboardMotionRight, KeyboardMotionStart,
-#     KeyboardMotionEnd, KeyboardMotionHigh, KeyboardMotionMiddle,
-#     KeyboardMotionLow, KeyboardMotionSemanticLeft,
-#     KeyboardMotionSemanticRight, KeyboardMotionSemanticLeftEnd,
-#     KeyboardMotionSemanticRightEnd, KeyboardMotionWordRight,
-#     KeyboardMotionWordLeft, KeyboardMotionWordRightEnd,
-#     KeyboardMotionWordLeftEnd, KeyboardMotionBracket
+#   - ClearLogNotice
+#   - ReceiveChar
+#   - None
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space
+#
+# - `keyboard_motion`: Execute a keyboard motion mode command
+#
+#   - ToggleNormalSelection
+#   - ToggleLineSelection,
+#   - ToggleBlockSelection
+#   - ToggleSemanticSelection
+#   - ClearSelection,
+#   - LaunchUrl
+#   - Up
+#   - Down,
+#   - Left
+#   - Right
+#   - Start,
+#   - End
+#   - High
+#   - Middle,
+#   - Low
+#   - SemanticLeft,
+#   - SemanticRight
+#   - SemanticLeftEnd,
+#   - SemanticRightEnd
+#   - WordRight,
+#   - WordLeft
+#   - WordRightEnd,
+#   - WordLeftEnd
+#   - Bracket
 #
 # - `command`: Fork and execute a specified command plus arguments
 #
@@ -520,46 +550,46 @@
   #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt       }
 
   # Keyboard Motion
-  #- { key: Escape, Control, mode: KeyboardMotion, ScrollToBottom                 }
-  #- { key: Escape, Control                        ToggleKeyboardMode             }
-  #- { key: Escape           mode: KeyboardMotion, ScrollToBottom                 }
-  #- { key: Escape           mode: KeyboardMotion, ToggleKeyboardMode             }
-  #- { key: I                mode: KeyboardMotion, ScrollToBottom                 }
-  #- { key: I                mode: KeyboardMotion, ToggleKeyboardMode             }
-  #- { key: V                mode: KeyboardMotion, ToggleNormalSelection          }
-  #- { key: V,      Shift,   mode: KeyboardMotion, ToggleLineSelection            }
-  #- { key: V,      Control, mode: KeyboardMotion, ToggleBlockSelection           }
-  #- { key: V,      Alt,     mode: KeyboardMotion, ToggleSemanticSelection        }
-  #- { key: Y,      Control, mode: KeyboardMotion, ScrollLineUp                   }
-  #- { key: E,      Control, mode: KeyboardMotion, ScrollLineDown                 }
-  #- { key: G                mode: KeyboardMotion, ScrollToTop                    }
-  #- { key: G,      Shift,   mode: KeyboardMotion, ScrollToBottom                 }
-  #- { key: B,      Control, mode: KeyboardMotion, ScrollPageUp                   }
-  #- { key: F,      Control, mode: KeyboardMotion, ScrollPageDown                 }
-  #- { key: U,      Control, mode: KeyboardMotion, ScrollHalfPageUp               }
-  #- { key: D,      Control, mode: KeyboardMotion, ScrollHalfPageDown             }
-  #- { key: Return           mode: KeyboardMotion, KeyboardMotionLaunchUrl        }
-  #- { key: K                mode: KeyboardMotion, KeyboardMotionUp               }
-  #- { key: J                mode: KeyboardMotion, KeyboardMotionDown             }
-  #- { key: H                mode: KeyboardMotion, KeyboardMotionLeft             }
-  #- { key: L                mode: KeyboardMotion, KeyboardMotionRight            }
-  #- { key: Up               mode: KeyboardMotion, KeyboardMotionUp               }
-  #- { key: Down             mode: KeyboardMotion, KeyboardMotionDown             }
-  #- { key: Left             mode: KeyboardMotion, KeyboardMotionLeft             }
-  #- { key: Right            mode: KeyboardMotion, KeyboardMotionRight            }
-  #- { key: Key0             mode: KeyboardMotion, KeyboardMotionStart            }
-  #- { key: Key4,   Shift,   mode: KeyboardMotion, KeyboardMotionEnd              }
-  #- { key: H,      Shift,   mode: KeyboardMotion, KeyboardMotionHigh             }
-  #- { key: M,      Shift,   mode: KeyboardMotion, KeyboardMotionMiddle           }
-  #- { key: L,      Shift,   mode: KeyboardMotion, KeyboardMotionLow              }
-  #- { key: B                mode: KeyboardMotion, KeyboardMotionSemanticLeft     }
-  #- { key: W                mode: KeyboardMotion, KeyboardMotionSemanticRight    }
-  #- { key: E                mode: KeyboardMotion, KeyboardMotionSemanticRightEnd }
-  #- { key: B,      Shift,   mode: KeyboardMotion, KeyboardMotionWordLeft         }
-  #- { key: W,      Shift,   mode: KeyboardMotion, KeyboardMotionWordRight        }
-  #- { key: E,      Shift,   mode: KeyboardMotion, KeyboardMotionWordRightEnd     }
-  #- { key: Key5,   Shift,   mode: KeyboardMotion, KeyboardMotionBracket          }
-  #- { key: Y                mode: KeyboardMotion, Copy                           }
+  #- { key: Escape, mods: Control, mode: KeyboardMotion, action: ScrollToBottom     }
+  #- { key: Escape, mods: Control,                       action: ToggleKeyboardMode }
+  #- { key: Escape,                mode: KeyboardMotion, action: ScrollToBottom     }
+  #- { key: Escape,                mode: KeyboardMotion, action: ToggleKeyboardMode }
+  #- { key: I,                     mode: KeyboardMotion, action: ScrollToBottom     }
+  #- { key: I,                     mode: KeyboardMotion, action: ToggleKeyboardMode }
+  #- { key: Y,      mods: Control, mode: KeyboardMotion, action: ScrollLineUp       }
+  #- { key: E,      mods: Control, mode: KeyboardMotion, action: ScrollLineDown     }
+  #- { key: G,                     mode: KeyboardMotion, action: ScrollToTop        }
+  #- { key: G,      mods: Shift,   mode: KeyboardMotion, action: ScrollToBottom     }
+  #- { key: B,      mods: Control, mode: KeyboardMotion, action: ScrollPageUp       }
+  #- { key: F,      mods: Control, mode: KeyboardMotion, action: ScrollPageDown     }
+  #- { key: U,      mods: Control, mode: KeyboardMotion, action: ScrollHalfPageUp   }
+  #- { key: D,      mods: Control, mode: KeyboardMotion, action: ScrollHalfPageDown }
+  #- { key: Y,                     mode: KeyboardMotion, action: Copy               }
+  #- { key: V,                     keyboard_motion: ToggleNormalSelection   }
+  #- { key: V,      mods: Shift,   keyboard_motion: ToggleLineSelection     }
+  #- { key: V,      mods: Control, keyboard_motion: ToggleBlockSelection    }
+  #- { key: V,      mods: Alt,     keyboard_motion: ToggleSemanticSelection }
+  #- { key: Return,                keyboard_motion: LaunchUrl               }
+  #- { key: K,                     keyboard_motion: Up                      }
+  #- { key: J,                     keyboard_motion: Down                    }
+  #- { key: H,                     keyboard_motion: Left                    }
+  #- { key: L,                     keyboard_motion: Right                   }
+  #- { key: Up,                    keyboard_motion: Up                      }
+  #- { key: Down,                  keyboard_motion: Down                    }
+  #- { key: Left,                  keyboard_motion: Left                    }
+  #- { key: Right,                 keyboard_motion: Right                   }
+  #- { key: Key0,                  keyboard_motion: Start                   }
+  #- { key: Key4,   mods: Shift,   keyboard_motion: End                     }
+  #- { key: H,      mods: Shift,   keyboard_motion: High                    }
+  #- { key: M,      mods: Shift,   keyboard_motion: Middle                  }
+  #- { key: L,      mods: Shift,   keyboard_motion: Low                     }
+  #- { key: B,                     keyboard_motion: SemanticLeft            }
+  #- { key: W,                     keyboard_motion: SemanticRight           }
+  #- { key: E,                     keyboard_motion: SemanticRightEnd        }
+  #- { key: B,      mods: Shift,   keyboard_motion: WordLeft                }
+  #- { key: W,      mods: Shift,   keyboard_motion: WordRight               }
+  #- { key: E,      mods: Shift,   keyboard_motion: WordRightEnd            }
+  #- { key: Key5,   mods: Shift,   keyboard_motion: Bracket                 }
 
   # (Windows, Linux, and BSD only)
   #- { key: V,        mods: Control|Shift, action: Paste            }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -475,11 +475,7 @@
 #   - ReceiveChar
 #   - None
 #
-#   (macOS only):
-#   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space
-#
-# - `vi_mode`: Execute a vi mode command
-#
+#   (`mode: Vi` only):
 #   - Open
 #   - Up
 #   - Down
@@ -504,6 +500,9 @@
 #   - ToggleLineSelection
 #   - ToggleBlockSelection
 #   - ToggleSemanticSelection
+#
+#   (macOS only):
+#   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space
 #
 # - `command`: Fork and execute a specified command plus arguments
 #
@@ -546,57 +545,57 @@
 # If the same trigger is assigned to multiple actions, all of them are executed
 # at once.
 #key_bindings:
-  #- { key: Paste,                    action: Paste                            }
-  #- { key: Copy,                     action: Copy                             }
-  #- { key: L,         mods: Control, action: ClearLogNotice                   }
-  #- { key: L,         mods: Control, chars: "\x0c"                            }
-  #- { key: PageUp,    mods: Shift,   action: ScrollPageUp,   mode: ~Alt       }
-  #- { key: PageDown,  mods: Shift,   action: ScrollPageDown, mode: ~Alt       }
-  #- { key: Home,      mods: Shift,   action: ScrollToTop,    mode: ~Alt       }
-  #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt       }
+  #- { key: Paste,                    action: Paste                      }
+  #- { key: Copy,                     action: Copy                       }
+  #- { key: L,         mods: Control, action: ClearLogNotice             }
+  #- { key: L,         mods: Control, chars: "\x0c"                      }
+  #- { key: PageUp,    mods: Shift,   action: ScrollPageUp,   mode: ~Alt }
+  #- { key: PageDown,  mods: Shift,   action: ScrollPageDown, mode: ~Alt }
+  #- { key: Home,      mods: Shift,   action: ScrollToTop,    mode: ~Alt }
+  #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt }
 
   # Vi Mode
-  #- { key: Space,  mods: Shift|Control, mode: ViMode, action: ScrollToBottom     }
-  #- { key: Space,  mods: Shift|Control,               action: ToggleViMode       }
-  #- { key: Escape,                      mode: ViMode, action: ScrollToBottom     }
-  #- { key: Escape,                      mode: ViMode, action: ToggleViMode       }
-  #- { key: I,                           mode: ViMode, action: ScrollToBottom     }
-  #- { key: I,                           mode: ViMode, action: ToggleViMode       }
-  #- { key: Y,      mods: Control,       mode: ViMode, action: ScrollLineUp       }
-  #- { key: E,      mods: Control,       mode: ViMode, action: ScrollLineDown     }
-  #- { key: G,                           mode: ViMode, action: ScrollToTop        }
-  #- { key: G,      mods: Shift,         mode: ViMode, action: ScrollToBottom     }
-  #- { key: B,      mods: Control,       mode: ViMode, action: ScrollPageUp       }
-  #- { key: F,      mods: Control,       mode: ViMode, action: ScrollPageDown     }
-  #- { key: U,      mods: Control,       mode: ViMode, action: ScrollHalfPageUp   }
-  #- { key: D,      mods: Control,       mode: ViMode, action: ScrollHalfPageDown }
-  #- { key: Y,                           mode: ViMode, action: Copy               }
-  #- { key: V,                     vi_mode: ToggleNormalSelection   }
-  #- { key: V,      mods: Shift,   vi_mode: ToggleLineSelection     }
-  #- { key: V,      mods: Control, vi_mode: ToggleBlockSelection    }
-  #- { key: V,      mods: Alt,     vi_mode: ToggleSemanticSelection }
-  #- { key: Return,                vi_mode: Open                    }
-  #- { key: K,                     vi_mode: Up                      }
-  #- { key: J,                     vi_mode: Down                    }
-  #- { key: H,                     vi_mode: Left                    }
-  #- { key: L,                     vi_mode: Right                   }
-  #- { key: Up,                    vi_mode: Up                      }
-  #- { key: Down,                  vi_mode: Down                    }
-  #- { key: Left,                  vi_mode: Left                    }
-  #- { key: Right,                 vi_mode: Right                   }
-  #- { key: Key0,                  vi_mode: First                   }
-  #- { key: Key4,   mods: Shift,   vi_mode: Last                    }
-  #- { key: Key6,   mods: Shift,   vi_mode: FirstOccupied           }
-  #- { key: H,      mods: Shift,   vi_mode: High                    }
-  #- { key: M,      mods: Shift,   vi_mode: Middle                  }
-  #- { key: L,      mods: Shift,   vi_mode: Low                     }
-  #- { key: B,                     vi_mode: SemanticLeft            }
-  #- { key: W,                     vi_mode: SemanticRight           }
-  #- { key: E,                     vi_mode: SemanticRightEnd        }
-  #- { key: B,      mods: Shift,   vi_mode: WordLeft                }
-  #- { key: W,      mods: Shift,   vi_mode: WordRight               }
-  #- { key: E,      mods: Shift,   vi_mode: WordRightEnd            }
-  #- { key: Key5,   mods: Shift,   vi_mode: Bracket                 }
+  #- { key: Space,  mods: Shift|Control, mode: Vi, action: ScrollToBottom          }
+  #- { key: Space,  mods: Shift|Control,           action: ToggleViMode            }
+  #- { key: Escape,                      mode: Vi, action: ScrollToBottom          }
+  #- { key: Escape,                      mode: Vi, action: ToggleViMode            }
+  #- { key: I,                           mode: Vi, action: ScrollToBottom          }
+  #- { key: I,                           mode: Vi, action: ToggleViMode            }
+  #- { key: Y,      mods: Control,       mode: Vi, action: ScrollLineUp            }
+  #- { key: E,      mods: Control,       mode: Vi, action: ScrollLineDown          }
+  #- { key: G,                           mode: Vi, action: ScrollToTop             }
+  #- { key: G,      mods: Shift,         mode: Vi, action: ScrollToBottom          }
+  #- { key: B,      mods: Control,       mode: Vi, action: ScrollPageUp            }
+  #- { key: F,      mods: Control,       mode: Vi, action: ScrollPageDown          }
+  #- { key: U,      mods: Control,       mode: Vi, action: ScrollHalfPageUp        }
+  #- { key: D,      mods: Control,       mode: Vi, action: ScrollHalfPageDown      }
+  #- { key: Y,                           mode: Vi, action: Copy                    }
+  #- { key: V,                           mode: Vi, action: ToggleNormalSelection   }
+  #- { key: V,      mods: Shift,         mode: Vi, action: ToggleLineSelection     }
+  #- { key: V,      mods: Control,       mode: Vi, action: ToggleBlockSelection    }
+  #- { key: V,      mods: Alt,           mode: Vi, action: ToggleSemanticSelection }
+  #- { key: Return,                      mode: Vi, action: Open                    }
+  #- { key: K,                           mode: Vi, action: Up                      }
+  #- { key: J,                           mode: Vi, action: Down                    }
+  #- { key: H,                           mode: Vi, action: Left                    }
+  #- { key: L,                           mode: Vi, action: Right                   }
+  #- { key: Up,                          mode: Vi, action: Up                      }
+  #- { key: Down,                        mode: Vi, action: Down                    }
+  #- { key: Left,                        mode: Vi, action: Left                    }
+  #- { key: Right,                       mode: Vi, action: Right                   }
+  #- { key: Key0,                        mode: Vi, action: First                   }
+  #- { key: Key4,   mods: Shift,         mode: Vi, action: Last                    }
+  #- { key: Key6,   mods: Shift,         mode: Vi, action: FirstOccupied           }
+  #- { key: H,      mods: Shift,         mode: Vi, action: High                    }
+  #- { key: M,      mods: Shift,         mode: Vi, action: Middle                  }
+  #- { key: L,      mods: Shift,         mode: Vi, action: Low                     }
+  #- { key: B,                           mode: Vi, action: SemanticLeft            }
+  #- { key: W,                           mode: Vi, action: SemanticRight           }
+  #- { key: E,                           mode: Vi, action: SemanticRightEnd        }
+  #- { key: B,      mods: Shift,         mode: Vi, action: WordLeft                }
+  #- { key: W,      mods: Shift,         mode: Vi, action: WordRight               }
+  #- { key: E,      mods: Shift,         mode: Vi, action: WordRightEnd            }
+  #- { key: Key5,   mods: Shift,         mode: Vi, action: Bracket                 }
 
   # (Windows, Linux, and BSD only)
   #- { key: V,        mods: Control|Shift, action: Paste            }
@@ -627,14 +626,14 @@
   #- { key: N,      mods: Command,         action: SpawnNewInstance }
   #- { key: F,      mods: Command|Control, action: ToggleFullscreen }
 
-  #- { key: Paste,                    action: Paste                            }
-  #- { key: Copy,                     action: Copy                             }
-  #- { key: L,         mods: Control, action: ClearLogNotice                   }
-  #- { key: L,         mods: Control, chars: "\x0c"                            }
-  #- { key: PageUp,    mods: Shift,   action: ScrollPageUp,   mode: ~Alt       }
-  #- { key: PageDown,  mods: Shift,   action: ScrollPageDown, mode: ~Alt       }
-  #- { key: Home,      mods: Shift,   action: ScrollToTop,    mode: ~Alt       }
-  #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt       }
+  #- { key: Paste,                    action: Paste                      }
+  #- { key: Copy,                     action: Copy                       }
+  #- { key: L,         mods: Control, action: ClearLogNotice             }
+  #- { key: L,         mods: Control, chars: "\x0c"                      }
+  #- { key: PageUp,    mods: Shift,   action: ScrollPageUp,   mode: ~Alt }
+  #- { key: PageDown,  mods: Shift,   action: ScrollPageDown, mode: ~Alt }
+  #- { key: Home,      mods: Shift,   action: ScrollToTop,    mode: ~Alt }
+  #- { key: End,       mods: Shift,   action: ScrollToBottom, mode: ~Alt }
 
 #debug:
   # Display the time it takes to redraw each frame.

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -206,8 +206,8 @@ pub enum Action {
     /// Clear active selection.
     ClearSelection,
 
-    /// Click at current keyboard motion cursor.
-    KeyboardMotionClick,
+    /// Launch the URL below the keyboard motion cursor.
+    KeyboardMotionLaunchUrl,
 
     /// Move keyboard motion cursor up.
     KeyboardMotionUp,
@@ -415,7 +415,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         F,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollPageDown;
         U,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollHalfPageUp;
         D,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollHalfPageDown;
-        Return,                        +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionClick;
+        Return,                        +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionLaunchUrl;
         K,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionUp;
         J,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionDown;
         H,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionLeft;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -203,6 +203,9 @@ pub enum Action {
     /// Toggle block keyboard selection.
     ToggleBlockSelection,
 
+    /// Toggle semantic keyboard selection.
+    ToggleSemanticSelection,
+
     /// Clear active selection.
     ClearSelection,
 
@@ -407,6 +410,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         V,                             +TermMode::KEYBOARD_MOTION; Action::ToggleNormalSelection;
         V,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::ToggleLineSelection;
         V,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ToggleBlockSelection;
+        V,      ModifiersState::ALT,   +TermMode::KEYBOARD_MOTION; Action::ToggleSemanticSelection;
         Y,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollLineUp;
         E,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollLineDown;
         G,                             +TermMode::KEYBOARD_MOTION; Action::ScrollToTop;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -407,6 +407,8 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         V,                             +TermMode::KEYBOARD_MOTION; Action::ToggleNormalSelection;
         V,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::ToggleLineSelection;
         V,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ToggleBlockSelection;
+        Y,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollLineUp;
+        E,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollLineDown;
         G,                             +TermMode::KEYBOARD_MOTION; Action::ScrollToTop;
         G,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;
         B,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollPageUp;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -234,7 +234,7 @@ impl<'a> Deserialize<'a> for KeyboardMotionWrapper {
                 // Manually append all `KeyboardMotionAction` options
                 let error_message = error.to_string()
                     + ", `ToggleNormalSelection`, `ToggleLineSelection`, `ToggleBlockSelection`, \
-                       `ToggleSemanticSelection`, `LaunchUrl`";
+                       `ToggleSemanticSelection`, `Open`";
                 Err(D::Error::custom(error_message))
             },
         }
@@ -262,7 +262,7 @@ pub enum KeyboardMotionAction {
     /// Toggle semantic keyboard selection.
     ToggleSemanticSelection,
     /// Launch the URL below the keyboard motion cursor.
-    LaunchUrl,
+    Open,
 }
 
 impl From<KeyboardMotionAction> for Action {
@@ -427,7 +427,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         V, ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; KeyboardMotionAction::ToggleLineSelection;
         V, ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; KeyboardMotionAction::ToggleBlockSelection;
         V, ModifiersState::ALT,   +TermMode::KEYBOARD_MOTION; KeyboardMotionAction::ToggleSemanticSelection;
-        Return,                   +TermMode::KEYBOARD_MOTION; KeyboardMotionAction::LaunchUrl;
+        Return,                   +TermMode::KEYBOARD_MOTION; KeyboardMotionAction::Open;
         K,                             +TermMode::KEYBOARD_MOTION; KeyboardMotion::Up;
         J,                             +TermMode::KEYBOARD_MOTION; KeyboardMotion::Down;
         H,                             +TermMode::KEYBOARD_MOTION; KeyboardMotion::Left;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -436,8 +436,9 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         Down,                          +TermMode::KEYBOARD_MOTION; KeyboardMotion::Down;
         Left,                          +TermMode::KEYBOARD_MOTION; KeyboardMotion::Left;
         Right,                         +TermMode::KEYBOARD_MOTION; KeyboardMotion::Right;
-        Key0,                          +TermMode::KEYBOARD_MOTION; KeyboardMotion::Start;
-        Key4,   ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; KeyboardMotion::End;
+        Key0,                          +TermMode::KEYBOARD_MOTION; KeyboardMotion::First;
+        Key4,   ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; KeyboardMotion::Last;
+        Key6,   ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; KeyboardMotion::FirstOccupied;
         H,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; KeyboardMotion::High;
         M,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; KeyboardMotion::Middle;
         L,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; KeyboardMotion::Low;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -408,8 +408,10 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         F19,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[33~".into());
         F20,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[34~".into());
         NumpadEnter, ~TermMode::KEYBOARD_MOTION; Action::Esc("\n".into());
-        Escape, ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;
-        Escape, ModifiersState::CTRL;                              Action::ToggleKeyboardMode;
+        Space,  ModifiersState::SHIFT | ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION;
+            Action::ScrollToBottom;
+        Space,  ModifiersState::SHIFT | ModifiersState::CTRL;
+            Action::ToggleKeyboardMode;
         Escape,                        +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;
         Escape,                        +TermMode::KEYBOARD_MOTION; Action::ToggleKeyboardMode;
         I,                             +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -203,6 +203,9 @@ pub enum Action {
     /// Toggle block keyboard selection.
     ToggleBlockSelection,
 
+    /// Clear active selection.
+    ClearSelection,
+
     /// Click at current keyboard motion cursor.
     KeyboardMotionClick,
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -349,15 +349,15 @@ macro_rules! bindings {
 pub fn default_mouse_bindings() -> Vec<MouseBinding> {
     bindings!(
         MouseBinding;
-        MouseButton::Middle; Action::PasteSelection;
+        MouseButton::Middle, ~TermMode::KEYBOARD_MOTION; Action::PasteSelection;
     )
 }
 
 pub fn default_key_bindings() -> Vec<KeyBinding> {
     let mut bindings = bindings!(
         KeyBinding;
-        Paste; Action::Paste;
         Copy;  Action::Copy;
+        Paste, ~TermMode::KEYBOARD_MOTION; Action::Paste;
         L, ModifiersState::CTRL; Action::ClearLogNotice;
         L,        ModifiersState::CTRL,  ~TermMode::KEYBOARD_MOTION; Action::Esc("\x0c".into());
         Tab,      ModifiersState::SHIFT, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[Z".into());
@@ -527,9 +527,9 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
 fn common_keybindings() -> Vec<KeyBinding> {
     bindings!(
         KeyBinding;
-        V,        ModifiersState::CTRL | ModifiersState::SHIFT; Action::Paste;
+        V,        ModifiersState::CTRL | ModifiersState::SHIFT, ~TermMode::KEYBOARD_MOTION; Action::Paste;
         C,        ModifiersState::CTRL | ModifiersState::SHIFT; Action::Copy;
-        Insert,   ModifiersState::SHIFT; Action::PasteSelection;
+        Insert,   ModifiersState::SHIFT, ~TermMode::KEYBOARD_MOTION; Action::PasteSelection;
         Key0,     ModifiersState::CTRL;  Action::ResetFontSize;
         Equals,   ModifiersState::CTRL;  Action::IncreaseFontSize;
         Add,      ModifiersState::CTRL;  Action::IncreaseFontSize;
@@ -563,10 +563,10 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         Minus,  ModifiersState::LOGO;  Action::DecreaseFontSize;
         Insert, ModifiersState::SHIFT, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[2;2~".into());
         K, ModifiersState::LOGO, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x0c".into());
+        V, ModifiersState::LOGO, ~TermMode::KEYBOARD_MOTION; Action::Paste;
         N, ModifiersState::LOGO; Action::SpawnNewInstance;
         F, ModifiersState::CTRL | ModifiersState::LOGO; Action::ToggleFullscreen;
         K, ModifiersState::LOGO; Action::ClearHistory;
-        V, ModifiersState::LOGO; Action::Paste;
         C, ModifiersState::LOGO; Action::Copy;
         H, ModifiersState::LOGO; Action::Hide;
         M, ModifiersState::LOGO; Action::Minimize;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -141,6 +141,12 @@ pub enum Action {
     /// Scroll exactly one page down.
     ScrollPageDown,
 
+    /// Scroll half a page up.
+    ScrollHalfPageUp,
+
+    /// Scroll half a page down.
+    ScrollHalfPageDown,
+
     /// Scroll one line up.
     ScrollLineUp,
 
@@ -184,6 +190,75 @@ pub enum Action {
 
     /// Allow receiving char input.
     ReceiveChar,
+
+    /// Toggle keyboard motion mode.
+    ToggleKeyboardMode,
+
+    /// Toggle normal keyboard selection.
+    ToggleNormalSelection,
+
+    /// Toggle line keyboard selection.
+    ToggleLineSelection,
+
+    /// Toggle block keyboard selection.
+    ToggleBlockSelection,
+
+    /// Click at current keyboard motion cursor.
+    KeyboardMotionClick,
+
+    /// Move keyboard motion cursor up.
+    KeyboardMotionUp,
+
+    /// Move keyboard motion cursor down.
+    KeyboardMotionDown,
+
+    /// Move keyboard motion cursor left.
+    KeyboardMotionLeft,
+
+    /// Move keyboard motion cursor right.
+    KeyboardMotionRight,
+
+    /// Move keyboard motion cursor to start of line.
+    KeyboardMotionStart,
+
+    /// Move keyboard motion cursor to end of line.
+    KeyboardMotionEnd,
+
+    /// Move keyboard motion cursor to top of screen.
+    KeyboardMotionHigh,
+
+    /// Move keyboard motion cursor to center of screen.
+    KeyboardMotionMiddle,
+
+    /// Move keyboard motion cursor to bottom of screen.
+    KeyboardMotionLow,
+
+    /// Move keyboard motion cursor to start of semantically separated word.
+    KeyboardMotionSemanticLeft,
+
+    /// Move keyboard motion cursor to start of next semantically separated word.
+    KeyboardMotionSemanticRight,
+
+    /// Move keyboard motion cursor to end of previous semantically separated word.
+    KeyboardMotionSemanticLeftEnd,
+
+    /// Move keyboard motion cursor to end of semantically separated word.
+    KeyboardMotionSemanticRightEnd,
+
+    /// Move keyboard motion cursor to start of whitespace separated word.
+    KeyboardMotionWordRight,
+
+    /// Move keyboard motion cursor to start of next whitespace separated word.
+    KeyboardMotionWordLeft,
+
+    /// Move keyboard motion cursor to end of previous whitespace separated word.
+    KeyboardMotionWordRightEnd,
+
+    /// Move keyboard motion cursor to end of whitespace separated word.
+    KeyboardMotionWordLeftEnd,
+
+    /// Move keyboard motion cursor to opposing bracket.
+    KeyboardMotionBracket,
 
     /// No action.
     None,
@@ -241,9 +316,9 @@ macro_rules! bindings {
             let mut _mods = ModifiersState::empty();
             $(_mods = $mods;)*
             let mut _mode = TermMode::empty();
-            $(_mode = $mode;)*
+            $(_mode.insert($mode);)*
             let mut _notmode = TermMode::empty();
-            $(_notmode = $notmode;)*
+            $(_notmode.insert($notmode);)*
 
             v.push($ty {
                 trigger: $key,
@@ -271,55 +346,92 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         Paste; Action::Paste;
         Copy;  Action::Copy;
         L, ModifiersState::CTRL; Action::ClearLogNotice;
-        L, ModifiersState::CTRL; Action::Esc("\x0c".into());
-        PageUp,   ModifiersState::SHIFT, ~TermMode::ALT_SCREEN; Action::ScrollPageUp;
-        PageDown, ModifiersState::SHIFT, ~TermMode::ALT_SCREEN; Action::ScrollPageDown;
-        Home,     ModifiersState::SHIFT, ~TermMode::ALT_SCREEN; Action::ScrollToTop;
-        End,      ModifiersState::SHIFT, ~TermMode::ALT_SCREEN; Action::ScrollToBottom;
-        Home, +TermMode::APP_CURSOR; Action::Esc("\x1bOH".into());
-        Home, ~TermMode::APP_CURSOR; Action::Esc("\x1b[H".into());
-        Home, ModifiersState::SHIFT, +TermMode::ALT_SCREEN; Action::Esc("\x1b[1;2H".into());
-        End,  +TermMode::APP_CURSOR; Action::Esc("\x1bOF".into());
-        End,  ~TermMode::APP_CURSOR; Action::Esc("\x1b[F".into());
-        End,  ModifiersState::SHIFT, +TermMode::ALT_SCREEN; Action::Esc("\x1b[1;2F".into());
-        PageUp;   Action::Esc("\x1b[5~".into());
-        PageUp,   ModifiersState::SHIFT, +TermMode::ALT_SCREEN; Action::Esc("\x1b[5;2~".into());
-        PageDown; Action::Esc("\x1b[6~".into());
-        PageDown, ModifiersState::SHIFT, +TermMode::ALT_SCREEN; Action::Esc("\x1b[6;2~".into());
-        Tab,  ModifiersState::SHIFT; Action::Esc("\x1b[Z".into());
-        Back; Action::Esc("\x7f".into());
-        Back, ModifiersState::ALT; Action::Esc("\x1b\x7f".into());
-        Insert; Action::Esc("\x1b[2~".into());
-        Delete; Action::Esc("\x1b[3~".into());
-        Up,    +TermMode::APP_CURSOR; Action::Esc("\x1bOA".into());
-        Up,    ~TermMode::APP_CURSOR; Action::Esc("\x1b[A".into());
-        Down,  +TermMode::APP_CURSOR; Action::Esc("\x1bOB".into());
-        Down,  ~TermMode::APP_CURSOR; Action::Esc("\x1b[B".into());
-        Right, +TermMode::APP_CURSOR; Action::Esc("\x1bOC".into());
-        Right, ~TermMode::APP_CURSOR; Action::Esc("\x1b[C".into());
-        Left,  +TermMode::APP_CURSOR; Action::Esc("\x1bOD".into());
-        Left,  ~TermMode::APP_CURSOR; Action::Esc("\x1b[D".into());
-        F1;  Action::Esc("\x1bOP".into());
-        F2;  Action::Esc("\x1bOQ".into());
-        F3;  Action::Esc("\x1bOR".into());
-        F4;  Action::Esc("\x1bOS".into());
-        F5;  Action::Esc("\x1b[15~".into());
-        F6;  Action::Esc("\x1b[17~".into());
-        F7;  Action::Esc("\x1b[18~".into());
-        F8;  Action::Esc("\x1b[19~".into());
-        F9;  Action::Esc("\x1b[20~".into());
-        F10; Action::Esc("\x1b[21~".into());
-        F11; Action::Esc("\x1b[23~".into());
-        F12; Action::Esc("\x1b[24~".into());
-        F13; Action::Esc("\x1b[25~".into());
-        F14; Action::Esc("\x1b[26~".into());
-        F15; Action::Esc("\x1b[28~".into());
-        F16; Action::Esc("\x1b[29~".into());
-        F17; Action::Esc("\x1b[31~".into());
-        F18; Action::Esc("\x1b[32~".into());
-        F19; Action::Esc("\x1b[33~".into());
-        F20; Action::Esc("\x1b[34~".into());
-        NumpadEnter; Action::Esc("\n".into());
+        L,        ModifiersState::CTRL,  ~TermMode::KEYBOARD_MOTION; Action::Esc("\x0c".into());
+        Tab,      ModifiersState::SHIFT, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[Z".into());
+        Back,     ModifiersState::ALT,   ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b\x7f".into());
+        Home,     ModifiersState::SHIFT, ~TermMode::ALT_SCREEN;      Action::ScrollToTop;
+        End,      ModifiersState::SHIFT, ~TermMode::ALT_SCREEN;      Action::ScrollToBottom;
+        PageUp,   ModifiersState::SHIFT, ~TermMode::ALT_SCREEN;      Action::ScrollPageUp;
+        PageDown, ModifiersState::SHIFT, ~TermMode::ALT_SCREEN;      Action::ScrollPageDown;
+        Home,     ModifiersState::SHIFT, +TermMode::ALT_SCREEN, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[1;2H".into());
+        End,      ModifiersState::SHIFT, +TermMode::ALT_SCREEN, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[1;2F".into());
+        PageUp,   ModifiersState::SHIFT, +TermMode::ALT_SCREEN, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[5;2~".into());
+        PageDown, ModifiersState::SHIFT, +TermMode::ALT_SCREEN, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[6;2~".into());
+        Home,  +TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOH".into());
+        Home,  ~TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[H".into());
+        End,   +TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOF".into());
+        End,   ~TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[F".into());
+        Up,    +TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOA".into());
+        Up,    ~TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[A".into());
+        Down,  +TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOB".into());
+        Down,  ~TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[B".into());
+        Right, +TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOC".into());
+        Right, ~TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[C".into());
+        Left,  +TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOD".into());
+        Left,  ~TermMode::APP_CURSOR, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[D".into());
+        Back,        ~TermMode::KEYBOARD_MOTION; Action::Esc("\x7f".into());
+        Insert,      ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[2~".into());
+        Delete,      ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[3~".into());
+        PageUp,      ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[5~".into());
+        PageDown,    ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[6~".into());
+        F1,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOP".into());
+        F2,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOQ".into());
+        F3,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOR".into());
+        F4,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1bOS".into());
+        F5,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[15~".into());
+        F6,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[17~".into());
+        F7,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[18~".into());
+        F8,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[19~".into());
+        F9,          ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[20~".into());
+        F10,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[21~".into());
+        F11,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[23~".into());
+        F12,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[24~".into());
+        F13,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[25~".into());
+        F14,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[26~".into());
+        F15,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[28~".into());
+        F16,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[29~".into());
+        F17,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[31~".into());
+        F18,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[32~".into());
+        F19,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[33~".into());
+        F20,         ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[34~".into());
+        NumpadEnter, ~TermMode::KEYBOARD_MOTION; Action::Esc("\n".into());
+        Escape, ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;
+        Escape, ModifiersState::CTRL;                              Action::ToggleKeyboardMode;
+        Escape,                        +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;
+        Escape,                        +TermMode::KEYBOARD_MOTION; Action::ToggleKeyboardMode;
+        I,                             +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;
+        I,                             +TermMode::KEYBOARD_MOTION; Action::ToggleKeyboardMode;
+        V,                             +TermMode::KEYBOARD_MOTION; Action::ToggleNormalSelection;
+        V,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::ToggleLineSelection;
+        V,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ToggleBlockSelection;
+        G,                             +TermMode::KEYBOARD_MOTION; Action::ScrollToTop;
+        G,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::ScrollToBottom;
+        B,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollPageUp;
+        F,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollPageDown;
+        U,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollHalfPageUp;
+        D,      ModifiersState::CTRL,  +TermMode::KEYBOARD_MOTION; Action::ScrollHalfPageDown;
+        Return,                        +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionClick;
+        K,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionUp;
+        J,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionDown;
+        H,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionLeft;
+        L,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionRight;
+        Up,                            +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionUp;
+        Down,                          +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionDown;
+        Left,                          +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionLeft;
+        Right,                         +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionRight;
+        Key0,                          +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionStart;
+        Key4,   ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionEnd;
+        H,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionHigh;
+        M,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionMiddle;
+        L,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionLow;
+        B,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionSemanticLeft;
+        W,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionSemanticRight;
+        E,                             +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionSemanticRightEnd;
+        B,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionWordLeft;
+        W,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionWordRight;
+        E,      ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionWordRightEnd;
+        Key5,   ModifiersState::SHIFT, +TermMode::KEYBOARD_MOTION; Action::KeyboardMotionBracket;
+        Y,                             +TermMode::KEYBOARD_MOTION; Action::Copy;
     );
 
     //   Code     Modifiers
@@ -348,31 +460,31 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         let modifiers_code = index + 2;
         bindings.extend(bindings!(
             KeyBinding;
-            Delete, mods; Action::Esc(format!("\x1b[3;{}~", modifiers_code));
-            Up,     mods; Action::Esc(format!("\x1b[1;{}A", modifiers_code));
-            Down,   mods; Action::Esc(format!("\x1b[1;{}B", modifiers_code));
-            Right,  mods; Action::Esc(format!("\x1b[1;{}C", modifiers_code));
-            Left,   mods; Action::Esc(format!("\x1b[1;{}D", modifiers_code));
-            F1,     mods; Action::Esc(format!("\x1b[1;{}P", modifiers_code));
-            F2,     mods; Action::Esc(format!("\x1b[1;{}Q", modifiers_code));
-            F3,     mods; Action::Esc(format!("\x1b[1;{}R", modifiers_code));
-            F4,     mods; Action::Esc(format!("\x1b[1;{}S", modifiers_code));
-            F5,     mods; Action::Esc(format!("\x1b[15;{}~", modifiers_code));
-            F6,     mods; Action::Esc(format!("\x1b[17;{}~", modifiers_code));
-            F7,     mods; Action::Esc(format!("\x1b[18;{}~", modifiers_code));
-            F8,     mods; Action::Esc(format!("\x1b[19;{}~", modifiers_code));
-            F9,     mods; Action::Esc(format!("\x1b[20;{}~", modifiers_code));
-            F10,    mods; Action::Esc(format!("\x1b[21;{}~", modifiers_code));
-            F11,    mods; Action::Esc(format!("\x1b[23;{}~", modifiers_code));
-            F12,    mods; Action::Esc(format!("\x1b[24;{}~", modifiers_code));
-            F13,    mods; Action::Esc(format!("\x1b[25;{}~", modifiers_code));
-            F14,    mods; Action::Esc(format!("\x1b[26;{}~", modifiers_code));
-            F15,    mods; Action::Esc(format!("\x1b[28;{}~", modifiers_code));
-            F16,    mods; Action::Esc(format!("\x1b[29;{}~", modifiers_code));
-            F17,    mods; Action::Esc(format!("\x1b[31;{}~", modifiers_code));
-            F18,    mods; Action::Esc(format!("\x1b[32;{}~", modifiers_code));
-            F19,    mods; Action::Esc(format!("\x1b[33;{}~", modifiers_code));
-            F20,    mods; Action::Esc(format!("\x1b[34;{}~", modifiers_code));
+            Delete, mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[3;{}~", modifiers_code));
+            Up,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}A", modifiers_code));
+            Down,   mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}B", modifiers_code));
+            Right,  mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}C", modifiers_code));
+            Left,   mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}D", modifiers_code));
+            F1,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}P", modifiers_code));
+            F2,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}Q", modifiers_code));
+            F3,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}R", modifiers_code));
+            F4,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}S", modifiers_code));
+            F5,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[15;{}~", modifiers_code));
+            F6,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[17;{}~", modifiers_code));
+            F7,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[18;{}~", modifiers_code));
+            F8,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[19;{}~", modifiers_code));
+            F9,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[20;{}~", modifiers_code));
+            F10,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[21;{}~", modifiers_code));
+            F11,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[23;{}~", modifiers_code));
+            F12,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[24;{}~", modifiers_code));
+            F13,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[25;{}~", modifiers_code));
+            F14,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[26;{}~", modifiers_code));
+            F15,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[28;{}~", modifiers_code));
+            F16,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[29;{}~", modifiers_code));
+            F17,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[31;{}~", modifiers_code));
+            F18,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[32;{}~", modifiers_code));
+            F19,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[33;{}~", modifiers_code));
+            F20,    mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[34;{}~", modifiers_code));
         ));
 
         // We're adding the following bindings with `Shift` manually above, so skipping them here
@@ -380,11 +492,11 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         if modifiers_code != 2 {
             bindings.extend(bindings!(
                 KeyBinding;
-                Insert,   mods; Action::Esc(format!("\x1b[2;{}~", modifiers_code));
-                PageUp,   mods; Action::Esc(format!("\x1b[5;{}~", modifiers_code));
-                PageDown, mods; Action::Esc(format!("\x1b[6;{}~", modifiers_code));
-                End,      mods; Action::Esc(format!("\x1b[1;{}F", modifiers_code));
-                Home,     mods; Action::Esc(format!("\x1b[1;{}H", modifiers_code));
+                Insert,   mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[2;{}~", modifiers_code));
+                PageUp,   mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[5;{}~", modifiers_code));
+                PageDown, mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[6;{}~", modifiers_code));
+                End,      mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}F", modifiers_code));
+                Home,     mods, ~TermMode::KEYBOARD_MOTION; Action::Esc(format!("\x1b[1;{}H", modifiers_code));
             ));
         }
     }
@@ -432,11 +544,11 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         Equals, ModifiersState::LOGO;  Action::IncreaseFontSize;
         Add,    ModifiersState::LOGO;  Action::IncreaseFontSize;
         Minus,  ModifiersState::LOGO;  Action::DecreaseFontSize;
-        Insert, ModifiersState::SHIFT; Action::Esc("\x1b[2;2~".into());
+        Insert, ModifiersState::SHIFT, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x1b[2;2~".into());
+        K, ModifiersState::LOGO, ~TermMode::KEYBOARD_MOTION; Action::Esc("\x0c".into());
         N, ModifiersState::LOGO; Action::SpawnNewInstance;
         F, ModifiersState::CTRL | ModifiersState::LOGO; Action::ToggleFullscreen;
         K, ModifiersState::LOGO; Action::ClearHistory;
-        K, ModifiersState::LOGO; Action::Esc("\x0c".into());
         V, ModifiersState::LOGO; Action::Paste;
         C, ModifiersState::LOGO; Action::Copy;
         H, ModifiersState::LOGO; Action::Hide;
@@ -491,7 +603,8 @@ impl<'a> Deserialize<'a> for ModeWrapper {
 
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(
-                    "Combination of AppCursor | AppKeypad | Alt, possibly with negation (~)",
+                    "Combination of AppCursor | AppKeypad | Alt | KeyboardMotion, possibly with \
+                     negation (~)",
                 )
             }
 
@@ -509,6 +622,8 @@ impl<'a> Deserialize<'a> for ModeWrapper {
                         "~appkeypad" => res.not_mode |= TermMode::APP_KEYPAD,
                         "alt" => res.mode |= TermMode::ALT_SCREEN,
                         "~alt" => res.not_mode |= TermMode::ALT_SCREEN,
+                        "keyboardmotion" => res.mode |= TermMode::KEYBOARD_MOTION,
+                        "~keyboardmotion" => res.not_mode |= TermMode::KEYBOARD_MOTION,
                         _ => error!(target: LOG_TARGET_CONFIG, "Unknown mode {:?}", modifier),
                     }
                 }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -354,8 +354,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         NumpadEnter, ~TermMode::VI; Action::Esc("\n".into());
         Space, ModifiersState::SHIFT | ModifiersState::CTRL, +TermMode::VI; Action::ScrollToBottom;
         Space, ModifiersState::SHIFT | ModifiersState::CTRL; Action::ToggleViMode;
-        Escape,                        +TermMode::VI; Action::ScrollToBottom;
-        Escape,                        +TermMode::VI; Action::ToggleViMode;
+        Escape,                        +TermMode::VI; Action::ClearSelection;
         I,                             +TermMode::VI; Action::ScrollToBottom;
         I,                             +TermMode::VI; Action::ToggleViMode;
         Y,      ModifiersState::CTRL,  +TermMode::VI; Action::ScrollLineUp;

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -24,8 +24,8 @@ use serde::de::{self, MapAccess, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer};
 
 use alacritty_terminal::config::LOG_TARGET_CONFIG;
-use alacritty_terminal::vi_mode::ViMotion;
 use alacritty_terminal::term::TermMode;
+use alacritty_terminal::vi_mode::ViMotion;
 
 /// Describes a state and action to take in that state
 ///
@@ -624,8 +624,8 @@ impl<'a> Deserialize<'a> for ModeWrapper {
 
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(
-                    "Combination of AppCursor | AppKeypad | Alt | ViMode, possibly with \
-                     negation (~)",
+                    "Combination of AppCursor | AppKeypad | Alt | ViMode, possibly with negation \
+                     (~)",
                 )
             }
 
@@ -890,9 +890,7 @@ impl<'a> Deserialize<'a> for RawBinding {
                         },
                         Field::ViMode => {
                             if vi_mode.is_some() {
-                                return Err(<V::Error as Error>::duplicate_field(
-                                    "vi_mode",
-                                ));
+                                return Err(<V::Error as Error>::duplicate_field("vi_mode"));
                             }
 
                             let action = map.next_value::<ViModeWrapper>()?.into();

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -812,7 +812,11 @@ impl<'a> Deserialize<'a> for RawBinding {
                                     Err(err) => {
                                         let value = match value {
                                             SerdeValue::String(string) => string,
-                                            SerdeValue::Mapping(map) if map.len() == 1 => {
+                                            SerdeValue::Mapping(map) => {
+                                                if map.len() != 1 {
+                                                    return Err(err).map_err(V::Error::custom);
+                                                }
+
                                                 match map.into_iter().next() {
                                                     Some((
                                                         SerdeValue::String(string),

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -15,7 +15,7 @@ pub mod monitor;
 mod mouse;
 mod ui_config;
 
-pub use crate::config::bindings::{Action, Binding, Key, KeyboardMotionAction};
+pub use crate::config::bindings::{Action, Binding, Key, ViAction};
 #[cfg(test)]
 pub use crate::config::mouse::{ClickHandler, Mouse};
 use crate::config::ui_config::UIConfig;

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -15,7 +15,7 @@ pub mod monitor;
 mod mouse;
 mod ui_config;
 
-pub use crate::config::bindings::{Action, Binding, Key};
+pub use crate::config::bindings::{Action, Binding, Key, KeyboardMotionAction};
 #[cfg(test)]
 pub use crate::config::mouse::{ClickHandler, Mouse};
 use crate::config::ui_config::UIConfig;

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -366,6 +366,12 @@ impl Display {
         let selection = !terminal.selection().as_ref().map(Selection::is_empty).unwrap_or(true);
         let mouse_mode = terminal.mode().intersects(TermMode::MOUSE_MODE);
 
+        let keyboard_cursor = if terminal.mode().contains(TermMode::KEYBOARD_MOTION) {
+            Some(terminal.keyboard_cursor)
+        } else {
+            None
+        };
+
         // Update IME position
         #[cfg(not(windows))]
         self.window.update_ime_position(&terminal, &self.size_info);
@@ -416,6 +422,13 @@ impl Display {
                 self.window.set_mouse_cursor(CursorIcon::Default);
             } else {
                 self.window.set_mouse_cursor(CursorIcon::Text);
+            }
+        }
+
+        // Highlight URLs at the keyboard cursor position
+        if let Some(keyboard_cursor) = keyboard_cursor {
+            if let Some(url) = self.urls.find_at(keyboard_cursor.point) {
+                rects.append(&mut url.rects(&metrics, &size_info));
             }
         }
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -366,8 +366,8 @@ impl Display {
         let selection = !terminal.selection().as_ref().map(Selection::is_empty).unwrap_or(true);
         let mouse_mode = terminal.mode().intersects(TermMode::MOUSE_MODE);
 
-        let keyboard_cursor = if terminal.mode().contains(TermMode::KEYBOARD_MOTION) {
-            Some(terminal.keyboard_cursor)
+        let vi_cursor = if terminal.mode().contains(TermMode::VI) {
+            Some(terminal.vi_cursor)
         } else {
             None
         };
@@ -425,9 +425,9 @@ impl Display {
             }
         }
 
-        // Highlight URLs at the keyboard cursor position
-        if let Some(keyboard_cursor) = keyboard_cursor {
-            if let Some(url) = self.urls.find_at(keyboard_cursor.point) {
+        // Highlight URLs at the vi mode cursor position
+        if let Some(vi_cursor) = vi_cursor {
+            if let Some(url) = self.urls.find_at(vi_cursor.point) {
                 rects.append(&mut url.rects(&metrics, &size_info));
             }
         }

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -366,8 +366,8 @@ impl Display {
         let selection = !terminal.selection().as_ref().map(Selection::is_empty).unwrap_or(true);
         let mouse_mode = terminal.mode().intersects(TermMode::MOUSE_MODE);
 
-        let vi_cursor = if terminal.mode().contains(TermMode::VI) {
-            Some(terminal.vi_cursor)
+        let vi_mode_cursor = if terminal.mode().contains(TermMode::VI) {
+            Some(terminal.vi_mode_cursor)
         } else {
             None
         };
@@ -426,8 +426,8 @@ impl Display {
         }
 
         // Highlight URLs at the vi mode cursor position
-        if let Some(vi_cursor) = vi_cursor {
-            if let Some(url) = self.urls.find_at(vi_cursor.point) {
+        if let Some(vi_mode_cursor) = vi_mode_cursor {
+            if let Some(url) = self.urls.find_at(vi_mode_cursor.point) {
                 rects.append(&mut url.rects(&metrics, &size_info));
             }
         }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -87,7 +87,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         // Update selection
         if self.terminal.mode().contains(TermMode::VI) {
-            self.update_selection(self.terminal.vi_cursor.point, Side::Right);
+            self.update_selection(self.terminal.vi_mode_cursor.point, Side::Right);
 
             if let Some(selection) = self.terminal.selection_mut() {
                 selection.include_all();

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -86,7 +86,9 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.terminal.scroll_display(scroll);
 
         // Update selection
-        if self.terminal.mode().contains(TermMode::VI) {
+        if self.terminal.mode().contains(TermMode::VI)
+            && self.terminal.selection().as_ref().map(|s| s.is_empty()) != Some(true)
+        {
             self.update_selection(self.terminal.vi_mode_cursor.point, Side::Right);
 
             if let Some(selection) = self.terminal.selection_mut() {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -129,14 +129,13 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.terminal.dirty = true;
     }
 
-    fn start_selection(&mut self, ty: SelectionType, point: Point, side: Option<Side>) {
+    fn start_selection(&mut self, ty: SelectionType, point: Point, side: Side) {
         let point = self.terminal.visible_to_buffer(point);
-        let side = side.unwrap_or(Side::Left);
         *self.terminal.selection_mut() = Some(Selection::new(ty, point, side));
         self.terminal.dirty = true;
     }
 
-    fn toggle_selection(&mut self, ty: SelectionType, point: Point, side: Option<Side>) {
+    fn toggle_selection(&mut self, ty: SelectionType, point: Point, side: Side) {
         match self.terminal.selection_mut() {
             Some(selection) if selection.ty == ty && !selection.is_empty() => {
                 self.clear_selection();

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -27,7 +27,7 @@ use alacritty_terminal::event::{Event, EventListener, Notify};
 use alacritty_terminal::grid::Scroll;
 use alacritty_terminal::index::{Column, Line, Point, Side};
 use alacritty_terminal::message_bar::{Message, MessageBuffer};
-use alacritty_terminal::selection::{Anchor, Selection, SelectionType};
+use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::sync::FairMutex;
 use alacritty_terminal::term::cell::Cell;
 use alacritty_terminal::term::{SizeInfo, Term};
@@ -116,7 +116,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         // Update selection if one exists
         if let Some(selection) = self.terminal.selection_mut() {
-            *selection.end() = Anchor::new(point, side);
+            selection.update(point, side);
         }
 
         self.terminal.dirty = true;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -163,6 +163,12 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     }
 
     #[inline]
+    fn mouse_mode(&self) -> bool {
+        self.terminal.mode().intersects(TermMode::MOUSE_MODE)
+            && !self.terminal.mode().contains(TermMode::VI)
+    }
+
+    #[inline]
     fn mouse_mut(&mut self) -> &mut Mouse {
         self.mouse
     }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -30,7 +30,7 @@ use alacritty_terminal::message_bar::{Message, MessageBuffer};
 use alacritty_terminal::selection::{Anchor, Selection, SelectionType};
 use alacritty_terminal::sync::FairMutex;
 use alacritty_terminal::term::cell::Cell;
-use alacritty_terminal::term::{SizeInfo, Term};
+use alacritty_terminal::term::{SizeInfo, Term, TermMode};
 #[cfg(not(windows))]
 use alacritty_terminal::tty;
 use alacritty_terminal::util::{limit, start_daemon};
@@ -274,6 +274,75 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
                 Err(_) => warn!("Unable to launch {} with args {:?}", launcher.program(), args),
             }
         }
+    }
+
+    /// Create a mouse report at a specific location.
+    fn mouse_report(&mut self, button: u8, state: ElementState, line: Line, column: Column) {
+        // Calculate modifiers value
+        let mut mods = 0;
+        if self.modifiers.shift() {
+            mods += 4;
+        }
+        if self.modifiers.alt() {
+            mods += 8;
+        }
+        if self.modifiers.ctrl() {
+            mods += 16;
+        }
+
+        // Report mouse events
+        if self.terminal.mode().contains(TermMode::SGR_MOUSE) {
+            self.sgr_mouse_report(button + mods, state, line, column);
+        } else if let ElementState::Released = state {
+            self.normal_mouse_report(3 + mods, line, column);
+        } else {
+            self.normal_mouse_report(button + mods, line, column);
+        }
+    }
+}
+
+impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
+    fn sgr_mouse_report(&mut self, button: u8, state: ElementState, line: Line, column: Column) {
+        let c = match state {
+            ElementState::Pressed => 'M',
+            ElementState::Released => 'm',
+        };
+
+        let msg = format!("\x1b[<{};{};{}{}", button, column + 1, line + 1, c);
+        self.write_to_pty(msg.into_bytes());
+    }
+
+    fn normal_mouse_report(&mut self, button: u8, line: Line, column: Column) {
+        let utf8 = self.terminal.mode().contains(TermMode::UTF8_MOUSE);
+
+        let max_point = if utf8 { 2015 } else { 223 };
+
+        if line >= Line(max_point) || column >= Column(max_point) {
+            return;
+        }
+
+        let mut msg = vec![b'\x1b', b'[', b'M', 32 + button];
+
+        let mouse_pos_encode = |pos: usize| -> Vec<u8> {
+            let pos = 32 + 1 + pos;
+            let first = 0xC0 + pos / 64;
+            let second = 0x80 + (pos & 63);
+            vec![first as u8, second as u8]
+        };
+
+        if utf8 && column >= Column(95) {
+            msg.append(&mut mouse_pos_encode(column.0));
+        } else {
+            msg.push(32 + 1 + column.0 as u8);
+        }
+
+        if utf8 && line >= Line(95) {
+            msg.append(&mut mouse_pos_encode(line.0));
+        } else {
+            msg.push(32 + 1 + line.0 as u8);
+        }
+
+        self.write_to_pty(msg);
     }
 }
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -86,8 +86,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.terminal.scroll_display(scroll);
 
         // Update selection
-        if self.terminal.mode().contains(TermMode::KEYBOARD_MOTION) {
-            self.update_selection(self.terminal.keyboard_cursor.point, Side::Right);
+        if self.terminal.mode().contains(TermMode::VI) {
+            self.update_selection(self.terminal.vi_cursor.point, Side::Right);
 
             if let Some(selection) = self.terminal.selection_mut() {
                 selection.include_all();

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -169,7 +169,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::KeyboardMotionAction(KeyboardMotionAction::ToggleSemanticSelection) => {
                 Self::toggle_selection(ctx, SelectionType::Semantic)
             },
-            Action::KeyboardMotionAction(KeyboardMotionAction::LaunchUrl) => {
+            Action::KeyboardMotionAction(KeyboardMotionAction::Open) => {
                 ctx.mouse_mut().block_url_launcher = false;
                 if let Some(url) = ctx.urls().find_at(ctx.terminal().keyboard_cursor.point) {
                     ctx.launch_url(url);

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -179,7 +179,7 @@ impl<T: EventListener> Execute<T> for Action {
                 }
             },
             Action::ClearSelection => ctx.clear_selection(),
-            Action::KeyboardMotionClick => {
+            Action::KeyboardMotionLaunchUrl => {
                 // Only allow this action while using keyboard motion
                 if !ctx.terminal().mode().contains(TermMode::KEYBOARD_MOTION) {
                     return;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -65,9 +65,9 @@ pub struct Processor<'a, T: EventListener, A: ActionContext<T>> {
 }
 
 pub trait ActionContext<T: EventListener> {
-    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, data: B);
+    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, _: B);
     fn size_info(&self) -> SizeInfo;
-    fn copy_selection(&mut self, ty: ClipboardType);
+    fn copy_selection(&mut self, _: ClipboardType);
     fn start_selection(&mut self, ty: SelectionType, point: Point, side: Option<Side>);
     fn toggle_selection(&mut self, ty: SelectionType, point: Point, side: Option<Side>);
     fn update_selection(&mut self, point: Point, side: Side);
@@ -92,8 +92,7 @@ pub trait ActionContext<T: EventListener> {
     fn config(&self) -> &Config;
     fn event_loop(&self) -> &EventLoopWindowTarget<Event>;
     fn urls(&self) -> &Urls;
-    fn launch_url(&self, url: Url);
-    fn mouse_report(&mut self, button: u8, state: ElementState, line: Line, column: Column);
+    fn launch_url(&self, _: Url);
 }
 
 trait Execute<T: EventListener> {
@@ -182,14 +181,8 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ClearSelection => ctx.clear_selection(),
             Action::KeyboardMotionClick => {
                 ctx.mouse_mut().block_url_launcher = false;
-                let point = ctx.terminal().keyboard_cursor.point;
-                match ctx.urls().find_at(point) {
-                    Some(url) => ctx.launch_url(url),
-                    None if ctx.terminal().mode().intersects(TermMode::MOUSE_MODE) => {
-                        ctx.mouse_report(0, ElementState::Pressed, point.line, point.col);
-                        ctx.mouse_report(0, ElementState::Released, point.line, point.col);
-                    },
-                    _ => (),
+                if let Some(url) = ctx.urls().find_at(ctx.terminal().keyboard_cursor.point) {
+                    ctx.launch_url(url);
                 }
             },
             Action::KeyboardMotionUp => ctx.terminal_mut().keyboard_motion(KeyboardMotion::Up),
@@ -407,6 +400,75 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         }
     }
 
+    fn normal_mouse_report(&mut self, button: u8) {
+        let (line, column) = (self.ctx.mouse().line, self.ctx.mouse().column);
+        let utf8 = self.ctx.terminal().mode().contains(TermMode::UTF8_MOUSE);
+
+        let max_point = if utf8 { 2015 } else { 223 };
+
+        if line >= Line(max_point) || column >= Column(max_point) {
+            return;
+        }
+
+        let mut msg = vec![b'\x1b', b'[', b'M', 32 + button];
+
+        let mouse_pos_encode = |pos: usize| -> Vec<u8> {
+            let pos = 32 + 1 + pos;
+            let first = 0xC0 + pos / 64;
+            let second = 0x80 + (pos & 63);
+            vec![first as u8, second as u8]
+        };
+
+        if utf8 && column >= Column(95) {
+            msg.append(&mut mouse_pos_encode(column.0));
+        } else {
+            msg.push(32 + 1 + column.0 as u8);
+        }
+
+        if utf8 && line >= Line(95) {
+            msg.append(&mut mouse_pos_encode(line.0));
+        } else {
+            msg.push(32 + 1 + line.0 as u8);
+        }
+
+        self.ctx.write_to_pty(msg);
+    }
+
+    fn sgr_mouse_report(&mut self, button: u8, state: ElementState) {
+        let (line, column) = (self.ctx.mouse().line, self.ctx.mouse().column);
+        let c = match state {
+            ElementState::Pressed => 'M',
+            ElementState::Released => 'm',
+        };
+
+        let msg = format!("\x1b[<{};{};{}{}", button, column + 1, line + 1, c);
+        self.ctx.write_to_pty(msg.into_bytes());
+    }
+
+    fn mouse_report(&mut self, button: u8, state: ElementState) {
+        // Calculate modifiers value
+        let mut mods = 0;
+        let modifiers = self.ctx.modifiers();
+        if modifiers.shift() {
+            mods += 4;
+        }
+        if modifiers.alt() {
+            mods += 8;
+        }
+        if modifiers.ctrl() {
+            mods += 16;
+        }
+
+        // Report mouse events
+        if self.ctx.terminal().mode().contains(TermMode::SGR_MOUSE) {
+            self.sgr_mouse_report(button + mods, state);
+        } else if let ElementState::Released = state {
+            self.normal_mouse_report(3 + mods);
+        } else {
+            self.normal_mouse_report(button + mods);
+        }
+    }
+
     fn on_mouse_double_click(&mut self, button: MouseButton, point: Point) {
         if button == MouseButton::Left {
             self.ctx.start_selection(SelectionType::Semantic, point, None);
@@ -505,10 +567,6 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         }
 
         self.copy_selection();
-    }
-
-    fn mouse_report(&mut self, button: u8, state: ElementState) {
-        self.ctx.mouse_report(button, state, self.ctx.mouse().line, self.ctx.mouse().column);
     }
 
     pub fn mouse_wheel_input(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
@@ -832,7 +890,7 @@ mod tests {
     use alacritty_terminal::clipboard::{Clipboard, ClipboardType};
     use alacritty_terminal::event::{Event as TerminalEvent, EventListener};
     use alacritty_terminal::grid::Scroll;
-    use alacritty_terminal::index::{Column, Line, Point, Side};
+    use alacritty_terminal::index::{Point, Side};
     use alacritty_terminal::message_bar::{Message, MessageBuffer};
     use alacritty_terminal::selection::{Selection, SelectionType};
     use alacritty_terminal::term::{SizeInfo, Term, TermMode};
@@ -979,16 +1037,6 @@ mod tests {
         }
 
         fn launch_url(&self, _: Url) {
-            unimplemented!();
-        }
-
-        fn mouse_report(
-            &mut self,
-            _button: u8,
-            _state: ElementState,
-            _line: Line,
-            _column: Column,
-        ) {
             unimplemented!();
         }
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -201,13 +201,13 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollLineUp => ctx.scroll(Scroll::Lines(1)),
             Action::ScrollLineDown => ctx.scroll(Scroll::Lines(-1)),
             Action::ScrollToTop => {
-                ctx.scroll(Scroll::Top);
                 ctx.terminal_mut().keyboard_cursor.point = Point::new(Line(0), Column(0));
+                ctx.scroll(Scroll::Top);
             },
             Action::ScrollToBottom => {
-                ctx.scroll(Scroll::Bottom);
                 let num_lines = ctx.terminal().grid().num_lines();
                 ctx.terminal_mut().keyboard_cursor.point = Point::new(num_lines - 1, Column(0));
+                ctx.scroll(Scroll::Bottom);
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
             Action::ClearLogNotice => ctx.pop_message(),

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -179,6 +179,7 @@ impl<T: EventListener> Execute<T> for Action {
                     selection.include_all();
                 }
             },
+            Action::ClearSelection => ctx.clear_selection(),
             Action::KeyboardMotionClick => {
                 ctx.mouse_mut().block_url_launcher = false;
                 let point = ctx.terminal().keyboard_cursor.point;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -65,9 +65,9 @@ pub struct Processor<'a, T: EventListener, A: ActionContext<T>> {
 }
 
 pub trait ActionContext<T: EventListener> {
-    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, _: B);
+    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, data: B);
     fn size_info(&self) -> SizeInfo;
-    fn copy_selection(&mut self, _: ClipboardType);
+    fn copy_selection(&mut self, ty: ClipboardType);
     fn start_selection(&mut self, ty: SelectionType, point: Point, side: Option<Side>);
     fn toggle_selection(&mut self, ty: SelectionType, point: Point, side: Option<Side>);
     fn update_selection(&mut self, point: Point, side: Side);
@@ -92,7 +92,7 @@ pub trait ActionContext<T: EventListener> {
     fn config(&self) -> &Config;
     fn event_loop(&self) -> &EventLoopWindowTarget<Event>;
     fn urls(&self) -> &Urls;
-    fn launch_url(&self, _: Url);
+    fn launch_url(&self, url: Url);
 }
 
 trait Execute<T: EventListener> {

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -142,7 +142,7 @@ impl<T: EventListener> Execute<T> for Action {
             },
             Action::ToggleKeyboardMode => ctx.terminal_mut().toggle_keyboard_mode(),
             Action::ToggleNormalSelection => {
-                // Only allow this mode while using keyboard motion
+                // Only allow this action while using keyboard motion
                 if !ctx.terminal().mode().contains(TermMode::KEYBOARD_MOTION) {
                     return;
                 }
@@ -156,7 +156,7 @@ impl<T: EventListener> Execute<T> for Action {
                 }
             },
             Action::ToggleLineSelection => {
-                // Only allow this mode while using keyboard motion
+                // Only allow this action while using keyboard motion
                 if !ctx.terminal().mode().contains(TermMode::KEYBOARD_MOTION) {
                     return;
                 }
@@ -165,7 +165,7 @@ impl<T: EventListener> Execute<T> for Action {
                 ctx.toggle_selection(SelectionType::Lines, cursor_point, None);
             },
             Action::ToggleBlockSelection => {
-                // Only allow this mode while using keyboard motion
+                // Only allow this action while using keyboard motion
                 if !ctx.terminal().mode().contains(TermMode::KEYBOARD_MOTION) {
                     return;
                 }
@@ -180,6 +180,11 @@ impl<T: EventListener> Execute<T> for Action {
             },
             Action::ClearSelection => ctx.clear_selection(),
             Action::KeyboardMotionClick => {
+                // Only allow this action while using keyboard motion
+                if !ctx.terminal().mode().contains(TermMode::KEYBOARD_MOTION) {
+                    return;
+                }
+
                 ctx.mouse_mut().block_url_launcher = false;
                 if let Some(url) = ctx.urls().find_at(ctx.terminal().keyboard_cursor.point) {
                     ctx.launch_url(url);

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -347,17 +347,12 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             // Treat motion over message bar like motion over the last line
             let line = min(point.line, last_term_line);
 
-            self.ctx.update_selection(Point { line, col: point.col }, cell_side);
-
+            // Move vi mode cursor to mouse cursor position
             if self.ctx.terminal().mode().contains(TermMode::VI) {
-                // Move vi mode cursor to mouse cursor position
                 self.ctx.terminal_mut().vi_mode_cursor.point = point;
-
-                // Extend selection to include partially selected cells
-                if let Some(selection) = self.ctx.terminal_mut().selection_mut() {
-                    selection.include_all();
-                }
             }
+
+            self.ctx.update_selection(Point { line, col: point.col }, cell_side);
         } else if inside_grid
             && cell_changed
             && point.line <= last_term_line
@@ -645,9 +640,8 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
             // Update selection
             let point = term.vi_mode_cursor.point;
-            self.ctx.update_selection(point, Side::Right);
-            if let Some(selection) = self.ctx.terminal_mut().selection_mut() {
-                selection.include_all();
+            if !self.ctx.selection_is_empty() {
+                self.ctx.update_selection(point, Side::Right);
             }
         }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -19,7 +19,7 @@
 //! needs to be tracked. Additionally, we need a bit of a state machine to
 //! determine what to do when a non-modifier key is pressed.
 use std::borrow::Cow;
-use std::cmp::{min, max, Ordering};
+use std::cmp::{min, Ordering};
 use std::marker::PhantomData;
 use std::time::Instant;
 
@@ -642,6 +642,13 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             let term = self.ctx.terminal_mut();
             term.vi_mode_cursor.point = term.grid().clamp_buffer_to_visible(absolute);
             term.vi_mode_cursor.point.col = absolute.col;
+
+            // Update selection
+            let point = term.vi_mode_cursor.point;
+            self.ctx.update_selection(point, Side::Right);
+            if let Some(selection) = self.ctx.terminal_mut().selection_mut() {
+                selection.include_all();
+            }
         }
 
         self.ctx.mouse_mut().scroll_px %= height;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -43,6 +43,7 @@ use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::term::mode::TermMode;
 use alacritty_terminal::term::{SizeInfo, Term};
 use alacritty_terminal::util::start_daemon;
+use alacritty_terminal::keyboard_motion::KeyboardMotion;
 
 use crate::config::{Action, Binding, Config, Key, KeyboardMotionAction};
 use crate::event::{ClickState, Mouse};
@@ -241,13 +242,19 @@ impl<T: EventListener> Execute<T> for Action {
                 ctx.scroll(Scroll::Lines(-1));
             },
             Action::ScrollToTop => {
-                ctx.terminal_mut().keyboard_cursor.point = Point::new(Line(0), Column(0));
                 ctx.scroll(Scroll::Top);
+
+                // Move keyboard cursor
+                ctx.terminal_mut().keyboard_cursor.point.line = Line(0);
+                ctx.terminal_mut().keyboard_motion(KeyboardMotion::FirstOccupied);
             },
             Action::ScrollToBottom => {
-                let num_lines = ctx.terminal().grid().num_lines();
-                ctx.terminal_mut().keyboard_cursor.point = Point::new(num_lines - 1, Column(0));
                 ctx.scroll(Scroll::Bottom);
+
+                // Move keyboard cursor
+                let term = ctx.terminal_mut();
+                term.keyboard_cursor.point.line = term.grid().num_lines() - 1;
+                term.keyboard_motion(KeyboardMotion::FirstOccupied);
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
             Action::ClearLogNotice => ctx.pop_message(),

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -19,7 +19,7 @@
 //! needs to be tracked. Additionally, we need a bit of a state machine to
 //! determine what to do when a non-modifier key is pressed.
 use std::borrow::Cow;
-use std::cmp::{min, Ordering};
+use std::cmp::{min, max, Ordering};
 use std::marker::PhantomData;
 use std::time::Instant;
 
@@ -632,7 +632,16 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
             let lines = self.ctx.mouse().scroll_px / height;
 
+            // Store absolute position of vi mode cursor
+            let term = self.ctx.terminal();
+            let absolute = term.visible_to_buffer(term.vi_mode_cursor.point);
+
             self.ctx.scroll(Scroll::Lines(lines as isize));
+
+            // Try to restore vi mode cursor position, to keep it above its previous content
+            let term = self.ctx.terminal_mut();
+            term.vi_mode_cursor.point = term.grid().clamp_buffer_to_visible(absolute);
+            term.vi_mode_cursor.point.col = absolute.col;
         }
 
         self.ctx.mouse_mut().scroll_px %= height;

--- a/alacritty/src/url.rs
+++ b/alacritty/src/url.rs
@@ -147,6 +147,7 @@ impl Urls {
         url.end_offset = end_offset;
     }
 
+    /// Find URL below the mouse cursor.
     pub fn highlighted(
         &self,
         config: &Config,
@@ -171,12 +172,16 @@ impl Urls {
             return None;
         }
 
+        self.find_at(Point::new(mouse.line, mouse.column))
+    }
+
+    /// Find URL at location.
+    pub fn find_at(&self, point: Point) -> Option<Url> {
         for url in &self.urls {
-            if (url.start()..=url.end()).contains(&Point::new(mouse.line, mouse.column)) {
+            if (url.start()..=url.end()).contains(&point) {
                 return Some(url.clone());
             }
         }
-
         None
     }
 

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -79,6 +79,10 @@ pub struct CursorColors {
     pub text: Option<Rgb>,
     #[serde(deserialize_with = "failure_default")]
     pub cursor: Option<Rgb>,
+    #[serde(deserialize_with = "failure_default")]
+    pub keyboard_motion_text: Option<Rgb>,
+    #[serde(deserialize_with = "failure_default")]
+    pub keyboard_motion_cursor: Option<Rgb>,
 }
 
 #[serde(default)]

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -12,7 +12,7 @@ pub struct Colors {
     #[serde(deserialize_with = "failure_default")]
     pub cursor: CursorColors,
     #[serde(deserialize_with = "failure_default")]
-    pub keyboard_motion_cursor: CursorColors,
+    pub vi_mode_cursor: CursorColors,
     #[serde(deserialize_with = "failure_default")]
     pub selection: SelectionColors,
     #[serde(deserialize_with = "failure_default")]

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -12,6 +12,8 @@ pub struct Colors {
     #[serde(deserialize_with = "failure_default")]
     pub cursor: CursorColors,
     #[serde(deserialize_with = "failure_default")]
+    pub keyboard_motion_cursor: CursorColors,
+    #[serde(deserialize_with = "failure_default")]
     pub selection: SelectionColors,
     #[serde(deserialize_with = "failure_default")]
     normal: NormalColors,
@@ -79,10 +81,6 @@ pub struct CursorColors {
     pub text: Option<Rgb>,
     #[serde(deserialize_with = "failure_default")]
     pub cursor: Option<Rgb>,
-    #[serde(deserialize_with = "failure_default")]
-    pub keyboard_motion_text: Option<Rgb>,
-    #[serde(deserialize_with = "failure_default")]
-    pub keyboard_motion_cursor: Option<Rgb>,
 }
 
 #[serde(default)]

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -28,7 +28,7 @@ mod scrolling;
 mod visual_bell;
 mod window;
 
-use crate::ansi::{Color, CursorStyle, NamedColor};
+use crate::ansi::{CursorStyle, NamedColor};
 
 pub use crate::config::colors::Colors;
 pub use crate::config::debug::Debug;
@@ -170,16 +170,28 @@ impl<T> Config<T> {
         self.dynamic_title.0
     }
 
-    /// Cursor foreground color
+    /// Cursor foreground color.
     #[inline]
     pub fn cursor_text_color(&self) -> Option<Rgb> {
         self.colors.cursor.text
     }
 
-    /// Cursor background color
+    /// Cursor background color.
     #[inline]
-    pub fn cursor_cursor_color(&self) -> Option<Color> {
-        self.colors.cursor.cursor.map(|_| Color::Named(NamedColor::Cursor))
+    pub fn cursor_cursor_color(&self) -> Option<NamedColor> {
+        self.colors.cursor.cursor.map(|_| NamedColor::Cursor)
+    }
+
+    /// Keyboard motion cursor foreground color.
+    #[inline]
+    pub fn keyboard_motion_cursor_text_color(&self) -> Option<Rgb> {
+        self.colors.cursor.keyboard_motion_text
+    }
+
+    /// Keyboard motion cursor background color.
+    #[inline]
+    pub fn keyboard_motion_cursor_cursor_color(&self) -> Option<Rgb> {
+        self.colors.cursor.keyboard_motion_cursor
     }
 
     #[inline]
@@ -230,18 +242,14 @@ impl Default for EscapeChars {
 }
 
 #[serde(default)]
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Deserialize, Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Cursor {
     #[serde(deserialize_with = "failure_default")]
     pub style: CursorStyle,
+    #[serde(deserialize_with = "option_explicit_none")]
+    pub keyboard_motion_style: Option<CursorStyle>,
     #[serde(deserialize_with = "failure_default")]
     unfocused_hollow: DefaultTrueBool,
-}
-
-impl Default for Cursor {
-    fn default() -> Self {
-        Self { style: Default::default(), unfocused_hollow: Default::default() }
-    }
 }
 
 impl Cursor {

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -182,16 +182,16 @@ impl<T> Config<T> {
         self.colors.cursor.cursor.map(|_| NamedColor::Cursor)
     }
 
-    /// Keyboard motion cursor foreground color.
+    /// Vi mode cursor foreground color.
     #[inline]
-    pub fn keyboard_motion_cursor_text_color(&self) -> Option<Rgb> {
-        self.colors.keyboard_motion_cursor.text
+    pub fn vi_mode_cursor_text_color(&self) -> Option<Rgb> {
+        self.colors.vi_mode_cursor.text
     }
 
-    /// Keyboard motion cursor background color.
+    /// Vi mode cursor background color.
     #[inline]
-    pub fn keyboard_motion_cursor_cursor_color(&self) -> Option<Rgb> {
-        self.colors.keyboard_motion_cursor.cursor
+    pub fn vi_mode_cursor_cursor_color(&self) -> Option<Rgb> {
+        self.colors.vi_mode_cursor.cursor
     }
 
     #[inline]
@@ -247,7 +247,7 @@ pub struct Cursor {
     #[serde(deserialize_with = "failure_default")]
     pub style: CursorStyle,
     #[serde(deserialize_with = "option_explicit_none")]
-    pub keyboard_motion_style: Option<CursorStyle>,
+    pub vi_mode_style: Option<CursorStyle>,
     #[serde(deserialize_with = "failure_default")]
     unfocused_hollow: DefaultTrueBool,
 }

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -185,13 +185,13 @@ impl<T> Config<T> {
     /// Keyboard motion cursor foreground color.
     #[inline]
     pub fn keyboard_motion_cursor_text_color(&self) -> Option<Rgb> {
-        self.colors.cursor.keyboard_motion_text
+        self.colors.keyboard_motion_cursor.text
     }
 
     /// Keyboard motion cursor background color.
     #[inline]
     pub fn keyboard_motion_cursor_cursor_color(&self) -> Option<Rgb> {
-        self.colors.cursor.keyboard_motion_cursor
+        self.colors.keyboard_motion_cursor.cursor
     }
 
     #[inline]

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -264,11 +264,9 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
         let mut new_empty_lines = 0;
         let mut reversed: Vec<Row<T>> = Vec::with_capacity(self.raw.len());
         for (i, mut row) in self.raw.drain().enumerate().rev() {
-            // FIXME: Rust 1.39.0+ allows moving in pattern guard here
             // Check if reflowing shoud be performed
-            let mut last_row = reversed.last_mut();
-            let last_row = match last_row {
-                Some(ref mut last_row) if should_reflow(last_row) => last_row,
+            let last_row = match reversed.last_mut() {
+                Some(last_row) if should_reflow(last_row) => last_row,
                 _ => {
                     reversed.push(row);
                     continue;
@@ -356,11 +354,9 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
             }
 
             loop {
-                // FIXME: Rust 1.39.0+ allows moving in pattern guard here
                 // Check if reflowing shoud be performed
-                let wrapped = row.shrink(cols);
-                let mut wrapped = match wrapped {
-                    Some(_) if reflow => wrapped.unwrap(),
+                let mut wrapped = match row.shrink(cols) {
+                    Some(wrapped) if reflow => wrapped,
                     _ => {
                         new_raw.push(row);
                         break;

--- a/alacritty_terminal/src/keyboard_motion.rs
+++ b/alacritty_terminal/src/keyboard_motion.rs
@@ -1,0 +1,541 @@
+use std::cmp::min;
+
+use crate::event::EventListener;
+use crate::grid::Scroll;
+use crate::index::{Column, Line, Point};
+use crate::term::{Search, Term};
+
+/// Possible keyboard motion movements.
+pub enum KeyboardMotion {
+    Up,
+    Down,
+    Left,
+    Right,
+    Start,
+    End,
+    High,
+    Middle,
+    Low,
+    SemanticLeft,
+    SemanticRight,
+    SemanticLeftEnd,
+    SemanticRightEnd,
+    WordLeft,
+    WordRight,
+    WordLeftEnd,
+    WordRightEnd,
+    Bracket,
+}
+
+/// Cursor tracking keyboard motion position.
+#[derive(Default, Copy, Clone)]
+pub struct KeyboardCursor {
+    pub point: Point,
+}
+
+impl KeyboardCursor {
+    pub fn new(point: Point) -> Self {
+        Self { point }
+    }
+
+    /// Move keyboard motion cursor.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    pub fn motion<T: EventListener>(mut self, term: &mut Term<T>, motion: KeyboardMotion) -> Self {
+        let lines = term.grid().num_lines();
+        let cols = term.grid().num_cols();
+
+        // Advance keyboard cursor
+        match motion {
+            KeyboardMotion::Up => {
+                if self.point.line.0 == 0 {
+                    term.scroll_display(Scroll::Lines(1));
+                } else {
+                    self.point.line -= 1;
+                }
+            },
+            KeyboardMotion::Down => {
+                if self.point.line >= lines - 1 {
+                    term.scroll_display(Scroll::Lines(-1));
+                } else {
+                    self.point.line += 1;
+                }
+            },
+            KeyboardMotion::Left => self.point.col = Column(self.point.col.saturating_sub(1)),
+            KeyboardMotion::Right => self.point.col = min(self.point.col + 1, cols - 1),
+            KeyboardMotion::Start => self.point.col = Column(0),
+            KeyboardMotion::End => self.point.col = cols - 1,
+            KeyboardMotion::High => self.point = Point::new(Line(0), Column(0)),
+            KeyboardMotion::Middle => self.point = Point::new(Line((lines.0 - 1) / 2), Column(0)),
+            KeyboardMotion::Low => self.point = Point::new(lines - 1, Column(0)),
+            KeyboardMotion::SemanticLeft => {
+                self.point = Self::semantic_move(term, self.point, true, true)
+            },
+            KeyboardMotion::SemanticRight => {
+                self.point = Self::semantic_move(term, self.point, false, true)
+            },
+            KeyboardMotion::SemanticLeftEnd => {
+                self.point = Self::semantic_move(term, self.point, true, false)
+            },
+            KeyboardMotion::SemanticRightEnd => {
+                self.point = Self::semantic_move(term, self.point, false, false)
+            },
+            KeyboardMotion::WordLeft => self.point = Self::word_move(term, self.point, true, true),
+            KeyboardMotion::WordRight => {
+                self.point = Self::word_move(term, self.point, false, true)
+            },
+            KeyboardMotion::WordLeftEnd => {
+                self.point = Self::word_move(term, self.point, true, false)
+            },
+            KeyboardMotion::WordRightEnd => {
+                self.point = Self::word_move(term, self.point, false, false)
+            },
+            KeyboardMotion::Bracket => {
+                if let Some(p) = term.bracket_search(term.visible_to_buffer(self.point)) {
+                    // Scroll viewport if necessary
+                    Self::scroll(term, p);
+
+                    self.point = term.buffer_to_visible(p).unwrap_or_else(Point::default).into();
+                }
+            },
+        }
+
+        self
+    }
+
+    /// Move by semanticuation separated word, like w/b/e/ge in vi.
+    fn semantic_move<T: EventListener>(
+        term: &mut Term<T>,
+        point: Point,
+        left: bool,
+        start: bool,
+    ) -> Point {
+        // Expand semantically based on movement direction
+        let semantic = |point: Point<usize>| {
+            // Do not expand when currently on an escape char
+            if term.semantic_escape_chars().contains(term.grid()[point.line][point.col].c) {
+                point
+            } else if left {
+                term.semantic_search_left(point)
+            } else {
+                term.semantic_search_right(point)
+            }
+        };
+
+        let mut buffer_point = term.visible_to_buffer(point);
+
+        // Move to word boundary
+        if !is_boundary(term, buffer_point, left) && left != start {
+            buffer_point = semantic(buffer_point);
+        }
+
+        // Skip whitespace
+        let mut point = advance(term, buffer_point, left);
+        while !is_boundary(term, buffer_point, left) && is_space(term, point) {
+            buffer_point = point;
+            point = advance(term, buffer_point, left);
+        }
+
+        // Assure minimum movement of one cell
+        if !is_boundary(term, buffer_point, left) {
+            buffer_point = advance(term, buffer_point, left);
+        }
+
+        // Move to word boundary
+        if !is_boundary(term, buffer_point, left) && left == start {
+            buffer_point = semantic(buffer_point);
+        }
+
+        // Scroll viewport if necessary
+        Self::scroll(term, buffer_point);
+
+        term.buffer_to_visible(buffer_point).unwrap_or_else(Point::default).into()
+    }
+
+    /// Move by whitespace separated word, like W/B/E/gE in vi.
+    fn word_move<T: EventListener>(
+        term: &mut Term<T>,
+        point: Point,
+        left: bool,
+        start: bool,
+    ) -> Point {
+        let mut buffer_point = term.visible_to_buffer(point);
+
+        // Skip whitespace until right before a word
+        if left == start {
+            let mut point = advance(term, buffer_point, left);
+            while !is_boundary(term, buffer_point, left) && is_space(term, point) {
+                buffer_point = point;
+                point = advance(term, point, left);
+            }
+        }
+
+        if left == start {
+            // Skip non-whitespace until right inside word boundary
+            let mut point = advance(term, buffer_point, left);
+            while !is_boundary(term, buffer_point, left) && !is_space(term, point) {
+                buffer_point = point;
+                point = advance(term, buffer_point, left);
+            }
+        } else {
+            // Skip non-whitespace until just beyond word
+            while !is_boundary(term, buffer_point, left) && !is_space(term, buffer_point) {
+                buffer_point = advance(term, buffer_point, left);
+            }
+        };
+
+        // Skip whitespace until right inside word boundary
+        if left != start {
+            while !is_boundary(term, buffer_point, left) && is_space(term, buffer_point) {
+                buffer_point = advance(term, buffer_point, left);
+            }
+        }
+
+        // Scroll viewport if necessary
+        Self::scroll(term, buffer_point);
+
+        term.buffer_to_visible(buffer_point).unwrap_or_else(Point::default).into()
+    }
+
+    /// Scroll display if point is outside of viewport.
+    fn scroll<T: EventListener>(term: &mut Term<T>, point: Point<usize>) {
+        let display_offset = term.grid().display_offset();
+        let lines = term.grid().num_lines();
+
+        // Scroll once the top/bottom has been reached
+        if point.line >= display_offset + lines.0 {
+            let lines = point.line.saturating_sub(display_offset + lines.0 - 1);
+            term.scroll_display(Scroll::Lines(lines as isize));
+        } else if point.line < display_offset {
+            let lines = display_offset.saturating_sub(point.line);
+            term.scroll_display(Scroll::Lines(-(lines as isize)));
+        };
+    }
+}
+
+/// Check if cell at point contains whitespace.
+fn is_space<T>(term: &Term<T>, point: Point<usize>) -> bool {
+    term.grid()[point.line][point.col].c == ' '
+}
+
+/// Check if point is at screen boundary.
+fn is_boundary<T>(term: &Term<T>, point: Point<usize>, left: bool) -> bool {
+    (point.line == 0 && point.col + 1 >= term.grid().num_cols() && !left)
+        || (point.line + 1 >= term.grid().len() && point.col.0 == 0 && left)
+}
+
+/// Advance point based on direction.
+fn advance<T>(term: &Term<T>, point: Point<usize>, left: bool) -> Point<usize> {
+    let cols = term.grid().num_cols();
+    if left {
+        point.sub_absolute(cols.0, 1)
+    } else {
+        point.add_absolute(cols.0, 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::clipboard::Clipboard;
+    use crate::config::MockConfig;
+    use crate::event::Event;
+    use crate::index::{Column, Line};
+    use crate::term::{SizeInfo, Term};
+
+    struct Mock;
+    impl EventListener for Mock {
+        fn send_event(&self, _event: Event) {}
+    }
+
+    fn term() -> Term<Mock> {
+        let size = SizeInfo {
+            width: 20.,
+            height: 20.,
+            cell_width: 1.0,
+            cell_height: 1.0,
+            padding_x: 0.0,
+            padding_y: 0.0,
+            dpr: 1.0,
+        };
+        Term::new(&MockConfig::default(), &size, Clipboard::new_nop(), Mock)
+    }
+
+    #[test]
+    fn motion_simple() {
+        let mut term = term();
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Right);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(1)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Left);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Down);
+        assert_eq!(cursor.point, Point::new(Line(1), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Up);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+    }
+
+    #[test]
+    fn motion_start_end() {
+        let mut term = term();
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::End);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(19)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Start);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+    }
+
+    #[test]
+    fn motion_high_middle_low() {
+        let mut term = term();
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::High);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Middle);
+        assert_eq!(cursor.point, Point::new(Line(9), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Low);
+        assert_eq!(cursor.point, Point::new(Line(19), Column(0)));
+    }
+
+    #[test]
+    fn motion_bracket() {
+        let mut term = term();
+        term.grid_mut()[Line(0)][Column(0)].c = '(';
+        term.grid_mut()[Line(0)][Column(1)].c = 'x';
+        term.grid_mut()[Line(0)][Column(2)].c = ')';
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Bracket);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(2)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::Bracket);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+    }
+
+    fn motion_semantic_term() -> Term<Mock> {
+        let mut term = term();
+
+        term.grid_mut()[Line(0)][Column(0)].c = 'x';
+        term.grid_mut()[Line(0)][Column(1)].c = ' ';
+        term.grid_mut()[Line(0)][Column(2)].c = 'x';
+        term.grid_mut()[Line(0)][Column(3)].c = 'x';
+        term.grid_mut()[Line(0)][Column(4)].c = ' ';
+        term.grid_mut()[Line(0)][Column(5)].c = ' ';
+        term.grid_mut()[Line(0)][Column(6)].c = ':';
+        term.grid_mut()[Line(0)][Column(7)].c = ' ';
+        term.grid_mut()[Line(0)][Column(8)].c = 'x';
+        term.grid_mut()[Line(0)][Column(9)].c = ':';
+        term.grid_mut()[Line(0)][Column(10)].c = 'x';
+        term.grid_mut()[Line(0)][Column(11)].c = ' ';
+        term.grid_mut()[Line(0)][Column(12)].c = ' ';
+        term.grid_mut()[Line(0)][Column(13)].c = ':';
+        term.grid_mut()[Line(0)][Column(14)].c = ' ';
+        term.grid_mut()[Line(0)][Column(15)].c = 'x';
+
+        term
+    }
+
+    #[test]
+    fn motion_semantic_right_end() {
+        let mut term = motion_semantic_term();
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(3)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(6)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(8)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(9)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(10)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(13)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(15)));
+    }
+
+    #[test]
+    fn motion_semantic_left_start() {
+        let mut term = motion_semantic_term();
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(15)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(13)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(10)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(9)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(8)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(6)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(2)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+    }
+
+    #[test]
+    fn motion_semantic_right_start() {
+        let mut term = motion_semantic_term();
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(2)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(6)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(8)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(9)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(10)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(13)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(15)));
+    }
+
+    #[test]
+    fn motion_semantic_left_end() {
+        let mut term = motion_semantic_term();
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(15)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(13)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(10)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(9)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(8)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(6)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(3)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+    }
+
+    #[test]
+    fn scroll_semantic() {
+        let mut term = term();
+        term.grid_mut().scroll_up(&(Line(0)..Line(20)), Line(5), &Default::default());
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+        assert_eq!(term.grid().display_offset(), 5);
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRight);
+        assert_eq!(cursor.point, Point::new(Line(19), Column(19)));
+        assert_eq!(term.grid().display_offset(), 0);
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+        assert_eq!(term.grid().display_offset(), 5);
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::SemanticRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(19), Column(19)));
+        assert_eq!(term.grid().display_offset(), 0);
+    }
+
+    #[test]
+    fn motion_word() {
+        let mut term = term();
+        term.grid_mut()[Line(0)][Column(0)].c = 'a';
+        term.grid_mut()[Line(0)][Column(1)].c = ';';
+        term.grid_mut()[Line(0)][Column(2)].c = ' ';
+        term.grid_mut()[Line(0)][Column(3)].c = ' ';
+        term.grid_mut()[Line(0)][Column(4)].c = 'a';
+        term.grid_mut()[Line(0)][Column(5)].c = ';';
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(1)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(5)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(4)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordRight);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(4)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(1)));
+    }
+
+    #[test]
+    fn scroll_word() {
+        let mut term = term();
+        term.grid_mut().scroll_up(&(Line(0)..Line(20)), Line(5), &Default::default());
+
+        let mut cursor = KeyboardCursor::new(Point::new(Line(0), Column(0)));
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordLeft);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+        assert_eq!(term.grid().display_offset(), 5);
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordRight);
+        assert_eq!(cursor.point, Point::new(Line(19), Column(19)));
+        assert_eq!(term.grid().display_offset(), 0);
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordLeftEnd);
+        assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+        assert_eq!(term.grid().display_offset(), 5);
+
+        cursor = cursor.motion(&mut term, KeyboardMotion::WordRightEnd);
+        assert_eq!(cursor.point, Point::new(Line(19), Column(19)));
+        assert_eq!(term.grid().display_offset(), 0);
+    }
+}

--- a/alacritty_terminal/src/keyboard_motion.rs
+++ b/alacritty_terminal/src/keyboard_motion.rs
@@ -73,7 +73,11 @@ impl KeyboardCursor {
 
         // Advance keyboard cursor
         match motion {
-            KeyboardMotion::Up => buffer_point.line += 1,
+            KeyboardMotion::Up => {
+                if buffer_point.line + 1 < term.grid().len() {
+                    buffer_point.line += 1;
+                }
+            },
             KeyboardMotion::Down => buffer_point.line = buffer_point.line.saturating_sub(1),
             KeyboardMotion::Left => {
                 buffer_point = expand_wide(term, buffer_point, true);

--- a/alacritty_terminal/src/keyboard_motion.rs
+++ b/alacritty_terminal/src/keyboard_motion.rs
@@ -403,7 +403,7 @@ fn advance<T>(term: &Term<T>, point: Point<usize>, left: bool) -> Point<usize> {
 /// Check if cell at point contains whitespace.
 fn is_space<T>(term: &Term<T>, point: Point<usize>) -> bool {
     let cell = term.grid()[point.line][point.col];
-    cell.c == ' ' && !cell.flags().contains(Flags::WIDE_CHAR_SPACER)
+    cell.c == ' ' || cell.c == '\t' && !cell.flags().contains(Flags::WIDE_CHAR_SPACER)
 }
 
 fn is_wrap<T>(term: &Term<T>, point: Point<usize>) -> bool {

--- a/alacritty_terminal/src/keyboard_motion.rs
+++ b/alacritty_terminal/src/keyboard_motion.rs
@@ -1,5 +1,7 @@
 use std::cmp::min;
 
+use serde::Deserialize;
+
 use crate::event::EventListener;
 use crate::grid::{GridCell, Scroll};
 use crate::index::{Column, Line, Point};
@@ -7,24 +9,43 @@ use crate::term::cell::Flags;
 use crate::term::{Search, Term};
 
 /// Possible keyboard motion movements.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 pub enum KeyboardMotion {
+    /// Move up.
     Up,
+    /// Move down.
     Down,
+    /// Move left.
     Left,
+    /// Move right.
     Right,
+    /// Move to start of line.
     Start,
+    /// Move to end of line.
     End,
+    /// Move to top of screen.
     High,
+    /// Move to center of screen.
     Middle,
+    /// Move to bottom of screen.
     Low,
+    /// Move to start of semantically separated word.
     SemanticLeft,
+    /// Move to start of next semantically separated word.
     SemanticRight,
+    /// Move to end of previous semantically separated word.
     SemanticLeftEnd,
+    /// Move to end of semantically separated word.
     SemanticRightEnd,
+    /// Move to start of whitespace separated word.
     WordLeft,
+    /// Move to start of next whitespace separated word.
     WordRight,
+    /// Move to end of previous whitespace separated word.
     WordLeftEnd,
+    /// Move to end of whitespace separated word.
     WordRightEnd,
+    /// Move to opposing bracket.
     Bracket,
 }
 

--- a/alacritty_terminal/src/keyboard_motion.rs
+++ b/alacritty_terminal/src/keyboard_motion.rs
@@ -188,7 +188,7 @@ fn scroll_to_point<T: EventListener>(term: &mut Term<T>, point: Point<usize>) {
 fn last<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
     let cols = term.grid().num_cols();
 
-    // Expand across wide cells.
+    // Expand across wide cells
     point = expand_wide(term, point, false);
 
     // Find last non-empty cell in the current line
@@ -221,7 +221,7 @@ fn first_occupied<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
     let occupied = first_occupied_in_line(term, point.line)
         .unwrap_or_else(|| Point::new(point.line, cols - 1));
 
-    // Jump acress wrapped lines if we're already at this lines first occupied cell
+    // Jump across wrapped lines if we're already at this line's first occupied cell
     if point == occupied {
         let mut occupied = None;
 

--- a/alacritty_terminal/src/lib.rs
+++ b/alacritty_terminal/src/lib.rs
@@ -28,7 +28,6 @@ pub mod event;
 pub mod event_loop;
 pub mod grid;
 pub mod index;
-pub mod vi_mode;
 pub mod locale;
 pub mod message_bar;
 pub mod meter;
@@ -38,6 +37,7 @@ pub mod sync;
 pub mod term;
 pub mod tty;
 pub mod util;
+pub mod vi_mode;
 
 pub use crate::grid::Grid;
 pub use crate::term::Term;

--- a/alacritty_terminal/src/lib.rs
+++ b/alacritty_terminal/src/lib.rs
@@ -28,6 +28,7 @@ pub mod event;
 pub mod event_loop;
 pub mod grid;
 pub mod index;
+pub mod keyboard_motion;
 pub mod locale;
 pub mod message_bar;
 pub mod meter;

--- a/alacritty_terminal/src/lib.rs
+++ b/alacritty_terminal/src/lib.rs
@@ -28,7 +28,7 @@ pub mod event;
 pub mod event_loop;
 pub mod grid;
 pub mod index;
-pub mod keyboard_motion;
+pub mod vi_mode;
 pub mod locale;
 pub mod message_bar;
 pub mod meter;

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -28,12 +28,12 @@ use crate::term::{Search, Term};
 /// A Point and side within that point.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Anchor {
-    point: Point<usize>,
-    side: Side,
+    pub point: Point<usize>,
+    pub side: Side,
 }
 
 impl Anchor {
-    fn new(point: Point<usize>, side: Side) -> Anchor {
+    pub fn new(point: Point<usize>, side: Side) -> Anchor {
         Anchor { point, side }
     }
 }
@@ -67,7 +67,7 @@ impl<L> SelectionRange<L> {
 
 /// Different kinds of selection.
 #[derive(Debug, Copy, Clone, PartialEq)]
-enum SelectionType {
+pub enum SelectionType {
     Simple,
     Block,
     Semantic,
@@ -95,47 +95,23 @@ enum SelectionType {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Selection {
     region: Range<Anchor>,
-    ty: SelectionType,
+    pub ty: SelectionType,
 }
 
 impl Selection {
-    pub fn simple(location: Point<usize>, side: Side) -> Selection {
+    pub fn new(ty: SelectionType, location: Point<usize>, side: Side) -> Selection {
         Self {
             region: Range { start: Anchor::new(location, side), end: Anchor::new(location, side) },
-            ty: SelectionType::Simple,
+            ty,
         }
     }
 
-    pub fn block(location: Point<usize>, side: Side) -> Selection {
-        Self {
-            region: Range { start: Anchor::new(location, side), end: Anchor::new(location, side) },
-            ty: SelectionType::Block,
-        }
+    pub fn start(&mut self) -> &mut Anchor {
+        &mut self.region.start
     }
 
-    pub fn semantic(location: Point<usize>) -> Selection {
-        Self {
-            region: Range {
-                start: Anchor::new(location, Side::Left),
-                end: Anchor::new(location, Side::Right),
-            },
-            ty: SelectionType::Semantic,
-        }
-    }
-
-    pub fn lines(location: Point<usize>) -> Selection {
-        Self {
-            region: Range {
-                start: Anchor::new(location, Side::Left),
-                end: Anchor::new(location, Side::Right),
-            },
-            ty: SelectionType::Lines,
-        }
-    }
-
-    pub fn update(&mut self, location: Point<usize>, side: Side) {
-        self.region.end.point = location;
-        self.region.end.side = side;
+    pub fn end(&mut self) -> &mut Anchor {
+        &mut self.region.end
     }
 
     pub fn rotate(
@@ -231,6 +207,24 @@ impl Selection {
             },
             SelectionType::Semantic | SelectionType::Lines => false,
         }
+    }
+
+    /// Expand selection sides to include all cells.
+    pub fn include_all(&mut self) {
+        let (start, end) = (self.region.start.point, self.region.end.point);
+        let (start_side, end_side) = match self.ty {
+            SelectionType::Block
+                if start.col > end.col || (start.col == end.col && start.line < end.line) =>
+            {
+                (Side::Right, Side::Left)
+            },
+            SelectionType::Block => (Side::Left, Side::Right),
+            _ if Self::points_need_swap(start, end) => (Side::Right, Side::Left),
+            _ => (Side::Left, Side::Right),
+        };
+
+        self.region.start.side = start_side;
+        self.region.end.side = end_side;
     }
 
     /// Convert selection to grid coordinates.
@@ -392,7 +386,8 @@ impl Selection {
 /// look like [ B] and [E ].
 #[cfg(test)]
 mod tests {
-    use super::{Selection, SelectionRange};
+    use super::*;
+
     use crate::clipboard::Clipboard;
     use crate::config::MockConfig;
     use crate::event::{Event, EventListener};
@@ -425,8 +420,8 @@ mod tests {
     #[test]
     fn single_cell_left_to_right() {
         let location = Point { line: 0, col: Column(0) };
-        let mut selection = Selection::simple(location, Side::Left);
-        selection.update(location, Side::Right);
+        let mut selection = Selection::new(SelectionType::Simple, location, Side::Left);
+        *selection.end() = Anchor::new(location, Side::Right);
 
         assert_eq!(selection.to_range(&term(1, 1)).unwrap(), SelectionRange {
             start: location,
@@ -443,8 +438,8 @@ mod tests {
     #[test]
     fn single_cell_right_to_left() {
         let location = Point { line: 0, col: Column(0) };
-        let mut selection = Selection::simple(location, Side::Right);
-        selection.update(location, Side::Left);
+        let mut selection = Selection::new(SelectionType::Simple, location, Side::Right);
+        *selection.end() = Anchor::new(location, Side::Left);
 
         assert_eq!(selection.to_range(&term(1, 1)).unwrap(), SelectionRange {
             start: location,
@@ -460,8 +455,9 @@ mod tests {
     /// 3. [ B][E ]
     #[test]
     fn between_adjacent_cells_left_to_right() {
-        let mut selection = Selection::simple(Point::new(0, Column(0)), Side::Right);
-        selection.update(Point::new(0, Column(1)), Side::Left);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(0, Column(0)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Left);
 
         assert_eq!(selection.to_range(&term(2, 1)), None);
     }
@@ -473,8 +469,9 @@ mod tests {
     /// 3. [ E][B ]
     #[test]
     fn between_adjacent_cells_right_to_left() {
-        let mut selection = Selection::simple(Point::new(0, Column(1)), Side::Left);
-        selection.update(Point::new(0, Column(0)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(0, Column(1)), Side::Left);
+        *selection.end() = Anchor::new(Point::new(0, Column(0)), Side::Right);
 
         assert_eq!(selection.to_range(&term(2, 1)), None);
     }
@@ -489,8 +486,9 @@ mod tests {
     ///     [XX][XE][  ][  ][  ]
     #[test]
     fn across_adjacent_lines_upward_final_cell_exclusive() {
-        let mut selection = Selection::simple(Point::new(1, Column(1)), Side::Right);
-        selection.update(Point::new(0, Column(1)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(1, Column(1)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Right);
 
         assert_eq!(selection.to_range(&term(5, 2)).unwrap(), SelectionRange {
             start: Point::new(1, Column(2)),
@@ -511,9 +509,10 @@ mod tests {
     ///     [XX][XB][  ][  ][  ]
     #[test]
     fn selection_bigger_then_smaller() {
-        let mut selection = Selection::simple(Point::new(0, Column(1)), Side::Right);
-        selection.update(Point::new(1, Column(1)), Side::Right);
-        selection.update(Point::new(1, Column(0)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(0, Column(1)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(1, Column(1)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(1, Column(0)), Side::Right);
 
         assert_eq!(selection.to_range(&term(5, 2)).unwrap(), SelectionRange {
             start: Point::new(1, Column(1)),
@@ -526,8 +525,9 @@ mod tests {
     fn line_selection() {
         let num_lines = 10;
         let num_cols = 5;
-        let mut selection = Selection::lines(Point::new(0, Column(1)));
-        selection.update(Point::new(5, Column(1)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Lines, Point::new(0, Column(1)), Side::Left);
+        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -541,8 +541,9 @@ mod tests {
     fn semantic_selection() {
         let num_lines = 10;
         let num_cols = 5;
-        let mut selection = Selection::semantic(Point::new(0, Column(3)));
-        selection.update(Point::new(5, Column(1)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Semantic, Point::new(0, Column(3)), Side::Left);
+        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -556,8 +557,9 @@ mod tests {
     fn simple_selection() {
         let num_lines = 10;
         let num_cols = 5;
-        let mut selection = Selection::simple(Point::new(0, Column(3)), Side::Right);
-        selection.update(Point::new(5, Column(1)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(0, Column(3)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -571,8 +573,9 @@ mod tests {
     fn block_selection() {
         let num_lines = 10;
         let num_cols = 5;
-        let mut selection = Selection::block(Point::new(0, Column(3)), Side::Right);
-        selection.update(Point::new(5, Column(1)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Block, Point::new(0, Column(3)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -584,27 +587,29 @@ mod tests {
 
     #[test]
     fn simple_is_empty() {
-        let mut selection = Selection::simple(Point::new(0, Column(0)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(0, Column(0)), Side::Right);
         assert!(selection.is_empty());
-        selection.update(Point::new(0, Column(1)), Side::Left);
+        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Left);
         assert!(selection.is_empty());
-        selection.update(Point::new(1, Column(0)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(1, Column(0)), Side::Right);
         assert!(!selection.is_empty());
     }
 
     #[test]
     fn block_is_empty() {
-        let mut selection = Selection::block(Point::new(0, Column(0)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Block, Point::new(0, Column(0)), Side::Right);
         assert!(selection.is_empty());
-        selection.update(Point::new(0, Column(1)), Side::Left);
+        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Left);
         assert!(selection.is_empty());
-        selection.update(Point::new(0, Column(1)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Right);
         assert!(!selection.is_empty());
-        selection.update(Point::new(1, Column(0)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(1, Column(0)), Side::Right);
         assert!(selection.is_empty());
-        selection.update(Point::new(1, Column(1)), Side::Left);
+        *selection.end() = Anchor::new(Point::new(1, Column(1)), Side::Left);
         assert!(selection.is_empty());
-        selection.update(Point::new(1, Column(1)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(1, Column(1)), Side::Right);
         assert!(!selection.is_empty());
     }
 
@@ -612,8 +617,9 @@ mod tests {
     fn rotate_in_region_up() {
         let num_lines = 10;
         let num_cols = 5;
-        let mut selection = Selection::simple(Point::new(2, Column(3)), Side::Right);
-        selection.update(Point::new(5, Column(1)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(2, Column(3)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
         selection =
             selection.rotate(num_lines, num_cols, &(Line(1)..Line(num_lines - 1)), 4).unwrap();
 
@@ -628,8 +634,9 @@ mod tests {
     fn rotate_in_region_down() {
         let num_lines = 10;
         let num_cols = 5;
-        let mut selection = Selection::simple(Point::new(5, Column(3)), Side::Right);
-        selection.update(Point::new(8, Column(1)), Side::Left);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point::new(5, Column(3)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(8, Column(1)), Side::Left);
         selection =
             selection.rotate(num_lines, num_cols, &(Line(1)..Line(num_lines - 1)), -5).unwrap();
 
@@ -644,8 +651,9 @@ mod tests {
     fn rotate_in_region_up_block() {
         let num_lines = 10;
         let num_cols = 5;
-        let mut selection = Selection::block(Point::new(2, Column(3)), Side::Right);
-        selection.update(Point::new(5, Column(1)), Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Block, Point::new(2, Column(3)), Side::Right);
+        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
         selection =
             selection.rotate(num_lines, num_cols, &(Line(1)..Line(num_lines - 1)), 4).unwrap();
 

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -28,12 +28,12 @@ use crate::term::{Search, Term};
 /// A Point and side within that point.
 #[derive(Debug, Copy, Clone, PartialEq)]
 struct Anchor {
-    pub point: Point<usize>,
-    pub side: Side,
+    point: Point<usize>,
+    side: Side,
 }
 
 impl Anchor {
-    pub fn new(point: Point<usize>, side: Side) -> Anchor {
+    fn new(point: Point<usize>, side: Side) -> Anchor {
         Anchor { point, side }
     }
 }

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -27,7 +27,7 @@ use crate::term::{Search, Term};
 
 /// A Point and side within that point.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Anchor {
+struct Anchor {
     pub point: Point<usize>,
     pub side: Side,
 }
@@ -94,8 +94,8 @@ pub enum SelectionType {
 /// [`update`]: enum.Selection.html#method.update
 #[derive(Debug, Clone, PartialEq)]
 pub struct Selection {
-    region: Range<Anchor>,
     pub ty: SelectionType,
+    region: Range<Anchor>,
 }
 
 impl Selection {
@@ -106,12 +106,8 @@ impl Selection {
         }
     }
 
-    pub fn start(&mut self) -> &mut Anchor {
-        &mut self.region.start
-    }
-
-    pub fn end(&mut self) -> &mut Anchor {
-        &mut self.region.end
+    pub fn update(&mut self, point: Point<usize>, side: Side) {
+        self.region.end = Anchor::new(point, side);
     }
 
     pub fn rotate(
@@ -421,7 +417,7 @@ mod tests {
     fn single_cell_left_to_right() {
         let location = Point { line: 0, col: Column(0) };
         let mut selection = Selection::new(SelectionType::Simple, location, Side::Left);
-        *selection.end() = Anchor::new(location, Side::Right);
+        selection.update(location, Side::Right);
 
         assert_eq!(selection.to_range(&term(1, 1)).unwrap(), SelectionRange {
             start: location,
@@ -439,7 +435,7 @@ mod tests {
     fn single_cell_right_to_left() {
         let location = Point { line: 0, col: Column(0) };
         let mut selection = Selection::new(SelectionType::Simple, location, Side::Right);
-        *selection.end() = Anchor::new(location, Side::Left);
+        selection.update(location, Side::Left);
 
         assert_eq!(selection.to_range(&term(1, 1)).unwrap(), SelectionRange {
             start: location,
@@ -457,7 +453,7 @@ mod tests {
     fn between_adjacent_cells_left_to_right() {
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(0, Column(0)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Left);
+        selection.update(Point::new(0, Column(1)), Side::Left);
 
         assert_eq!(selection.to_range(&term(2, 1)), None);
     }
@@ -471,7 +467,7 @@ mod tests {
     fn between_adjacent_cells_right_to_left() {
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(0, Column(1)), Side::Left);
-        *selection.end() = Anchor::new(Point::new(0, Column(0)), Side::Right);
+        selection.update(Point::new(0, Column(0)), Side::Right);
 
         assert_eq!(selection.to_range(&term(2, 1)), None);
     }
@@ -488,7 +484,7 @@ mod tests {
     fn across_adjacent_lines_upward_final_cell_exclusive() {
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(1, Column(1)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Right);
+        selection.update(Point::new(0, Column(1)), Side::Right);
 
         assert_eq!(selection.to_range(&term(5, 2)).unwrap(), SelectionRange {
             start: Point::new(1, Column(2)),
@@ -511,8 +507,8 @@ mod tests {
     fn selection_bigger_then_smaller() {
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(0, Column(1)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(1, Column(1)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(1, Column(0)), Side::Right);
+        selection.update(Point::new(1, Column(1)), Side::Right);
+        selection.update(Point::new(1, Column(0)), Side::Right);
 
         assert_eq!(selection.to_range(&term(5, 2)).unwrap(), SelectionRange {
             start: Point::new(1, Column(1)),
@@ -527,7 +523,7 @@ mod tests {
         let num_cols = 5;
         let mut selection =
             Selection::new(SelectionType::Lines, Point::new(0, Column(1)), Side::Left);
-        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
+        selection.update(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -543,7 +539,7 @@ mod tests {
         let num_cols = 5;
         let mut selection =
             Selection::new(SelectionType::Semantic, Point::new(0, Column(3)), Side::Left);
-        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
+        selection.update(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -559,7 +555,7 @@ mod tests {
         let num_cols = 5;
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(0, Column(3)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
+        selection.update(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -575,7 +571,7 @@ mod tests {
         let num_cols = 5;
         let mut selection =
             Selection::new(SelectionType::Block, Point::new(0, Column(3)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
+        selection.update(Point::new(5, Column(1)), Side::Right);
         selection = selection.rotate(num_lines, num_cols, &(Line(0)..Line(num_lines)), 7).unwrap();
 
         assert_eq!(selection.to_range(&term(num_cols, num_lines)).unwrap(), SelectionRange {
@@ -590,9 +586,9 @@ mod tests {
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(0, Column(0)), Side::Right);
         assert!(selection.is_empty());
-        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Left);
+        selection.update(Point::new(0, Column(1)), Side::Left);
         assert!(selection.is_empty());
-        *selection.end() = Anchor::new(Point::new(1, Column(0)), Side::Right);
+        selection.update(Point::new(1, Column(0)), Side::Right);
         assert!(!selection.is_empty());
     }
 
@@ -601,15 +597,15 @@ mod tests {
         let mut selection =
             Selection::new(SelectionType::Block, Point::new(0, Column(0)), Side::Right);
         assert!(selection.is_empty());
-        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Left);
+        selection.update(Point::new(0, Column(1)), Side::Left);
         assert!(selection.is_empty());
-        *selection.end() = Anchor::new(Point::new(0, Column(1)), Side::Right);
+        selection.update(Point::new(0, Column(1)), Side::Right);
         assert!(!selection.is_empty());
-        *selection.end() = Anchor::new(Point::new(1, Column(0)), Side::Right);
+        selection.update(Point::new(1, Column(0)), Side::Right);
         assert!(selection.is_empty());
-        *selection.end() = Anchor::new(Point::new(1, Column(1)), Side::Left);
+        selection.update(Point::new(1, Column(1)), Side::Left);
         assert!(selection.is_empty());
-        *selection.end() = Anchor::new(Point::new(1, Column(1)), Side::Right);
+        selection.update(Point::new(1, Column(1)), Side::Right);
         assert!(!selection.is_empty());
     }
 
@@ -619,7 +615,7 @@ mod tests {
         let num_cols = 5;
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(2, Column(3)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
+        selection.update(Point::new(5, Column(1)), Side::Right);
         selection =
             selection.rotate(num_lines, num_cols, &(Line(1)..Line(num_lines - 1)), 4).unwrap();
 
@@ -636,7 +632,7 @@ mod tests {
         let num_cols = 5;
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(5, Column(3)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(8, Column(1)), Side::Left);
+        selection.update(Point::new(8, Column(1)), Side::Left);
         selection =
             selection.rotate(num_lines, num_cols, &(Line(1)..Line(num_lines - 1)), -5).unwrap();
 
@@ -653,7 +649,7 @@ mod tests {
         let num_cols = 5;
         let mut selection =
             Selection::new(SelectionType::Block, Point::new(2, Column(3)), Side::Right);
-        *selection.end() = Anchor::new(Point::new(5, Column(1)), Side::Right);
+        selection.update(Point::new(5, Column(1)), Side::Right);
         selection =
             selection.rotate(num_lines, num_cols, &(Line(1)..Line(num_lines - 1)), 4).unwrap();
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1383,10 +1383,7 @@ impl<T> Term<T> {
         };
 
         let (text_color, cursor_color) = if keyboard_motion {
-            (
-                config.keyboard_motion_cursor_text_color(),
-                config.keyboard_motion_cursor_cursor_color(),
-            )
+            (config.keyboard_motion_cursor_text_color(), config.keyboard_motion_cursor_cursor_color())
         } else {
             let cursor_cursor_color = config.cursor_cursor_color().map(|c| self.colors[c]);
             (config.cursor_text_color(), cursor_cursor_color)
@@ -1398,7 +1395,10 @@ impl<T> Term<T> {
         RenderableCursor {
             text_color,
             cursor_color,
-            key: CursorKey { style: cursor_style, is_wide },
+            key: CursorKey {
+                style: cursor_style,
+                is_wide,
+            },
             point,
             rendered: false,
         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -31,8 +31,9 @@ use crate::event::{Event, EventListener};
 use crate::grid::{
     BidirectionalIterator, DisplayIter, Grid, GridCell, IndexRegion, Indexed, Scroll,
 };
-use crate::index::{self, Column, IndexRange, Line, Point};
-use crate::selection::{Selection, SelectionRange};
+use crate::index::{self, Column, IndexRange, Line, Point, Side};
+use crate::keyboard_motion::{KeyboardCursor, KeyboardMotion};
+use crate::selection::{Anchor, Selection, SelectionRange};
 use crate::term::cell::{Cell, Flags, LineLength};
 use crate::term::color::Rgb;
 
@@ -180,7 +181,17 @@ impl<T> Search for Term<T> {
     }
 }
 
-/// A key for caching cursor glyphs
+/// Cursor storing all information relevant for rendering.
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize)]
+struct RenderableCursor {
+    text_color: Option<Rgb>,
+    cursor_color: Option<Rgb>,
+    key: CursorKey,
+    point: Point,
+    rendered: bool,
+}
+
+/// A key for caching cursor glyphs.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Deserialize)]
 pub struct CursorKey {
     pub style: CursorStyle,
@@ -198,10 +209,7 @@ pub struct CursorKey {
 pub struct RenderableCellsIter<'a, C> {
     inner: DisplayIter<'a, Cell>,
     grid: &'a Grid<Cell>,
-    cursor: &'a Point,
-    cursor_offset: usize,
-    cursor_key: Option<CursorKey>,
-    cursor_style: CursorStyle,
+    cursor: RenderableCursor,
     config: &'a Config<C>,
     colors: &'a color::List,
     selection: Option<SelectionRange<Line>>,
@@ -216,12 +224,10 @@ impl<'a, C> RenderableCellsIter<'a, C> {
         term: &'b Term<T>,
         config: &'b Config<C>,
         selection: Option<SelectionRange>,
-        mut cursor_style: CursorStyle,
     ) -> RenderableCellsIter<'b, C> {
         let grid = &term.grid;
         let num_cols = grid.num_cols();
 
-        let cursor_offset = grid.num_lines().0 - term.cursor.point.line.0 - 1;
         let inner = grid.display_iter();
 
         let selection_range = selection.and_then(|span| {
@@ -242,29 +248,13 @@ impl<'a, C> RenderableCellsIter<'a, C> {
             Some(SelectionRange::new(start, end, span.is_block))
         });
 
-        // Load cursor glyph
-        let cursor = &term.cursor.point;
-        let cursor_visible = term.mode.contains(TermMode::SHOW_CURSOR) && grid.contains(cursor);
-        let cursor_key = if cursor_visible {
-            let is_wide =
-                grid[cursor].flags.contains(Flags::WIDE_CHAR) && (cursor.col + 1) < num_cols;
-            Some(CursorKey { style: cursor_style, is_wide })
-        } else {
-            // Use hidden cursor so text will not get inverted
-            cursor_style = CursorStyle::Hidden;
-            None
-        };
-
         RenderableCellsIter {
-            cursor,
-            cursor_offset,
+            cursor: term.renderable_cursor(config),
             grid,
             inner,
             selection: selection_range,
             config,
             colors: &term.colors,
-            cursor_key,
-            cursor_style,
         }
     }
 
@@ -274,6 +264,18 @@ impl<'a, C> RenderableCellsIter<'a, C> {
             Some(selection) => selection,
             None => return false,
         };
+
+        // Do not invert block cursor at selection boundaries
+        if self.cursor.key.style == CursorStyle::Block
+            && self.cursor.point == point
+            && (selection.start == point
+                || selection.end == point
+                || (selection.is_block
+                    && ((selection.start.line == point.line && selection.end.col == point.col)
+                        || (selection.end.line == point.line && selection.start.col == point.col))))
+        {
+            return false;
+        }
 
         // Point itself is selected
         if selection.contains(point.col, point.line) {
@@ -442,15 +444,34 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if self.cursor_offset == self.inner.offset() && self.inner.column() == self.cursor.col {
-                let selected = self.is_selected(Point::new(self.cursor.line, self.cursor.col));
+            if self.cursor.point.line == self.inner.line()
+                && self.cursor.point.col == self.inner.column()
+            {
+                let selected = self.is_selected(self.cursor.point);
 
-                // Handle cursor
-                if let Some(cursor_key) = self.cursor_key.take() {
+                // Handle cell below cursor
+                if self.cursor.rendered {
+                    let mut cell =
+                        RenderableCell::new(self.config, self.colors, self.inner.next()?, selected);
+
+                    if self.cursor.key.style == CursorStyle::Block {
+                        std::mem::swap(&mut cell.bg, &mut cell.fg);
+
+                        if let Some(color) = self.cursor.text_color {
+                            cell.fg = color;
+                        }
+                    }
+
+                    return Some(cell);
+                } else {
+                    // Handle cursor
+                    self.cursor.rendered = true;
+
+                    let buffer_point = self.grid.visible_to_buffer(self.cursor.point);
                     let cell = Indexed {
-                        inner: self.grid[self.cursor],
-                        column: self.cursor.col,
-                        // Using `self.cursor.line` leads to inconsitent cursor position when
+                        inner: self.grid[buffer_point.line][buffer_point.col],
+                        column: self.cursor.point.col,
+                        // Using `cursor.line` leads to inconsitent cursor position when
                         // scrolling. See https://github.com/alacritty/alacritty/issues/2570 for more
                         // info.
                         line: self.inner.line(),
@@ -459,26 +480,13 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                     let mut renderable_cell =
                         RenderableCell::new(self.config, self.colors, cell, selected);
 
-                    renderable_cell.inner = RenderableCellContent::Cursor(cursor_key);
+                    renderable_cell.inner = RenderableCellContent::Cursor(self.cursor.key);
 
-                    if let Some(color) = self.config.cursor_cursor_color() {
-                        renderable_cell.fg = RenderableCell::compute_bg_rgb(self.colors, color);
+                    if let Some(color) = self.cursor.cursor_color {
+                        renderable_cell.fg = color;
                     }
 
                     return Some(renderable_cell);
-                } else {
-                    let mut cell =
-                        RenderableCell::new(self.config, self.colors, self.inner.next()?, selected);
-
-                    if self.cursor_style == CursorStyle::Block {
-                        std::mem::swap(&mut cell.bg, &mut cell.fg);
-
-                        if let Some(color) = self.config.cursor_text_color() {
-                            cell.fg = color;
-                        }
-                    }
-
-                    return Some(cell);
                 }
             } else {
                 let cell = self.inner.next()?;
@@ -497,26 +505,27 @@ pub mod mode {
     use bitflags::bitflags;
 
     bitflags! {
-        pub struct TermMode: u16 {
-            const SHOW_CURSOR         = 0b0000_0000_0000_0001;
-            const APP_CURSOR          = 0b0000_0000_0000_0010;
-            const APP_KEYPAD          = 0b0000_0000_0000_0100;
-            const MOUSE_REPORT_CLICK  = 0b0000_0000_0000_1000;
-            const BRACKETED_PASTE     = 0b0000_0000_0001_0000;
-            const SGR_MOUSE           = 0b0000_0000_0010_0000;
-            const MOUSE_MOTION        = 0b0000_0000_0100_0000;
-            const LINE_WRAP           = 0b0000_0000_1000_0000;
-            const LINE_FEED_NEW_LINE  = 0b0000_0001_0000_0000;
-            const ORIGIN              = 0b0000_0010_0000_0000;
-            const INSERT              = 0b0000_0100_0000_0000;
-            const FOCUS_IN_OUT        = 0b0000_1000_0000_0000;
-            const ALT_SCREEN          = 0b0001_0000_0000_0000;
-            const MOUSE_DRAG          = 0b0010_0000_0000_0000;
-            const MOUSE_MODE          = 0b0010_0000_0100_1000;
-            const UTF8_MOUSE          = 0b0100_0000_0000_0000;
-            const ALTERNATE_SCROLL    = 0b1000_0000_0000_0000;
-            const ANY                 = 0b1111_1111_1111_1111;
+        pub struct TermMode: u32 {
             const NONE                = 0;
+            const SHOW_CURSOR         = 0b0000_0000_0000_0000_0001;
+            const APP_CURSOR          = 0b0000_0000_0000_0000_0010;
+            const APP_KEYPAD          = 0b0000_0000_0000_0000_0100;
+            const MOUSE_REPORT_CLICK  = 0b0000_0000_0000_0000_1000;
+            const BRACKETED_PASTE     = 0b0000_0000_0000_0001_0000;
+            const SGR_MOUSE           = 0b0000_0000_0000_0010_0000;
+            const MOUSE_MOTION        = 0b0000_0000_0000_0100_0000;
+            const LINE_WRAP           = 0b0000_0000_0000_1000_0000;
+            const LINE_FEED_NEW_LINE  = 0b0000_0000_0001_0000_0000;
+            const ORIGIN              = 0b0000_0000_0010_0000_0000;
+            const INSERT              = 0b0000_0000_0100_0000_0000;
+            const FOCUS_IN_OUT        = 0b0000_0000_1000_0000_0000;
+            const ALT_SCREEN          = 0b0000_0001_0000_0000_0000;
+            const MOUSE_DRAG          = 0b0000_0010_0000_0000_0000;
+            const MOUSE_MODE          = 0b0000_0010_0000_0100_1000;
+            const UTF8_MOUSE          = 0b0000_0100_0000_0000_0000;
+            const ALTERNATE_SCROLL    = 0b0000_1000_0000_0000_0000;
+            const KEYBOARD_MOTION     = 0b0001_0000_0000_0000_0000;
+            const ANY                 = std::u32::MAX;
         }
     }
 
@@ -730,113 +739,28 @@ impl VisualBell {
     }
 }
 
-pub struct Term<T> {
-    /// Terminal focus
-    pub is_focused: bool,
-
-    /// The grid
-    grid: Grid<Cell>,
-
-    /// Tracks if the next call to input will need to first handle wrapping.
-    /// This is true after the last column is set with the input function. Any function that
-    /// implicitly sets the line or column needs to set this to false to avoid wrapping twice.
-    /// input_needs_wrap ensures that cursor.col is always valid for use into indexing into
-    /// arrays. Without it we would have to sanitize cursor.col every time we used it.
-    input_needs_wrap: bool,
-
-    /// Alternate grid
-    alt_grid: Grid<Cell>,
-
-    /// Alt is active
-    alt: bool,
-
-    /// The cursor
-    cursor: Cursor,
-
-    /// The graphic character set, out of `charsets`, which ASCII is currently
-    /// being mapped to
-    active_charset: CharsetIndex,
-
-    /// Tabstops
-    tabs: TabStops,
-
-    /// Mode flags
-    mode: TermMode,
-
-    /// Scroll region.
-    ///
-    /// Range going from top to bottom of the terminal, indexed from the top of the viewport.
-    scroll_region: Range<Line>,
-
-    pub dirty: bool,
-
-    pub visual_bell: VisualBell,
-
-    /// Saved cursor from main grid
-    cursor_save: Cursor,
-
-    /// Saved cursor from alt grid
-    cursor_save_alt: Cursor,
-
-    semantic_escape_chars: String,
-
-    /// Colors used for rendering
-    colors: color::List,
-
-    /// Is color in `colors` modified or not
-    color_modified: [bool; color::COUNT],
-
-    /// Original colors from config
-    original_colors: color::List,
-
-    /// Current style of the cursor
-    cursor_style: Option<CursorStyle>,
-
-    /// Default style for resetting the cursor
-    default_cursor_style: CursorStyle,
-
-    /// Clipboard access coupled to the active window
-    clipboard: Clipboard,
-
-    /// Proxy for sending events to the event loop
-    event_proxy: T,
-
-    /// Current title of the window.
-    title: Option<String>,
-
-    /// Default title for resetting it.
-    default_title: String,
-
-    /// Whether to permit updating the terminal title.
-    dynamic_title: bool,
-
-    /// Stack of saved window titles. When a title is popped from this stack, the `title` for the
-    /// term is set, and the Glutin window's title attribute is changed through the event listener.
-    title_stack: Vec<Option<String>>,
-}
-
-/// Terminal size info
+/// Terminal size info.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq)]
 pub struct SizeInfo {
-    /// Terminal window width
+    /// Terminal window width.
     pub width: f32,
 
-    /// Terminal window height
+    /// Terminal window height.
     pub height: f32,
 
-    /// Width of individual cell
+    /// Width of individual cell.
     pub cell_width: f32,
 
-    /// Height of individual cell
+    /// Height of individual cell.
     pub cell_height: f32,
 
-    /// Horizontal window padding
+    /// Horizontal window padding.
     pub padding_x: f32,
 
-    /// Horizontal window padding
+    /// Horizontal window padding.
     pub padding_y: f32,
 
-    /// DPI factor of the current window
+    /// DPI factor of the current window.
     #[serde(default)]
     pub dpr: f64,
 }
@@ -871,6 +795,96 @@ impl SizeInfo {
             col: min(col, Column(self.cols().saturating_sub(1))),
         }
     }
+}
+
+pub struct Term<T> {
+    /// Terminal focus.
+    pub is_focused: bool,
+
+    /// The grid.
+    grid: Grid<Cell>,
+
+    /// Tracks if the next call to input will need to first handle wrapping.
+    /// This is true after the last column is set with the input function. Any function that
+    /// implicitly sets the line or column needs to set this to false to avoid wrapping twice.
+    /// input_needs_wrap ensures that cursor.col is always valid for use into indexing into
+    /// arrays. Without it we would have to sanitize cursor.col every time we used it.
+    input_needs_wrap: bool,
+
+    /// Alternate grid.
+    alt_grid: Grid<Cell>,
+
+    /// Alt is active.
+    alt: bool,
+
+    /// The cursor.
+    cursor: Cursor,
+
+    /// Cursor location for keyboard-driven motion.
+    pub keyboard_cursor: KeyboardCursor,
+
+    /// Index into `charsets`, pointing to what ASCII is currently being mapped to.
+    active_charset: CharsetIndex,
+
+    /// Tabstops.
+    tabs: TabStops,
+
+    /// Mode flags.
+    mode: TermMode,
+
+    /// Scroll region.
+    ///
+    /// Range going from top to bottom of the terminal, indexed from the top of the viewport.
+    scroll_region: Range<Line>,
+
+    pub dirty: bool,
+
+    pub visual_bell: VisualBell,
+
+    /// Saved cursor from main grid.
+    cursor_save: Cursor,
+
+    /// Saved cursor from alt grid.
+    cursor_save_alt: Cursor,
+
+    semantic_escape_chars: String,
+
+    /// Colors used for rendering.
+    colors: color::List,
+
+    /// Is color in `colors` modified or not.
+    color_modified: [bool; color::COUNT],
+
+    /// Original colors from config.
+    original_colors: color::List,
+
+    /// Current style of the cursor.
+    cursor_style: Option<CursorStyle>,
+
+    /// Default style for resetting the cursor.
+    default_cursor_style: CursorStyle,
+
+    /// Style of the keyboard motion cursor.
+    keyboard_motion_cursor_style: Option<CursorStyle>,
+
+    /// Clipboard access coupled to the active window
+    clipboard: Clipboard,
+
+    /// Proxy for sending events to the event loop.
+    event_proxy: T,
+
+    /// Current title of the window.
+    title: Option<String>,
+
+    /// Default title for resetting it.
+    default_title: String,
+
+    /// Whether to permit updating the terminal title.
+    dynamic_title: bool,
+
+    /// Stack of saved window titles. When a title is popped from this stack, the `title` for the
+    /// term is set, and the Glutin window's title attribute is changed through the event listener.
+    title_stack: Vec<Option<String>>,
 }
 
 impl<T> Term<T> {
@@ -920,6 +934,7 @@ impl<T> Term<T> {
             alt: false,
             active_charset: Default::default(),
             cursor: Default::default(),
+            keyboard_cursor: Default::default(),
             cursor_save: Default::default(),
             cursor_save_alt: Default::default(),
             tabs,
@@ -931,6 +946,7 @@ impl<T> Term<T> {
             semantic_escape_chars: config.selection.semantic_escape_chars().to_owned(),
             cursor_style: None,
             default_cursor_style: config.cursor.style,
+            keyboard_motion_cursor_style: config.cursor.keyboard_motion_style,
             dynamic_title: config.dynamic_title(),
             clipboard,
             event_proxy,
@@ -959,6 +975,7 @@ impl<T> Term<T> {
             self.mode.remove(TermMode::ALTERNATE_SCROLL);
         }
         self.default_cursor_style = config.cursor.style;
+        self.keyboard_motion_cursor_style = config.cursor.keyboard_motion_style;
 
         self.default_title = config.window.title.clone();
         self.dynamic_title = config.dynamic_title();
@@ -1105,13 +1122,7 @@ impl<T> Term<T> {
     pub fn renderable_cells<'b, C>(&'b self, config: &'b Config<C>) -> RenderableCellsIter<'_, C> {
         let selection = self.grid.selection.as_ref().and_then(|s| s.to_range(self));
 
-        let cursor = if self.is_focused || !config.cursor.unfocused_hollow() {
-            self.cursor_style.unwrap_or(self.default_cursor_style)
-        } else {
-            CursorStyle::HollowBlock
-        };
-
-        RenderableCellsIter::new(&self, config, selection, cursor)
+        RenderableCellsIter::new(&self, config, selection)
     }
 
     /// Resize terminal to new dimensions
@@ -1178,6 +1189,8 @@ impl<T> Term<T> {
         self.cursor_save.point.line = min(self.cursor_save.point.line, num_lines - 1);
         self.cursor_save_alt.point.col = min(self.cursor_save_alt.point.col, num_cols - 1);
         self.cursor_save_alt.point.line = min(self.cursor_save_alt.point.line, num_lines - 1);
+        self.keyboard_cursor.point.col = min(self.keyboard_cursor.point.col, num_cols - 1);
+        self.keyboard_cursor.point.line = min(self.keyboard_cursor.point.line, num_lines - 1);
 
         // Recreate tabs list
         self.tabs.resize(self.grid.num_cols());
@@ -1258,8 +1271,51 @@ impl<T> Term<T> {
         self.event_proxy.send_event(Event::Exit);
     }
 
+    #[inline]
     pub fn clipboard(&mut self) -> &mut Clipboard {
         &mut self.clipboard
+    }
+
+    /// Toggle the keyboard motion mode.
+    #[inline]
+    pub fn toggle_keyboard_mode(&mut self) {
+        self.mode ^= TermMode::KEYBOARD_MOTION;
+        self.grid.selection = None;
+
+        // Reset keyboard cursor position to match primary cursor
+        if self.mode.contains(TermMode::KEYBOARD_MOTION) {
+            let line = min(self.cursor.point.line + self.grid.display_offset(), self.lines() - 1);
+            self.keyboard_cursor = KeyboardCursor::new(Point::new(line, self.cursor.point.col));
+        }
+
+        self.dirty = true;
+    }
+
+    /// Move keyboard motion cursor.
+    #[inline]
+    pub fn keyboard_motion(&mut self, motion: KeyboardMotion)
+    where
+        T: EventListener,
+    {
+        // Move cursor
+        self.keyboard_cursor = self.keyboard_cursor.motion(self, motion);
+
+        // Update selection if one is active
+        let viewport_point = self.visible_to_buffer(self.keyboard_cursor.point);
+        if let Some(selection) = &mut self.grid.selection {
+            // Do not extend empty selections started by single mouse click
+            if !selection.is_empty() {
+                *selection.end() = Anchor::new(viewport_point, Side::Right);
+                selection.include_all();
+            }
+        }
+
+        self.dirty = true;
+    }
+
+    #[inline]
+    pub fn semantic_escape_chars(&self) -> &str {
+        &self.semantic_escape_chars
     }
 
     /// Insert a linebreak at the current cursor position.
@@ -1296,6 +1352,56 @@ impl<T> Term<T> {
         *cell = self.cursor.template;
         cell.c = self.cursor.charsets[self.active_charset].map(c);
         cell
+    }
+
+    /// Get render information about the active cursor.
+    fn renderable_cursor<C>(&self, config: &Config<C>) -> RenderableCursor {
+        let keyboard_motion = self.mode.contains(TermMode::KEYBOARD_MOTION);
+
+        let mut point = if keyboard_motion {
+            self.keyboard_cursor.point
+        } else {
+            let mut point = self.cursor.point;
+            point.line += self.grid.display_offset();
+            point
+        };
+
+        let hidden = !self.mode.contains(TermMode::SHOW_CURSOR) || point.line >= self.lines();
+        let cursor_style = if hidden && !keyboard_motion {
+            point.line = Line(0);
+            CursorStyle::Hidden
+        } else if !self.is_focused && config.cursor.unfocused_hollow() {
+            CursorStyle::HollowBlock
+        } else {
+            let cursor_style = self.cursor_style.unwrap_or(self.default_cursor_style);
+
+            if keyboard_motion {
+                self.keyboard_motion_cursor_style.unwrap_or(cursor_style)
+            } else {
+                cursor_style
+            }
+        };
+
+        let (text_color, cursor_color) = if keyboard_motion {
+            (config.keyboard_motion_cursor_text_color(), config.keyboard_motion_cursor_cursor_color())
+        } else {
+            let cursor_cursor_color = config.cursor_cursor_color().map(|c| self.colors[c]);
+            (config.cursor_text_color(), cursor_cursor_color)
+        };
+
+        let is_wide =
+            self.grid[&point].flags.contains(Flags::WIDE_CHAR) && point.col + 1 < self.cols();
+
+        RenderableCursor {
+            text_color,
+            cursor_color,
+            key: CursorKey {
+                style: cursor_style,
+                is_wide,
+            },
+            point,
+            rendered: false,
+        }
     }
 }
 
@@ -2184,7 +2290,7 @@ mod tests {
     use crate::event::{Event, EventListener};
     use crate::grid::{Grid, Scroll};
     use crate::index::{Column, Line, Point, Side};
-    use crate::selection::Selection;
+    use crate::selection::{Anchor, Selection, SelectionType};
     use crate::term::cell::{Cell, Flags};
     use crate::term::{SizeInfo, Term};
 
@@ -2222,17 +2328,29 @@ mod tests {
         mem::swap(&mut term.semantic_escape_chars, &mut escape_chars);
 
         {
-            *term.selection_mut() = Some(Selection::semantic(Point { line: 2, col: Column(1) }));
+            *term.selection_mut() = Some(Selection::new(
+                SelectionType::Semantic,
+                Point { line: 2, col: Column(1) },
+                Side::Left,
+            ));
             assert_eq!(term.selection_to_string(), Some(String::from("aa")));
         }
 
         {
-            *term.selection_mut() = Some(Selection::semantic(Point { line: 2, col: Column(4) }));
+            *term.selection_mut() = Some(Selection::new(
+                SelectionType::Semantic,
+                Point { line: 2, col: Column(4) },
+                Side::Left,
+            ));
             assert_eq!(term.selection_to_string(), Some(String::from("aaa")));
         }
 
         {
-            *term.selection_mut() = Some(Selection::semantic(Point { line: 1, col: Column(1) }));
+            *term.selection_mut() = Some(Selection::new(
+                SelectionType::Semantic,
+                Point { line: 1, col: Column(1) },
+                Side::Left,
+            ));
             assert_eq!(term.selection_to_string(), Some(String::from("aaa")));
         }
     }
@@ -2258,7 +2376,11 @@ mod tests {
 
         mem::swap(&mut term.grid, &mut grid);
 
-        *term.selection_mut() = Some(Selection::lines(Point { line: 0, col: Column(3) }));
+        *term.selection_mut() = Some(Selection::new(
+            SelectionType::Lines,
+            Point { line: 0, col: Column(3) },
+            Side::Left,
+        ));
         assert_eq!(term.selection_to_string(), Some(String::from("\"aa\"a\n")));
     }
 
@@ -2285,8 +2407,9 @@ mod tests {
 
         mem::swap(&mut term.grid, &mut grid);
 
-        let mut selection = Selection::simple(Point { line: 2, col: Column(0) }, Side::Left);
-        selection.update(Point { line: 0, col: Column(2) }, Side::Right);
+        let mut selection =
+            Selection::new(SelectionType::Simple, Point { line: 2, col: Column(0) }, Side::Left);
+        *selection.end() = Anchor::new(Point { line: 0, col: Column(2) }, Side::Right);
         *term.selection_mut() = Some(selection);
         assert_eq!(term.selection_to_string(), Some("aaa\n\naaa\n".into()));
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1140,12 +1140,12 @@ impl<T> Term<T> {
         self.grid.selection = None;
         self.alt_grid.selection = None;
 
-        // Should not allow less than 1 col, causes all sorts of checks to be required.
+        // Should not allow less than 2 cols, causes all sorts of checks to be required.
         if num_cols <= Column(1) {
             num_cols = Column(2);
         }
 
-        // Should not allow less than 1 line, causes all sorts of checks to be required.
+        // Should not allow less than 2 lines, causes all sorts of checks to be required.
         if num_lines <= Line(1) {
             num_lines = Line(2);
         }
@@ -1397,8 +1397,15 @@ impl<T> Term<T> {
             (config.cursor_text_color(), cursor_cursor_color)
         };
 
-        let is_wide =
-            self.grid[&point].flags.contains(Flags::WIDE_CHAR) && point.col + 1 < self.cols();
+        let cell = self.grid[&point];
+        let prev = point.sub(self.cols().0, 1);
+        let prev_cell = self.grid[&prev];
+        let is_wide = cell.flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER);
+        if cell.flags.contains(Flags::WIDE_CHAR_SPACER)
+            && prev_cell.flags.contains(Flags::WIDE_CHAR)
+        {
+            point = prev;
+        }
 
         RenderableCursor {
             text_color,

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1356,7 +1356,7 @@ impl<T> Term<T> {
         cell
     }
 
-    /// Get render information about the active cursor.
+    /// Get rendering information about the active cursor.
     fn renderable_cursor<C>(&self, config: &Config<C>) -> RenderableCursor {
         let keyboard_motion = self.mode.contains(TermMode::KEYBOARD_MOTION);
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1297,6 +1297,11 @@ impl<T> Term<T> {
     where
         T: EventListener,
     {
+        // Require keyboard motion mode to be active
+        if !self.mode.contains(TermMode::KEYBOARD_MOTION) {
+            return;
+        }
+
         // Move cursor
         self.keyboard_cursor = self.keyboard_cursor.motion(self, motion);
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -33,7 +33,7 @@ use crate::grid::{
 };
 use crate::index::{self, Column, IndexRange, Line, Point, Side};
 use crate::keyboard_motion::{KeyboardCursor, KeyboardMotion};
-use crate::selection::{Anchor, Selection, SelectionRange};
+use crate::selection::{Selection, SelectionRange};
 use crate::term::cell::{Cell, Flags, LineLength};
 use crate::term::color::Rgb;
 
@@ -1310,7 +1310,7 @@ impl<T> Term<T> {
         if let Some(selection) = &mut self.grid.selection {
             // Do not extend empty selections started by single mouse click
             if !selection.is_empty() {
-                *selection.end() = Anchor::new(viewport_point, Side::Right);
+                selection.update(viewport_point, Side::Right);
                 selection.include_all();
             }
         }
@@ -2304,7 +2304,7 @@ mod tests {
     use crate::event::{Event, EventListener};
     use crate::grid::{Grid, Scroll};
     use crate::index::{Column, Line, Point, Side};
-    use crate::selection::{Anchor, Selection, SelectionType};
+    use crate::selection::{Selection, SelectionType};
     use crate::term::cell::{Cell, Flags};
     use crate::term::{SizeInfo, Term};
 
@@ -2423,7 +2423,7 @@ mod tests {
 
         let mut selection =
             Selection::new(SelectionType::Simple, Point { line: 2, col: Column(0) }, Side::Left);
-        *selection.end() = Anchor::new(Point { line: 0, col: Column(2) }, Side::Right);
+        selection.update(Point { line: 0, col: Column(2) }, Side::Right);
         *term.selection_mut() = Some(selection);
         assert_eq!(term.selection_to_string(), Some("aaa\n\naaa\n".into()));
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1383,7 +1383,10 @@ impl<T> Term<T> {
         };
 
         let (text_color, cursor_color) = if keyboard_motion {
-            (config.keyboard_motion_cursor_text_color(), config.keyboard_motion_cursor_cursor_color())
+            (
+                config.keyboard_motion_cursor_text_color(),
+                config.keyboard_motion_cursor_cursor_color(),
+            )
         } else {
             let cursor_cursor_color = config.cursor_cursor_color().map(|c| self.colors[c]);
             (config.cursor_text_color(), cursor_cursor_color)
@@ -1395,10 +1398,7 @@ impl<T> Term<T> {
         RenderableCursor {
             text_color,
             cursor_color,
-            key: CursorKey {
-                style: cursor_style,
-                is_wide,
-            },
+            key: CursorKey { style: cursor_style, is_wide },
             point,
             rendered: false,
         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1397,15 +1397,17 @@ impl<T> Term<T> {
             (config.cursor_text_color(), cursor_cursor_color)
         };
 
-        let cell = self.grid[&point];
-        let prev = point.sub(self.cols().0, 1);
-        let prev_cell = self.grid[&prev];
-        let is_wide = cell.flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER);
-        if cell.flags.contains(Flags::WIDE_CHAR_SPACER)
-            && prev_cell.flags.contains(Flags::WIDE_CHAR)
+        // Expand across wide cell when inside wide char or spacer
+        let buffer_point = self.visible_to_buffer(point);
+        let cell = self.grid[buffer_point.line][buffer_point.col];
+        let is_wide = if cell.flags.contains(Flags::WIDE_CHAR_SPACER)
+            && self.grid[buffer_point.line][buffer_point.col - 1].flags.contains(Flags::WIDE_CHAR)
         {
-            point = prev;
-        }
+            point.col -= 1;
+            true
+        } else {
+            cell.flags.contains(Flags::WIDE_CHAR)
+        };
 
         RenderableCursor {
             text_color,

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -139,7 +139,7 @@ impl ViModeCursor {
         }
 
         scroll_to_point(term, buffer_point);
-        self.point = term.buffer_to_visible(buffer_point).unwrap_or_default().into();
+        self.point = term.grid().clamp_buffer_to_visible(buffer_point);
 
         self
     }

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -53,11 +53,11 @@ pub enum ViMotion {
 
 /// Cursor tracking vi mode position.
 #[derive(Default, Copy, Clone)]
-pub struct ViCursor {
+pub struct ViModeCursor {
     pub point: Point,
 }
 
-impl ViCursor {
+impl ViModeCursor {
     pub fn new(point: Point) -> Self {
         Self { point }
     }
@@ -124,17 +124,11 @@ impl ViCursor {
                 let line = display_offset;
                 let col = first_occupied_in_line(term, line).unwrap_or_default().col;
                 buffer_point = Point::new(line, col);
-            }
+            },
             ViMotion::SemanticLeft => buffer_point = semantic(term, buffer_point, true, true),
-            ViMotion::SemanticRight => {
-                buffer_point = semantic(term, buffer_point, false, true)
-            },
-            ViMotion::SemanticLeftEnd => {
-                buffer_point = semantic(term, buffer_point, true, false)
-            },
-            ViMotion::SemanticRightEnd => {
-                buffer_point = semantic(term, buffer_point, false, false)
-            },
+            ViMotion::SemanticRight => buffer_point = semantic(term, buffer_point, false, true),
+            ViMotion::SemanticLeftEnd => buffer_point = semantic(term, buffer_point, true, false),
+            ViMotion::SemanticRightEnd => buffer_point = semantic(term, buffer_point, false, false),
             ViMotion::WordLeft => buffer_point = word(term, buffer_point, true, true),
             ViMotion::WordRight => buffer_point = word(term, buffer_point, false, true),
             ViMotion::WordLeftEnd => buffer_point = word(term, buffer_point, true, false),
@@ -447,7 +441,7 @@ mod tests {
     fn motion_simple() {
         let mut term = term();
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::Right);
         assert_eq!(cursor.point, Point::new(Line(0), Column(1)));
@@ -472,11 +466,11 @@ mod tests {
         term.grid_mut()[Line(0)][Column(2)].flags.insert(Flags::WIDE_CHAR_SPACER);
         term.grid_mut()[Line(0)][Column(3)].c = 'a';
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(1)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(1)));
         cursor = cursor.motion(&mut term, ViMotion::Right);
         assert_eq!(cursor.point, Point::new(Line(0), Column(3)));
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(2)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(2)));
         cursor = cursor.motion(&mut term, ViMotion::Left);
         assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
     }
@@ -485,7 +479,7 @@ mod tests {
     fn motion_start_end() {
         let mut term = term();
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::Last);
         assert_eq!(cursor.point, Point::new(Line(0), Column(19)));
@@ -506,7 +500,7 @@ mod tests {
         term.grid_mut()[Line(2)][Column(0)].c = 'z';
         term.grid_mut()[Line(2)][Column(1)].c = ' ';
 
-        let mut cursor = ViCursor::new(Point::new(Line(2), Column(1)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(2), Column(1)));
 
         cursor = cursor.motion(&mut term, ViMotion::FirstOccupied);
         assert_eq!(cursor.point, Point::new(Line(2), Column(0)));
@@ -519,7 +513,7 @@ mod tests {
     fn motion_high_middle_low() {
         let mut term = term();
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::High);
         assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
@@ -538,7 +532,7 @@ mod tests {
         term.grid_mut()[Line(0)][Column(1)].c = 'x';
         term.grid_mut()[Line(0)][Column(2)].c = ')';
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::Bracket);
         assert_eq!(cursor.point, Point::new(Line(0), Column(2)));
@@ -574,7 +568,7 @@ mod tests {
     fn motion_semantic_right_end() {
         let mut term = motion_semantic_term();
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::SemanticRightEnd);
         assert_eq!(cursor.point, Point::new(Line(0), Column(3)));
@@ -602,7 +596,7 @@ mod tests {
     fn motion_semantic_left_start() {
         let mut term = motion_semantic_term();
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(15)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(15)));
 
         cursor = cursor.motion(&mut term, ViMotion::SemanticLeft);
         assert_eq!(cursor.point, Point::new(Line(0), Column(13)));
@@ -630,7 +624,7 @@ mod tests {
     fn motion_semantic_right_start() {
         let mut term = motion_semantic_term();
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::SemanticRight);
         assert_eq!(cursor.point, Point::new(Line(0), Column(2)));
@@ -658,7 +652,7 @@ mod tests {
     fn motion_semantic_left_end() {
         let mut term = motion_semantic_term();
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(15)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(15)));
 
         cursor = cursor.motion(&mut term, ViMotion::SemanticLeftEnd);
         assert_eq!(cursor.point, Point::new(Line(0), Column(13)));
@@ -687,7 +681,7 @@ mod tests {
         let mut term = term();
         term.grid_mut().scroll_up(&(Line(0)..Line(20)), Line(5), &Default::default());
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::SemanticLeft);
         assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
@@ -718,11 +712,11 @@ mod tests {
         term.grid_mut()[Line(0)][Column(4)].c = ' ';
         term.grid_mut()[Line(0)][Column(5)].c = 'a';
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(2)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(2)));
         cursor = cursor.motion(&mut term, ViMotion::SemanticRight);
         assert_eq!(cursor.point, Point::new(Line(0), Column(5)));
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(3)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(3)));
         cursor = cursor.motion(&mut term, ViMotion::SemanticLeft);
         assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
     }
@@ -737,7 +731,7 @@ mod tests {
         term.grid_mut()[Line(0)][Column(4)].c = 'a';
         term.grid_mut()[Line(0)][Column(5)].c = ';';
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::WordRightEnd);
         assert_eq!(cursor.point, Point::new(Line(0), Column(1)));
@@ -763,7 +757,7 @@ mod tests {
         let mut term = term();
         term.grid_mut().scroll_up(&(Line(0)..Line(20)), Line(5), &Default::default());
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(0)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(0)));
 
         cursor = cursor.motion(&mut term, ViMotion::WordLeft);
         assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
@@ -794,11 +788,11 @@ mod tests {
         term.grid_mut()[Line(0)][Column(4)].c = ' ';
         term.grid_mut()[Line(0)][Column(5)].c = 'a';
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(2)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(2)));
         cursor = cursor.motion(&mut term, ViMotion::WordRight);
         assert_eq!(cursor.point, Point::new(Line(0), Column(5)));
 
-        let mut cursor = ViCursor::new(Point::new(Line(0), Column(3)));
+        let mut cursor = ViModeCursor::new(Point::new(Line(0), Column(3)));
         cursor = cursor.motion(&mut term, ViMotion::WordLeft);
         assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
     }

--- a/extra/linux/redhat/alacritty.spec
+++ b/extra/linux/redhat/alacritty.spec
@@ -7,7 +7,7 @@ URL:           https://github.com/alacritty/alacritty
 VCS:           https://github.com/alacritty/alacritty.git
 Source:        alacritty-%{version}.tar
 
-BuildRequires: rust >= 1.37.0
+BuildRequires: rust >= 1.39.0
 BuildRequires: cargo
 BuildRequires: cmake
 BuildRequires: freetype-devel


### PR DESCRIPTION
This implements a basic mode for navigating inside of Alacritty's
history with keyboard bindings. They're bound by default to vi's motion
shortcuts but are fully customizable. Since this relies on key bindings
only single key bindings are currently supported (so no `ge`, or
repetition).

Other than navigating the history and moving the viewport, this mode
should enable making use of all available selection modes to copy
content to the clipboard and launch URLs below the cursor.

This also changes the rendering of the block cursor at the side of
selections, since previously it could be inverted to be completely
invisible. Since that would have caused some troubles with this keyboard
selection mode, the block cursor now is no longer inverted when it is at
the edges of a selection.

Fixes #262.
