### PR TITLE
Fix cursor position after alt screen resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decorations visible when in fullscreen on Wayland
 - Window size not persisted correctly after fullscreening on macOS
 - Crash on startup with some locales on X11
+- Shrinking terminal height in alt screen deleting primary screen content
 
 ### Removed
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -205,7 +205,7 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
         }
 
         match self.lines.cmp(&lines) {
-            Ordering::Less => self.grow_lines(lines, template),
+            Ordering::Less => self.grow_lines(lines, cursor_pos, template),
             Ordering::Greater => self.shrink_lines(lines),
             Ordering::Equal => (),
         }
@@ -236,17 +236,20 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
     /// Alacritty keeps the cursor at the bottom of the terminal as long as there
     /// is scrollback available. Once scrollback is exhausted, new lines are
     /// simply added to the bottom of the screen.
-    fn grow_lines(&mut self, new_line_count: Line, template: &T) {
+    fn grow_lines(&mut self, new_line_count: Line, cursor_pos: &mut Point, template: &T) {
         let lines_added = new_line_count - self.lines;
 
         // Need to "resize" before updating buffer
         self.raw.grow_visible_lines(new_line_count, Row::new(self.cols, template));
         self.lines = new_line_count;
 
-        // Move existing lines up if there is no scrollback to fill new lines
         let history_size = self.history_size();
         if lines_added.0 > history_size {
+            // Move existing lines up if there is no scrollback to fill new lines
             self.scroll_up(&(Line(0)..new_line_count), lines_added - history_size, template);
+        } else {
+            // Move cursor down for all lines pulled from history
+            cursor_pos.line = cursor_pos.line + lines_added.0;
         }
 
         self.decrease_scroll_limit(*lines_added);

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -247,7 +247,7 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
         let from_history = min(history_size, lines_added.0);
 
         // Move cursor down for all lines pulled from history
-        cursor_pos.line = cursor_pos.line + from_history;
+        cursor_pos.line += from_history;
 
         if from_history != lines_added.0 {
             // Move existing lines up for every line that couldn't be pulled from history

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -244,12 +244,14 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
         self.lines = new_line_count;
 
         let history_size = self.history_size();
-        if lines_added.0 > history_size {
-            // Move existing lines up if there is no scrollback to fill new lines
-            self.scroll_up(&(Line(0)..new_line_count), lines_added - history_size, template);
-        } else {
-            // Move cursor down for all lines pulled from history
-            cursor_pos.line = cursor_pos.line + lines_added.0;
+        let from_history = min(history_size, lines_added.0);
+
+        // Move cursor down for all lines pulled from history
+        cursor_pos.line = cursor_pos.line + from_history;
+
+        if from_history != lines_added.0 {
+            // Move existing lines up for every line that couldn't be pulled from history
+            self.scroll_up(&(Line(0)..new_line_count), lines_added - from_history, template);
         }
 
         self.decrease_scroll_limit(*lines_added);

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1167,12 +1167,6 @@ impl<T> Term<T> {
             self.alt_grid.scroll_up(&(Line(0)..old_lines), lines, &template);
         }
 
-        // Move prompt down when growing if scrollback lines are available
-        if num_lines > old_lines && !self.mode.contains(TermMode::ALT_SCREEN) {
-            let growage = min(num_lines - old_lines, Line(self.grid.history_size()));
-            self.cursor.point.line += growage;
-        }
-
         debug!("New num_cols is {} and num_lines is {}", num_cols, num_lines);
 
         // Resize grids to new size


### PR DESCRIPTION
This fixes a regression introduced in 4cc6421, which ignored the main
grid's cursor when increasing the number of lines available, causing
incorrect cursor position after restoring to the primary screen.

Fixes #3499.
