### PR TITLE
Fix block selection including last column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handling of URLs with single quotes
 - Parser reset between DCS escapes
 - Parser stopping at unknown DEC private modes/SGR character attributes
+- Block selection appending duplicate newlines when last column is selected
 
 ### Removed
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -984,7 +984,12 @@ impl<T> Term<T> {
 
         if is_block {
             for line in (end.line + 1..=start.line).rev() {
-                res += &(self.line_to_string(line, start.col..end.col, start.col.0 != 0) + "\n");
+                res += &self.line_to_string(line, start.col..end.col, start.col.0 != 0);
+
+                // If the last column is included, newline is appended automatically
+                if end.col != self.cols() - 1 {
+                    res += "\n";
+                }
             }
             res += &self.line_to_string(end.line, start.col..end.col, true);
         } else {


### PR DESCRIPTION
The block selection will now only insert extra newline characters after
each line if the last line isn't already included. This resolves an
issue with duplicate newlines, since newlines are automatically appended
when the last column is part of a selection.

Fixes #3304.
