### PR TITLE
Change default colorscheme to Tomorrow Night

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mouse bindings for additional buttons need to be specified as a number not a string
 - Don't hide cursor on modifier press with `mouse.hide_when_typing` enabled
 - `Shift + Backspace` now sends `^?` instead of `^H`
+- Default color scheme is now `Tomorrow Night` with the bright colors of `Tomorrow Night Bright`
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -169,20 +169,20 @@
 # If `true`, bold text is drawn using the bright color variants.
 #draw_bold_text_with_bright_colors: false
 
-# Colors (Tomorrow Night Bright)
+# Colors (Tomorrow Night)
 #colors:
   # Default colors
   #primary:
-  #  background: '#000000'
-  #  foreground: '#eaeaea'
+  #  background: '#1d1f21'
+  #  foreground: '#c5c8c6'
 
     # Bright and dim foreground colors
     #
     # The dimmed foreground color is calculated automatically if it is not present.
     # If the bright foreground color is not set, or `draw_bold_text_with_bright_colors`
     # is `false`, the normal foreground color will be used.
-    #dim_foreground: '#9a9a9a'
-    #bright_foreground: '#ffffff'
+    #dim_foreground: '#828482'
+    #bright_foreground: '#eaeaea'
 
   # Cursor colors
   #
@@ -211,39 +211,39 @@
 
   # Normal colors
   #normal:
-  #  black:   '#000000'
-  #  red:     '#d54e53'
-  #  green:   '#b9ca4a'
-  #  yellow:  '#e6c547'
-  #  blue:    '#7aa6da'
-  #  magenta: '#c397d8'
-  #  cyan:    '#70c0ba'
-  #  white:   '#eaeaea'
+  #  black:   '#1d1f21'
+  #  red:     '#cc6666'
+  #  green:   '#b5bd68'
+  #  yellow:  '#f0c674'
+  #  blue:    '#81a2be'
+  #  magenta: '#b294bb'
+  #  cyan:    '#8abeb7'
+  #  white:   '#c5c8c6'
 
   # Bright colors
   #bright:
   #  black:   '#666666'
-  #  red:     '#ff3334'
-  #  green:   '#9ec400'
+  #  red:     '#d54e53'
+  #  green:   '#b9ca4a'
   #  yellow:  '#e7c547'
   #  blue:    '#7aa6da'
-  #  magenta: '#b77ee0'
-  #  cyan:    '#54ced6'
-  #  white:   '#ffffff'
+  #  magenta: '#c397d8'
+  #  cyan:    '#70c0b1'
+  #  white:   '#eaeaea'
 
   # Dim colors
   #
   # If the dim colors are not set, they will be calculated automatically based
   # on the `normal` colors.
   #dim:
-  #  black:   '#000000'
-  #  red:     '#8c3336'
-  #  green:   '#7a8530'
-  #  yellow:  '#97822e'
-  #  blue:    '#506d8f'
-  #  magenta: '#80638e'
-  #  cyan:    '#497e7a'
-  #  white:   '#9a9a9a'
+  #  black:   '#131415'
+  #  red:     '#864343'
+  #  green:   '#777c44'
+  #  yellow:  '#9e824c'
+  #  blue:    '#556a7d'
+  #  magenta: '#75617b'
+  #  cyan:    '#5b7d78'
+  #  white:   '#828482'
 
   # Indexed Colors
   #

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -117,11 +117,11 @@ impl Default for PrimaryColors {
 }
 
 fn default_background() -> Rgb {
-    Rgb { r: 0, g: 0, b: 0 }
+    Rgb { r: 0x1d, g: 0x1f, b: 0x21 }
 }
 
 fn default_foreground() -> Rgb {
-    Rgb { r: 0xea, g: 0xea, b: 0xea }
+    Rgb { r: 0xc5, g: 0xc8, b: 0xc6 }
 }
 
 /// The 8-colors sections of config.
@@ -151,14 +151,14 @@ struct NormalColors(AnsiColors);
 impl Default for NormalColors {
     fn default() -> Self {
         NormalColors(AnsiColors {
-            black: Rgb { r: 0x00, g: 0x00, b: 0x00 },
-            red: Rgb { r: 0xd5, g: 0x4e, b: 0x53 },
-            green: Rgb { r: 0xb9, g: 0xca, b: 0x4a },
-            yellow: Rgb { r: 0xe6, g: 0xc5, b: 0x47 },
-            blue: Rgb { r: 0x7a, g: 0xa6, b: 0xda },
-            magenta: Rgb { r: 0xc3, g: 0x97, b: 0xd8 },
-            cyan: Rgb { r: 0x70, g: 0xc0, b: 0xba },
-            white: Rgb { r: 0xea, g: 0xea, b: 0xea },
+            black: Rgb { r: 0x1d, g: 0x1f, b: 0x21 },
+            red: Rgb { r: 0xcc, g: 0x66, b: 0x66 },
+            green: Rgb { r: 0xb5, g: 0xbd, b: 0x68 },
+            yellow: Rgb { r: 0xf0, g: 0xc6, b: 0x74 },
+            blue: Rgb { r: 0x81, g: 0xa2, b: 0xbe },
+            magenta: Rgb { r: 0xb2, g: 0x94, b: 0xbb },
+            cyan: Rgb { r: 0x8a, g: 0xbe, b: 0xb7 },
+            white: Rgb { r: 0xc5, g: 0xc8, b: 0xc6 },
         })
     }
 }
@@ -170,13 +170,13 @@ impl Default for BrightColors {
     fn default() -> Self {
         BrightColors(AnsiColors {
             black: Rgb { r: 0x66, g: 0x66, b: 0x66 },
-            red: Rgb { r: 0xff, g: 0x33, b: 0x34 },
-            green: Rgb { r: 0x9e, g: 0xc4, b: 0x00 },
+            red: Rgb { r: 0xd5, g: 0x4e, b: 0x53 },
+            green: Rgb { r: 0xb9, g: 0xca, b: 0x4a },
             yellow: Rgb { r: 0xe7, g: 0xc5, b: 0x47 },
             blue: Rgb { r: 0x7a, g: 0xa6, b: 0xda },
-            magenta: Rgb { r: 0xb7, g: 0x7e, b: 0xe0 },
-            cyan: Rgb { r: 0x54, g: 0xce, b: 0xd6 },
-            white: Rgb { r: 0xff, g: 0xff, b: 0xff },
+            magenta: Rgb { r: 0xc3, g: 0x97, b: 0xd8 },
+            cyan: Rgb { r: 0x70, g: 0xc0, b: 0xb1 },
+            white: Rgb { r: 0xea, g: 0xea, b: 0xea },
         })
     }
 }


### PR DESCRIPTION
This is implementation of #3404 

Attached example of the colors with the default config. The first line is black and bright black, which are almost invisible.
![Screenshot from 2020-03-05 23-09-37](https://user-images.githubusercontent.com/2017002/76025902-7c822c80-5f36-11ea-862d-7fbb76c6b265.png)
