### PR TITLE
Add selection expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Fontconfig embolden and matrix options
 - Opt-out compilation flag `winpty` to disable WinPTY support
 - Scrolling during selection when mouse is at top/bottom of window
-- Expanding existing selections using the Shift key
+- Expanding existing selections using the right mouse button
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Fontconfig embolden and matrix options
 - Opt-out compilation flag `winpty` to disable WinPTY support
 - Scrolling during selection when mouse is at top/bottom of window
+- Expanding existing selections using the Shift key
 
 ### Changed
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use glutin::dpi::PhysicalSize;
-use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, WindowEvent};
+use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, WindowEvent, MouseButton};
 use glutin::event_loop::{ControlFlow, EventLoop, EventLoopProxy, EventLoopWindowTarget};
 use glutin::platform::desktop::EventLoopExtDesktop;
 #[cfg(not(any(target_os = "macos", windows)))]
@@ -351,6 +351,7 @@ pub struct Mouse {
     pub middle_button_state: ElementState,
     pub right_button_state: ElementState,
     pub last_click_timestamp: Instant,
+    pub last_click_button: MouseButton,
     pub click_state: ClickState,
     pub scroll_px: f64,
     pub line: Line,
@@ -367,6 +368,7 @@ impl Default for Mouse {
             x: 0,
             y: 0,
             last_click_timestamp: Instant::now(),
+            last_click_button: MouseButton::Left,
             left_button_state: ElementState::Released,
             middle_button_state: ElementState::Released,
             right_button_state: ElementState::Released,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use glutin::dpi::PhysicalSize;
-use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, WindowEvent, MouseButton};
+use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, MouseButton, WindowEvent};
 use glutin::event_loop::{ControlFlow, EventLoop, EventLoopProxy, EventLoopWindowTarget};
 use glutin::platform::desktop::EventLoopExtDesktop;
 #[cfg(not(any(target_os = "macos", windows)))]

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -493,11 +493,16 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
             self.mouse_report(code, ElementState::Pressed);
         } else {
-            // Calculate time since the last click to handle double/triple clicks in normal mode.
+            // Reset click state if button has changed
+            if button != self.ctx.mouse().last_click_button {
+                self.ctx.mouse_mut().last_click_button = button;
+                self.ctx.mouse_mut().click_state = ClickState::None;
+            }
+
+            // Calculate time since the last click to handle double/triple clicks.
             let now = Instant::now();
             let elapsed = now - self.ctx.mouse().last_click_timestamp;
             self.ctx.mouse_mut().last_click_timestamp = now;
-            self.ctx.mouse_mut().last_click_button = button;
 
             // Load mouse point, treating message bar and padding as closest cell.
             let mouse = self.ctx.mouse();
@@ -1257,7 +1262,7 @@ mod tests {
             },
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
-        end_state: ClickState::None,
+        end_state: ClickState::Click,
     }
 
     test_clickstate! {
@@ -1321,7 +1326,7 @@ mod tests {
             },
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
-        end_state: ClickState::None,
+        end_state: ClickState::Click,
     }
 
     test_process_binding! {

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -46,13 +46,7 @@ impl Scheduler {
     }
 
     /// Schedule a new event.
-    pub fn schedule(
-        &mut self,
-        event: Event,
-        interval: Duration,
-        repeat: bool,
-        timer_id: TimerId,
-    ) {
+    pub fn schedule(&mut self, event: Event, interval: Duration, repeat: bool, timer_id: TimerId) {
         let deadline = Instant::now() + interval;
 
         // Get insert position in the schedule.


### PR DESCRIPTION
This allows for expanding the selection using the shift key. The new
selection type depends on the number of clicks and applies to both sides
of the selection.

Fixes #1554.