### PR TITLE
Don’t allow setting HollowBlock and Hidden cursors in config

### DIFF
--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -349,9 +349,11 @@ pub enum CursorStyle {
     Beam,
 
     /// Cursor is a box like `☐`
+    #[serde(skip)]
     HollowBlock,
 
     /// Invisible cursor
+    #[serde(skip)]
     Hidden,
 }
 


### PR DESCRIPTION
Fix #3367

I'm not sure if it warrants a Changelog entry, as users were not supposed to use these variants.