### PR TITLE
Fix invisible selection

### DIFF
--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -651,11 +651,6 @@ impl<T> Grid<T> {
     }
 
     #[inline]
-    pub fn contains(&self, point: &Point) -> bool {
-        self.lines > point.line && self.cols > point.col
-    }
-
-    #[inline]
     pub fn display_offset(&self) -> usize {
         self.display_offset
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -239,9 +239,7 @@ impl<'a, C> RenderableCellsIter<'a, C> {
             // Do not render completely offscreen selection
             let viewport_start = grid.display_offset();
             let viewport_end = viewport_start + grid.num_lines().0;
-            if (span.start.line >= viewport_end && span.end.line >= viewport_end)
-                || (span.start.line < viewport_start && span.end.line < viewport_start)
-            {
+            if span.end.line >= viewport_end || span.start.line < viewport_start {
                 return None;
             }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -226,7 +226,6 @@ impl<'a, C> RenderableCellsIter<'a, C> {
         selection: Option<SelectionRange>,
     ) -> RenderableCellsIter<'b, C> {
         let grid = &term.grid;
-        let num_cols = grid.num_cols();
 
         let inner = grid.display_iter();
 
@@ -234,8 +233,17 @@ impl<'a, C> RenderableCellsIter<'a, C> {
             let (limit_start, limit_end) = if span.is_block {
                 (span.start.col, span.end.col)
             } else {
-                (Column(0), num_cols - 1)
+                (Column(0), grid.num_cols() - 1)
             };
+
+            // Do not render completely offscreen selection
+            let viewport_start = grid.display_offset();
+            let viewport_end = viewport_start + grid.num_lines().0;
+            if (span.start.line >= viewport_end && span.end.line >= viewport_end)
+                || (span.start.line < viewport_start && span.end.line < viewport_start)
+            {
+                return None;
+            }
 
             // Get on-screen lines of the selection's locations
             let mut start = grid.clamp_buffer_to_visible(span.start);


### PR DESCRIPTION
This resolves a bug where the very first/last cell would still be
selected when both the start and end were above/below the viewport.
