### PR TITLE
Clear Selection on ANSI Clear Line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Block cursor is no longer inverted at the start/end of a selection
 - Preserve selection on non-LMB or mouse mode clicks
+- Clear selection on ANSI clear line actions
 
 ## 0.4.2-dev
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -562,6 +562,15 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
         }
     }
 
+    /// Clear the entire selection if it's contained within the given line/column
+    /// region.
+    pub fn clear_selection(&mut self, line: Range<Line>, column: Range<Column>) {
+        // if selection.contains(point.col, point.line) {
+        //     self.grid.selection = None;
+        // }
+        unimplemented!()
+    }
+
     pub fn clear_viewport(&mut self, template: &T) {
         // Determine how many lines to scroll up by.
         let end = Point { line: 0, col: self.num_cols() };

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -63,6 +63,13 @@ impl<L> SelectionRange<L> {
             && (self.start.col <= col || (self.start.line != line && !self.is_block))
             && (self.end.col >= col || (self.end.line != line && !self.is_block))
     }
+
+    pub fn intersects(&self, col: Range<Column>, line: Range<L>) -> bool
+    where
+        L: PartialEq + PartialOrd,
+    {
+        unimplemented!()
+    }
 }
 
 /// Different kinds of selection.

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1930,11 +1930,10 @@ impl<T: EventListener> Handler for Term<T> {
         trace!("Clearing screen: {:?}", mode);
         let template = self.cursor.template;
 
-        // Remove active selections
-        self.grid.selection = None;
-
         match mode {
             ansi::ClearMode::Above => {
+                self.grid.selection = None;
+
                 // If clearing more than one line
                 if self.cursor.point.line > Line(1) {
                     // Fully clear all lines before the current line
@@ -1949,6 +1948,8 @@ impl<T: EventListener> Handler for Term<T> {
                 }
             },
             ansi::ClearMode::Below => {
+                self.grid.selection = None;
+
                 for cell in &mut self.grid[self.cursor.point.line][self.cursor.point.col..] {
                     cell.reset(&template);
                 }
@@ -1959,6 +1960,8 @@ impl<T: EventListener> Handler for Term<T> {
                 }
             },
             ansi::ClearMode::All => {
+                self.grid.selection = None;
+
                 if self.mode.contains(TermMode::ALT_SCREEN) {
                     self.grid.region_mut(..).each(|c| c.reset(&template));
                 } else {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1833,6 +1833,9 @@ impl<T: EventListener> Handler for Term<T> {
     fn clear_line(&mut self, mode: ansi::LineClearMode) {
         trace!("Clearing line: {:?}", mode);
 
+        // Remove active selections
+        self.grid.selection = None;
+
         let col = self.cursor.point.col;
 
         match mode {


### PR DESCRIPTION
This should fix selections staying around in applications like weechat, when the screen is changed with mouse actions, for example.

- [ ] Update `clear_screen`
  - [ ] Only clear selections that overlap with cleared lines
  - [ ] Don't clear selection when saved lines are cleared
  - [ ] Decide if we should rotate or clear the selection on `ClearMode::All` (VTE, for example rotates, however I think I'd prefer to clear)
- [ ] Update `clear_line`