### PR TITLE
Run clippy on oldest supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,15 @@ matrix:
     - name: "Clippy Linux"
       os: linux
       env: CLIPPY=true
-      rust: stable
+      rust: 1.37.0
     - name: "Clippy OSX"
       os: osx
       env: CLIPPY=true
-      rust: stable
+      rust: 1.37.0
     - name: "Clippy Windows"
       os: windows
       env: CLIPPY=true
-      rust: stable-x86_64-pc-windows-msvc
+      rust: 1.37.0-x86_64-pc-windows-msvc
     - name: "Rustfmt"
       os: linux
       env: RUSTFMT=true

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -33,7 +33,7 @@ pub fn get_cursor_glyph(
     // Calculate the cell metrics
     let height = metrics.line_height as i32 + i32::from(offset_y);
     let mut width = metrics.average_advance as i32 + i32::from(offset_x);
-    let line_width = cmp::max((width as f64 * CURSOR_WIDTH_PERCENTAGE).round() as i32, 1);
+    let line_width = cmp::max((f64::from(width) * CURSOR_WIDTH_PERCENTAGE).round() as i32, 1);
 
     // Double the cursor width if it's above a double-width glyph
     if is_wide {

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -469,7 +469,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         match delta {
             MouseScrollDelta::LineDelta(_columns, lines) => {
                 let new_scroll_px = lines * self.ctx.size_info().cell_height;
-                self.scroll_terminal(new_scroll_px as f64);
+                self.scroll_terminal(f64::from(new_scroll_px));
             },
             MouseScrollDelta::PixelDelta(lpos) => {
                 match phase {
@@ -487,7 +487,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
     }
 
     fn scroll_terminal(&mut self, new_scroll_px: f64) {
-        let height = self.ctx.size_info().cell_height as f64;
+        let height = f64::from(self.ctx.size_info().cell_height);
 
         if self.ctx.terminal().mode().intersects(TermMode::MOUSE_MODE) {
             self.ctx.mouse_mut().scroll_px += new_scroll_px;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -442,7 +442,7 @@ impl FreeTypeRasterizer {
             } else {
                 // Fallback if user has bitmap scaling disabled
                 let metrics = face.ft_face.size_metrics().ok_or(Error::MissingSizeMetrics)?;
-                f64::from(pixelsize) /  f64::from(metrics.y_ppem)
+                f64::from(pixelsize) / f64::from(metrics.y_ppem)
             };
             Ok(downsample_bitmap(rasterized_glyph, fixup_factor))
         } else {

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -442,7 +442,7 @@ impl FreeTypeRasterizer {
             } else {
                 // Fallback if user has bitmap scaling disabled
                 let metrics = face.ft_face.size_metrics().ok_or(Error::MissingSizeMetrics)?;
-                pixelsize as f64 / metrics.y_ppem as f64
+                f64::from(pixelsize) /  f64::from(metrics.y_ppem)
             };
             Ok(downsample_bitmap(rasterized_glyph, fixup_factor))
         } else {
@@ -659,10 +659,10 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
 
                 for source_column in source_column_start..source_column_end {
                     let offset = (source_pixel_index + source_column) * 4;
-                    r += bitmap_buffer[offset] as u32;
-                    g += bitmap_buffer[offset + 1] as u32;
-                    b += bitmap_buffer[offset + 2] as u32;
-                    a += bitmap_buffer[offset + 3] as u32;
+                    r += u32::from(bitmap_buffer[offset]);
+                    g += u32::from(bitmap_buffer[offset + 1]);
+                    b += u32::from(bitmap_buffer[offset + 2]);
+                    a += u32::from(bitmap_buffer[offset + 3]);
                     pixels_picked += 1;
                 }
             }
@@ -678,8 +678,8 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
     bitmap_glyph.buf = BitmapBuffer::RGBA(downsampled_buffer);
 
     // Downscale the metrics
-    bitmap_glyph.top = (bitmap_glyph.top as f64 * fixup_factor) as i32;
-    bitmap_glyph.left = (bitmap_glyph.left as f64 * fixup_factor) as i32;
+    bitmap_glyph.top = (f64::from(bitmap_glyph.top) * fixup_factor) as i32;
+    bitmap_glyph.left = (f64::from(bitmap_glyph.left) * fixup_factor) as i32;
     bitmap_glyph.width = target_width as i32;
     bitmap_glyph.height = target_height as i32;
 


### PR DESCRIPTION
Since there were some problems with clippy suggesting changes that were
not yet available in the oldest supported Rust compiler of Alacritty,
the clippy stage has been moved from stable to 1.37.0.
