### PR TITLE
Fix parser stopping at unknown modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modifier key combinations like `Ctrl + Q` not generating characters on macOS
 - Handling of URLs with single quotes
 - Parser reset between DCS escapes
+- Parser stopping at unknown DEC private modes/SGR character attributes
 
 ### Removed
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1022,10 +1022,7 @@ where
                 for arg in args {
                     match Mode::from_primitive(intermediate, *arg) {
                         Some(mode) => handler.unset_mode(mode),
-                        None => {
-                            unhandled!();
-                            return;
-                        },
+                        None => unhandled!(),
                     }
                 }
             },
@@ -1044,10 +1041,7 @@ where
                 for arg in args {
                     match Mode::from_primitive(intermediate, *arg) {
                         Some(mode) => handler.set_mode(mode),
-                        None => {
-                            unhandled!();
-                            return;
-                        },
+                        None => unhandled!(),
                     }
                 }
             },
@@ -1058,10 +1052,7 @@ where
                     for attr in attrs_from_sgr_parameters(args) {
                         match attr {
                             Some(attr) => handler.terminal_attribute(attr),
-                            None => {
-                                unhandled!();
-                                return;
-                            },
+                            None => unhandled!(),
                         }
                     }
                 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -893,6 +893,7 @@ where
         }
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[inline]
     fn csi_dispatch(
         &mut self,


### PR DESCRIPTION
This resolves an issue in the parser where it would stop as soon as the
first unknown value is encountered in private mode/sgr attribute
escapes.

Fixes #3339.
