### PR TITLE
Add manpage, terminfo, and completions to macOS App bundle (#2653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Live config reload for `window.title`
+- Added manpage, terminfo, and completions to macOS application bundle.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimum Rust version has been bumped to 1.41.0
 - Prebuilt Linux binaries have been removed
+- Added manpage, terminfo, and completions to macOS application bundle
 
 ### Removed
 
@@ -81,8 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Live config reload for `window.title`
-- Added manpage, terminfo, and completions to macOS application bundle.
-- Added manpage, terminfo, and completions to macOS application bundle
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Live config reload for `window.title`
 - Added manpage, terminfo, and completions to macOS application bundle.
+- Added manpage, terminfo, and completions to macOS application bundle
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(APP_NAME): $(TARGET)
 	@mkdir -p $(APP_EXTRAS_DIR)
 	@mkdir -p $(APP_COMPLETIONS_DIR)
 	@gzip -c $(MANPAGE) > $(APP_EXTRAS_DIR)/alacritty.1.gz
-	@tic -xe alacritty,alacritty-direct $(TERMINFO) -o $(APP_EXTRAS_DIR)
+	@tic -xe alacritty,alacritty-direct -o $(APP_EXTRAS_DIR) $(TERMINFO)
 	@cp -fRp $(APP_TEMPLATE) $(APP_DIR)
 	@cp -fp $(APP_BINARY) $(APP_BINARY_DIR)
 	@cp -fp $(COMPLETIONS) $(APP_COMPLETIONS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ TARGET = alacritty
 ASSETS_DIR = extra
 RELEASE_DIR = target/release
 COMPLETIONS_DIR = $(ASSETS_DIR)/completions
-EXTRAS = $(ASSETS_DIR)/alacritty.info $(ASSETS_DIR)/alacritty.man
-COMPLETIONS = $(COMPLETIONS_DIR)/_alacritty $(COMPLETIONS_DIR)/alacritty.bash $(COMPLETIONS_DIR)/alacritty.fish
+MANPAGE = $(ASSETS_DIR)/alacritty.man
+TERMINFO = $(ASSETS_DIR)/alacritty.info
+COMPLETIONS = $(COMPLETIONS_DIR)/_alacritty \
+			  $(COMPLETIONS_DIR)/alacritty.bash \
+			  $(COMPLETIONS_DIR)/alacritty.fish
 
 APP_NAME = Alacritty.app
 APP_TEMPLATE = $(ASSETS_DIR)/osx/$(APP_NAME)
@@ -31,13 +34,14 @@ $(TARGET):
 	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release
 
 app: | $(APP_NAME) ## Clone Alacritty.app template and mount binary
-$(APP_NAME): $(TARGET) $(APP_TEMPLATE) $(EXTRAS) $(COMPLETIONS)
+$(APP_NAME): $(TARGET)
 	@mkdir -p $(APP_BINARY_DIR)
 	@mkdir -p $(APP_EXTRAS_DIR)
 	@mkdir -p $(APP_COMPLETIONS_DIR)
+	@gzip -c $(MANPAGE) > $(APP_EXTRAS_DIR)/alacritty.1.gz
+	@tic -xe alacritty,alacritty-direct $(TERMINFO) -o $(APP_EXTRAS_DIR)
 	@cp -fRp $(APP_TEMPLATE) $(APP_DIR)
 	@cp -fp $(APP_BINARY) $(APP_BINARY_DIR)
-	@cp -fp $(EXTRAS) $(APP_EXTRAS_DIR)
 	@cp -fp $(COMPLETIONS) $(APP_COMPLETIONS_DIR)
 	@touch -r "$(APP_BINARY)" "$(APP_DIR)/$(APP_NAME)"
 	@echo "Created '$@' in '$(APP_DIR)'"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 TARGET = alacritty
 
-APP_NAME = Alacritty.app
 ASSETS_DIR = extra
 RELEASE_DIR = target/release
 COMPLETIONS_DIR = $(ASSETS_DIR)/completions
-
 EXTRAS = $(ASSETS_DIR)/alacritty.info $(ASSETS_DIR)/alacritty.man
 COMPLETIONS = $(COMPLETIONS_DIR)/_alacritty $(COMPLETIONS_DIR)/alacritty.bash $(COMPLETIONS_DIR)/alacritty.fish
 
+APP_NAME = Alacritty.app
 APP_TEMPLATE = $(ASSETS_DIR)/osx/$(APP_NAME)
 APP_DIR = $(RELEASE_DIR)/osx
 APP_BINARY = $(RELEASE_DIR)/$(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,17 @@ TARGET = alacritty
 APP_NAME = Alacritty.app
 ASSETS_DIR = extra
 RELEASE_DIR = target/release
+COMPLETIONS_DIR = $(ASSETS_DIR)/completions
+
+EXTRAS = $(ASSETS_DIR)/alacritty.info $(ASSETS_DIR)/alacritty.man
+COMPLETIONS = $(COMPLETIONS_DIR)/_alacritty $(COMPLETIONS_DIR)/alacritty.bash $(COMPLETIONS_DIR)/alacritty.fish
+
 APP_TEMPLATE = $(ASSETS_DIR)/osx/$(APP_NAME)
 APP_DIR = $(RELEASE_DIR)/osx
 APP_BINARY = $(RELEASE_DIR)/$(TARGET)
 APP_BINARY_DIR  = $(APP_DIR)/$(APP_NAME)/Contents/MacOS
+APP_EXTRAS_DIR = $(APP_DIR)/$(APP_NAME)/Contents/Resources
+APP_COMPLETIONS_DIR = $(APP_EXTRAS_DIR)/completions
 
 DMG_NAME = Alacritty.dmg
 DMG_DIR = $(RELEASE_DIR)/osx
@@ -25,10 +32,14 @@ $(TARGET):
 	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release
 
 app: | $(APP_NAME) ## Clone Alacritty.app template and mount binary
-$(APP_NAME): $(TARGET) $(APP_TEMPLATE)
+$(APP_NAME): $(TARGET) $(APP_TEMPLATE) $(EXTRAS) $(COMPLETIONS)
 	@mkdir -p $(APP_BINARY_DIR)
+	@mkdir -p $(APP_EXTRAS_DIR)
+	@mkdir -p $(APP_COMPLETIONS_DIR)
 	@cp -fRp $(APP_TEMPLATE) $(APP_DIR)
 	@cp -fp $(APP_BINARY) $(APP_BINARY_DIR)
+	@cp -fp $(EXTRAS) $(APP_EXTRAS_DIR)
+	@cp -fp $(COMPLETIONS) $(APP_COMPLETIONS_DIR)
 	@touch -r "$(APP_BINARY)" "$(APP_DIR)/$(APP_NAME)"
 	@echo "Created '$@' in '$(APP_DIR)'"
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ TARGET = alacritty
 
 ASSETS_DIR = extra
 RELEASE_DIR = target/release
-COMPLETIONS_DIR = $(ASSETS_DIR)/completions
 MANPAGE = $(ASSETS_DIR)/alacritty.man
 TERMINFO = $(ASSETS_DIR)/alacritty.info
+COMPLETIONS_DIR = $(ASSETS_DIR)/completions
 COMPLETIONS = $(COMPLETIONS_DIR)/_alacritty \
 			  $(COMPLETIONS_DIR)/alacritty.bash \
 			  $(COMPLETIONS_DIR)/alacritty.fish

--- a/README.md
+++ b/README.md
@@ -131,12 +131,9 @@ pkg install alacritty
 brew cask install alacritty
 ```
 
-Once the cask is installed, it is recommended to setup the
-[manual page](INSTALL.md#manual-page),
-[shell completions](INSTALL.md#shell-completions), and
-[terminfo definitions](INSTALL.md#terminfo). These instructions need to be
-followed from within the Alacritty source for your version, which can be found
-on the [GitHub releases page](https://github.com/alacritty/alacritty/releases).
+Once the cask is installed, it is recommended to setup the manual page, shell
+completions, and terminfo definitions. These are located inside the installed
+application's Resources directory: `Alacritty.app/Contents/Resources`.
 
 ### Windows
 


### PR DESCRIPTION
- Add manpage, terminfo, and completions to macOS App bundle (#2653)
- Update README with new macOS extras/completions location (#2653)
- Update changelog

I didn't edit INSTALL.md as that's for manual installation which requires the repo anyway.