### PR TITLE
Fix display_offset computation when on top of scrollback

### DIFF
--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -523,7 +523,7 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
         if region.start == Line(0) {
             // Update display offset when not pinned to active area
             if self.display_offset != 0 {
-                self.display_offset = min(self.display_offset + *positions, self.len() - num_lines);
+                self.display_offset = min(self.display_offset + *positions, self.max_scroll_limit);
             }
 
             self.increase_scroll_limit(*positions, template);


### PR DESCRIPTION
Regression was introduced in 4cc6421daa4ff5976ab43c67110a7a80a36541e5,
however it was working before only due to grid.len() bug.
