### PR TITLE
Add Default Keybinding for SpawnNewInstance on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Live config reload for `window.title`
+- Default Command+N keybinding for SpawnNewInstance on macOS
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.5.0-dev
 
+### Added
+
+- Default Command+N keybinding for SpawnNewInstance on macOS
+
 ## 0.4.2-dev
 
 ### Packaging
@@ -17,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Live config reload for `window.title`
-- Default Command+N keybinding for SpawnNewInstance on macOS
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -527,6 +527,7 @@
   #- { key: M,      mods: Command,         action: Minimize         }
   #- { key: Q,      mods: Command,         action: Quit             }
   #- { key: W,      mods: Command,         action: Quit             }
+  #- { key: N,      mods: Command,         action: SpawnNewInstance }
   #- { key: F,      mods: Command|Control, action: ToggleFullscreen }
 
   #- { key: Paste,                    action: Paste                            }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -433,6 +433,7 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         Add,    ModifiersState::LOGO;  Action::IncreaseFontSize;
         Minus,  ModifiersState::LOGO;  Action::DecreaseFontSize;
         Insert, ModifiersState::SHIFT; Action::Esc("\x1b[2;2~".into());
+        N, ModifiersState::LOGO; Action::SpawnNewInstance;
         F, ModifiersState::CTRL | ModifiersState::LOGO; Action::ToggleFullscreen;
         K, ModifiersState::LOGO; Action::ClearHistory;
         K, ModifiersState::LOGO; Action::Esc("\x0c".into());


### PR DESCRIPTION
By default <kbd>Command+N</kbd> should open a new terminal. In addition to macOS, I'm wondering if we should add this binding on Windows too. I think on other systems it's best to avoid a default binding for this.

I'll also note here, that there seems to be a bug when running `SpawnNewInstance` on a version of alacritty outside the `PATH`.