### PR TITLE
Remove `ref_test` option from configuration file

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -558,6 +558,3 @@
 
   # Print all received window events.
   #print_events: false
-
-  # Record all characters and escape sequences as test data.
-  #ref_test: false

--- a/alacritty_terminal/src/config/debug.rs
+++ b/alacritty_terminal/src/config/debug.rs
@@ -22,7 +22,7 @@ pub struct Debug {
     pub render_timer: bool,
 
     /// Record ref test
-    #[serde(deserialize_with = "failure_default")]
+    #[serde(skip)]
     pub ref_test: bool,
 }
 


### PR DESCRIPTION
This removes the `debug.ref_test` option from the configuration file,
after this change was originally requested from kchibisov in
https://github.com/alacritty/alacritty/pull/3396.

While this option is valueable for the CLI, it provides no value in the
configuration file.
