### PR TITLE
Fix tabs across linewrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config reload creating alternate screen history instead of updating scrollback
 - Crash on Wayland compositors supporting `wl_seat` version 7+
 - Message bar not hiding after fixing wrong color value in config
+- Tabstops cleared on resize
+- Tabstops not breaking across lines
 
 ### Removed
 


### PR DESCRIPTION
This resolves an issue with tabs not breaking across line boundaries,
instead the characters would just all get written to the last column and
thus be lost.

It also tweaks the behavior of what happens when the terminal resizes
with the default tabspaces changed, using something like the `tabs`
program. Previously all tabstops would be reset to the default on
resize, which is what URxvt does. Now the tabspaces are kept and the new
columns are filled with the default tabstops, which emulates Termite.
