### PR TITLE
Add a new cursor style: Glass.

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -305,6 +305,7 @@
   #   - ▇ Block
   #   - _ Underline
   #   - | Beam
+  #   - ◻ Glass, inner part is semi transparent
   #style: Block
 
   # If this is `true`, the cursor will be rendered as a hollow box when the

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -41,10 +41,11 @@ pub fn get_cursor_glyph(
     }
 
     match cursor {
-        CursorStyle::HollowBlock => get_box_cursor_glyph(height, width, line_width),
+        CursorStyle::HollowBlock => get_box_cursor_glyph(height, width, line_width, 0),
         CursorStyle::Underline => get_underline_cursor_glyph(width, line_width),
         CursorStyle::Beam => get_beam_cursor_glyph(height, line_width),
         CursorStyle::Block => get_block_cursor_glyph(height, width),
+        CursorStyle::Glass => get_box_cursor_glyph(height, width, line_width, 150),
         CursorStyle::Hidden => RasterizedGlyph::default(),
     }
 }
@@ -82,7 +83,7 @@ pub fn get_beam_cursor_glyph(height: i32, line_width: i32) -> RasterizedGlyph {
 }
 
 // Returns a custom box cursor character
-pub fn get_box_cursor_glyph(height: i32, width: i32, line_width: i32) -> RasterizedGlyph {
+pub fn get_box_cursor_glyph(height: i32, width: i32, line_width: i32, fill: u8) -> RasterizedGlyph {
     // Create a new box outline rectangle
     let mut buf = Vec::with_capacity((width * height * 3) as usize);
     for y in 0..height {
@@ -94,7 +95,7 @@ pub fn get_box_cursor_glyph(height: i32, width: i32, line_width: i32) -> Rasteri
             {
                 buf.append(&mut vec![255u8; 3]);
             } else {
-                buf.append(&mut vec![0u8; 3]);
+                buf.append(&mut vec![fill; 3]);
             }
         }
     }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -351,6 +351,9 @@ pub enum CursorStyle {
     /// Cursor is a box like `☐`
     HollowBlock,
 
+    /// Like HollowBlock but the interior is semi-transparent
+    Glass,
+
     /// Invisible cursor
     Hidden,
 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -484,7 +484,8 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                     let mut cell =
                         RenderableCell::new(self.config, self.colors, self.inner.next()?, selected);
 
-                    if self.cursor_style == CursorStyle::Block {
+                    if self.cursor_style == CursorStyle::Block ||
+                        self.cursor_style == CursorStyle::Glass {
                         std::mem::swap(&mut cell.bg, &mut cell.fg);
 
                         if let Some(color) = self.config.cursor_text_color() {


### PR DESCRIPTION
Glass looks like just a Hollow cursor (unfocused window), except the
interior is semi-transparent.

Subjectively this is a fancier looking cursor compared to other variants. 

Disclaimer: I have 0 clue about Rust - - the change seemed easy enough and the compiler didn't really complain :)