### PR TITLE
Fix crash when selecting last column

### DIFF
--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -346,6 +346,11 @@ impl Selection {
         // Remove first cell if selection starts at the right of a cell
         if start.side == Side::Right && start.point != end.point {
             start.point.col += 1;
+
+            // Wrap to next line when selection starts to the right of last column
+            if start.point.col == num_cols {
+                start.point = Point::new(start.point.line.saturating_sub(1), Column(0));
+            }
         }
 
         Some(SelectionRange { start: start.point, end: end.point, is_block: false })


### PR DESCRIPTION
This resolves a bug where the selection start would be set to the number
of columns, causing an out of bounds when trying to index with it.
Instead of extending the selection beyond the grid when the right side
of the last column is the start of the selection, the selection will now
start in the beginning of the next line.

Fixes #3446.
