### PR TITLE
Revert "Fix backspace deleting chars when IME is open"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize of bitmap fonts
 - Crash when using bitmap font with `embeddedbitmap` set to `false`
 - Inconsistent fontconfig fallback
-- Backspace deleting characters while IME is open on macOS
 - Handling of OpenType variable fonts
 - Expansion of block-selection on partially selected full-width glyphs
 - Minimize action only works with decorations on macOS

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -287,6 +287,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         PageDown; Action::Esc("\x1b[6~".into());
         PageDown, ModifiersState::SHIFT, +TermMode::ALT_SCREEN; Action::Esc("\x1b[6;2~".into());
         Tab,  ModifiersState::SHIFT; Action::Esc("\x1b[Z".into());
+        Back; Action::Esc("\x7f".into());
         Back, ModifiersState::ALT; Action::Esc("\x1b\x7f".into());
         Insert; Action::Esc("\x1b[2~".into());
         Delete; Action::Esc("\x1b[3~".into());
@@ -405,7 +406,6 @@ fn common_keybindings() -> Vec<KeyBinding> {
         Add,      ModifiersState::CTRL;  Action::IncreaseFontSize;
         Subtract, ModifiersState::CTRL;  Action::DecreaseFontSize;
         Minus,    ModifiersState::CTRL;  Action::DecreaseFontSize;
-        Back; Action::Esc("\x7f".into());
     )
 }
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -7,9 +7,6 @@ use std::path::PathBuf;
 #[cfg(windows)]
 use dirs;
 use log::{error, warn};
-use serde_yaml;
-#[cfg(not(windows))]
-use xdg;
 
 use alacritty_terminal::config::{Config as TermConfig, LOG_TARGET_CONFIG};
 

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -27,7 +27,6 @@ use std::sync::{Arc, Mutex};
 
 use glutin::event_loop::EventLoopProxy;
 use log::{self, Level};
-use time;
 
 use alacritty_terminal::event::Event;
 use alacritty_terminal::message_bar::Message;

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -19,8 +19,6 @@ use std::str;
 use log::{debug, trace};
 use serde::{Deserialize, Serialize};
 
-use vte;
-
 use crate::index::{Column, Line};
 use crate::term::color::Rgb;
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2181,8 +2181,6 @@ impl IndexMut<Column> for TabStops {
 mod tests {
     use std::mem;
 
-    use serde_json;
-
     use crate::ansi::{self, CharsetIndex, Handler, StandardCharset};
     use crate::clipboard::Clipboard;
     use crate::config::MockConfig;

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 //! tty related functionality
-use mio;
 use std::{env, io};
 
 use terminfo::Database;

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -18,7 +18,6 @@ use crate::config::{Config, Shell};
 use crate::event::OnResize;
 use crate::term::SizeInfo;
 use crate::tty::{ChildEvent, EventedPty, EventedReadWrite};
-use mio;
 
 use libc::{self, c_int, pid_t, winsize, TIOCSCTTY};
 use log::error;

--- a/winpty/build.rs
+++ b/winpty/build.rs
@@ -62,7 +62,7 @@ fn aquire_winpty_agent(out_path: &Path) {
 
     let mut archive = zip::ZipArchive::new(file).unwrap();
 
-    let target = match env::var("TARGET").unwrap().split("-").next().unwrap() {
+    let target = match env::var("TARGET").unwrap().split('-').next().unwrap() {
         "x86_64" => "x64",
         "i386" => "ia32",
         _ => panic!("architecture has no winpty binary"),


### PR DESCRIPTION
This reverts commit 7f4dce2ee04859fb0b48f15cf808b60065778703.

Originally it was assumed that macOS always sends the \x7f on backspace
anyways, however this is not true. It seems like the character on
backspace can change even within the same terminal session, so we need
to have our own binding to reliably set the correct binding.

A solution for #1606 should be implemented in cooperation with winit.

Fixes #3317.
Breaks #1606.
