### PR TITLE
Add missing angled bracket to email

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alacritty"
 version = "0.4.2-dev"
-authors = ["Christian Duerr <contact@christianduerr.com", "Joe Wilm <joe@jwilm.com>"]
+authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "GPU-accelerated terminal emulator"
 readme = "../README.md"


### PR DESCRIPTION
Now `alacritty --help` will not look as strange.