### PR TITLE
Explicitly state default TERM value in config

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -10,7 +10,7 @@
   # each instance of Alacritty. If it is not present, alacritty will
   # check the local terminfo database and use `alacritty` if it is
   # available, otherwise `xterm-256color` is used.
-  #TERM: xterm-256color
+  #TERM: alacritty
 
 #window:
   # Window dimensions (changes require restart)


### PR DESCRIPTION
Well, since the first value is `alacritty` and not `xterm-256color` we should likely explicitly state it in alacritty.yml placeholder value.