### PR TITLE
Cache FreeType faces instead of loading new

### DIFF
--- a/font/src/directwrite/mod.rs
+++ b/font/src/directwrite/mod.rs
@@ -113,7 +113,7 @@ impl crate::Rasterize for DirectWriteRasterizer {
         let face = font.create_font_face();
         self.fonts.push(face);
 
-        Ok(FontKey { token: (self.fonts.len() - 1) as u16 })
+        Ok(FontKey { token: (self.fonts.len() - 1) as u32 })
     }
 
     fn get_glyph(&mut self, glyph: GlyphKey) -> Result<RasterizedGlyph, Error> {

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -253,7 +253,7 @@ impl FreeTypeRasterizer {
             return Ok(primary_font_key);
         }
 
-        // Load font if we haven't loaded one
+        // Load font if we haven't loaded it yet
         if !self.faces.contains_key(&primary_font_key) {
             self.face_from_pattern(&primary_font, primary_font_key)
                 .and_then(|pattern| pattern.ok_or_else(|| Error::MissingFont(desc.to_owned())))?;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -321,14 +321,9 @@ impl FreeTypeRasterizer {
 
             trace!("Got font path={:?}", path);
 
-            let ft_face = if let Some(face) = self.ft_faces.get(&path) {
-                if let Some(ft_face) = face.upgrade() {
-                    ft_face
-                } else {
-                    self.load_ft_face(path, index)?
-                }
-            } else {
-                self.load_ft_face(path, index)?
+            let ft_face = match self.ft_faces.get(&path).and_then(|ft_face| ft_face.upgrade()) {
+                Some(ft_face) => ft_face,
+                None => self.load_ft_face(path, index)?,
             };
 
             // Get available pixel sizes if font isn't scalable.

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -21,7 +21,6 @@
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
 
 use std::fmt;
-use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -97,7 +96,7 @@ impl fmt::Display for FontDesc {
 /// Identifier for a Font for use in maps/etc
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct FontKey {
-    token: u16,
+    token: u32,
 }
 
 impl FontKey {
@@ -111,37 +110,11 @@ impl FontKey {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct GlyphKey {
     pub c: char,
     pub font_key: FontKey,
     pub size: Size,
-}
-
-impl Hash for GlyphKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        unsafe {
-            // This transmute is fine:
-            //
-            // - If GlyphKey ever becomes a different size, this will fail to compile
-            // - Result is being used for hashing and has no fields (it's a u64)
-            ::std::mem::transmute::<GlyphKey, u64>(*self)
-        }
-        .hash(state);
-    }
-}
-
-impl PartialEq for GlyphKey {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe {
-            // This transmute is fine:
-            //
-            // - If GlyphKey ever becomes a different size, this will fail to compile
-            // - Result is being used for equality checking and has no fields (it's a u64)
-            let other = ::std::mem::transmute::<GlyphKey, u64>(*other);
-            ::std::mem::transmute::<GlyphKey, u64>(*self).eq(&other)
-        }
-    }
 }
 
 /// Font size stored as integer


### PR DESCRIPTION
This commit introduces a cache for all loading faces, and replaces `Face` with `FaceLoadingProperties`, since we don't need to carry faces around, only loading options for them. It also removes `FontID` in favor of building `FontKey` right away.

I'd also like to test an idea of returning `FaceLoadingProperties` over `FontKey`, however it'll likely require to use `Rc` boxes or cloning them. So I'd like to test performance of the solution mentioned in this paragraph.

In addition, I think it'll be nice to add an API for rasterizer to remove curtain keys from use, since now they're kind of persistent, but I'm not sure that it's up to this PR.