### PR TITLE
Add custom merge strategy for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGELOG.md merge=union


### PR DESCRIPTION
The merge strategy `union` should hopefully reduce the number of
conflicts when trying to rebase the configuration file, since most of
the changes are simple additions anyways.
