### PR TITLE
Add regex scrollback buffer search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opt-out compilation flag `winpty` to disable WinPTY support
 - Scrolling during selection when mouse is at top/bottom of window
 - Expanding existing selections using the right mouse button
+- Terminal search
 
 ### Changed
 
@@ -58,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linewrap tracking when switching between primary and alternate screen buffer
 - Preservation of the alternate screen's saved cursor when swapping to primary screen and back
 - Reflow of cursor during resize
+- Cursor color escape ignored when its color is set to inverted in the config
 
 ## 0.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Default Command+N keybinding for SpawnNewInstance on macOS
-- Vi mode for copying text and opening links
+- Vi mode for regex search, copying text, and opening links
 - `CopySelection` action which copies into selection buffer on Linux/BSD
 - Option `cursor.thickness` to set terminal cursor thickness
 - Font fallback on Windows
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opt-out compilation flag `winpty` to disable WinPTY support
 - Scrolling during selection when mouse is at top/bottom of window
 - Expanding existing selections using the right mouse button
-- Vi mode terminal regex search
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opt-out compilation flag `winpty` to disable WinPTY support
 - Scrolling during selection when mouse is at top/bottom of window
 - Expanding existing selections using the right mouse button
-- Terminal search
+- Vi mode terminal regex search
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dragging files into terminal now adds a space after each path
 - Default binding replacement conditions
 - Adjusted selection clearing granularity to more accurately match content
+- To use the cell's text color for selection with a modified background, the `color.selection.text`
+    variable must now be set to `CellForeground` instead of omitting it
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adler32"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -26,15 +26,16 @@ dependencies = [
  "font 0.1.0",
  "gl_generator 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.23.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.23.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlocator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.26.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -46,7 +47,7 @@ dependencies = [
 name = "alacritty_terminal"
 version = "0.5.0-dev"
 dependencies = [
- "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "font 0.1.0",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -55,14 +56,15 @@ dependencies = [
  "mio-anonymous-pipes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminfo 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vte 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -106,7 +108,7 @@ name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -129,7 +131,7 @@ name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -146,7 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -165,7 +167,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,7 +246,7 @@ name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -411,7 +413,7 @@ name = "deflate"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -421,8 +423,8 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -464,7 +466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dtoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -474,8 +476,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -506,7 +508,7 @@ name = "euclid"
 version = "0.20.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -537,7 +539,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -587,8 +589,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -755,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -780,23 +782,15 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytemuck 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "png 0.16.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "inflate"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -832,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -899,7 +893,7 @@ name = "line_drawing"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -952,10 +946,10 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -982,7 +976,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "spsc-buffer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1005,7 +999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1022,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1110,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.1"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1136,21 +1130,21 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1159,13 +1153,13 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1187,8 +1181,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1249,7 +1243,7 @@ dependencies = [
  "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1257,7 +1251,7 @@ name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1341,13 +1335,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "png"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deflate 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1399,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1486,13 +1480,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1592,40 +1595,40 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1664,7 +1667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1768,11 +1771,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1785,7 +1788,7 @@ dependencies = [
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1804,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1839,7 +1842,7 @@ name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1877,7 +1880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1928,7 +1931,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2004,7 +2007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.26.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "xcursor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xcursor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2045,7 +2048,7 @@ version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2136,7 +2139,7 @@ dependencies = [
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithay-client-toolkit 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2152,7 +2155,7 @@ dependencies = [
  "http_req 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winpty-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2219,10 +2222,10 @@ dependencies = [
 
 [[package]]
 name = "xcursor"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2245,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2256,7 +2259,7 @@ dependencies = [
 ]
 
 [metadata]
-"checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
+"checksum adler32 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum andrew 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b7f09f89872c2b6b29e319377b1fbe91c6f5947df19a25596e121cf19a7b35e"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
@@ -2269,7 +2272,7 @@ dependencies = [
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+"checksum base64 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e223af0dc48c96d4f8342ec01a4974f139df863896b316681efd36742f22cc67"
 "checksum bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
@@ -2305,7 +2308,7 @@ dependencies = [
 "checksum dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 "checksum dlib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b11f15d1e3268f140f68d390637d5e76d849782d971ae7063e0da69fe9709a76"
 "checksum downcast-rs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
-"checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+"checksum dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 "checksum dwrote 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
 "checksum embed-resource 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f6b0b4403da80c2fd32333937dd468292c001d778c587ae759b75432772715d"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -2335,16 +2338,15 @@ dependencies = [
 "checksum glutin_gles2_sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07e853d96bebcb8e53e445225c3009758c6f5960d44f2543245f6f07b567dae0"
 "checksum glutin_glx_sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "08c243de74d6cf5ea100c788826d2fb9319de315485dd4b310811a663b3809c3"
 "checksum glutin_wgl_sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a93dba7ee3a0feeac0f437141ff25e71ce2066bcf1a706acab1559ffff94eb6a"
-"checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+"checksum hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 "checksum http_req 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ef9a6b5b2cd80630d9c6bda175408a86908d8a9c1eb5b2857206529d88d063a3"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-"checksum image 0.23.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9117f4167a8f21fa2bb3f17a652a760acd7572645281c98e3b612a26242c96ee"
-"checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
+"checksum image 0.23.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d534e95ad8b9d5aa614322d02352b4f1bf962254adcf02ac6f2def8be18498e8"
 "checksum inotify 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum instant 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7777a24a1ce5de49fcdde84ec46efa487c3af49d5b6e6e0a50367cc5c1096182"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 "checksum jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -2362,13 +2364,13 @@ dependencies = [
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-"checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
+"checksum miniz_oxide 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
 "checksum mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)" = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 "checksum mio-anonymous-pipes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8c274c3c52dcd1d78c5d7ed841eca1e9ea2db8353f3b8ec25789cc62c471aaf"
 "checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 "checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum miow 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
+"checksum miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 "checksum native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 "checksum ndk 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95a356cafe20aee088789830bfea3a61336e84ded9e545e00d3869ce95dcb80c"
 "checksum ndk-glue 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1730ee2e3de41c3321160a6da815f008c4006d71b095880ea50e17cf52332b8"
@@ -2376,12 +2378,12 @@ dependencies = [
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-"checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
+"checksum nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 "checksum notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
-"checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
-"checksum num-iter 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
+"checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+"checksum num-iter 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
 "checksum num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
 "checksum num_enum_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 "checksum objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
@@ -2402,7 +2404,7 @@ dependencies = [
 "checksum phf_generator 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 "checksum phf_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-"checksum png 0.16.4 (registry+https://github.com/rust-lang/crates.io-index)" = "12faa637ed9ae3d3c881332e54b5ae2dba81cda9fc4bbce0faa1ba53abcead50"
+"checksum png 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)" = "34ccdd66f6fe4b2433b07e4728e9a013e43233120427046e93ceb709c3a439bf"
 "checksum podio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 "checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
@@ -2410,7 +2412,7 @@ dependencies = [
 "checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -2420,8 +2422,9 @@ dependencies = [
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 "checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+"checksum regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 "checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
-"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b725dadae9fabc488df69a287f5a99c5eaf5d10853842a8a3dfac52476f544ee"
@@ -2434,15 +2437,15 @@ dependencies = [
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum security-framework 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 "checksum security-framework-sys 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
-"checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
-"checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
-"checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
-"checksum serde_yaml 0.8.12 (registry+https://github.com/rust-lang/crates.io-index)" = "16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4"
+"checksum serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)" = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+"checksum serde_derive 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)" = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+"checksum serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+"checksum serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 "checksum servo-fontconfig 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b47fef69c52fb55838c756949c60595f0b855daa4e82fc52ad99ff3e03e2c70"
 "checksum servo-fontconfig-sys 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "facb23c6a801c935c3bddfdd7dc4e823af853babc5b0c90ffa3419ebef5d92c7"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-"checksum signal-hook 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6"
+"checksum signal-hook 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum siphasher 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
@@ -2454,7 +2457,7 @@ dependencies = [
 "checksum spsc-buffer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be6c3f39c37a4283ee4b43d1311c828f2e1fb0541e76ea0cb1a2abd9ef2f5b3b"
 "checksum stb_truetype 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f77b6b07e862c66a9f3e62a07588fee67cd90a9135a2b942409f195507b4fb51"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+"checksum syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum terminfo 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
@@ -2468,7 +2471,7 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum urlocator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "317bb1e85e87e72c11cb9cda7cb8909ca174a21d0abeb0f6955b8f6b0178b164"
 "checksum utf8parse 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-"checksum vcpkg 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "55d1e41d56121e07f1e223db0a4def204e45c85425f6a16d462fd07c8d10d74c"
+"checksum vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
@@ -2505,8 +2508,8 @@ dependencies = [
 "checksum x11-clipboard 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e5e937afd03b64b7be4f959cc044e09260a47241b71e56933f37db097bf7859d"
 "checksum x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"
 "checksum xcb 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62056f63138b39116f82a540c983cc11f1c90cd70b3d492a70c25eaa50bd22a6"
-"checksum xcursor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "56edec90b342d0f46d1189f3fd4a3374954636f3d76c861855b675efc7ef1435"
+"checksum xcursor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a481cfdefd35e1c50073ae33a8000d695c98039544659f5dc5dd71311b0d01"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 "checksum yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
-"checksum zip 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6df134e83b8f0f8153a094c7b0fd79dfebe437f1d76e7715afa18ed95ebe2fd7"
+"checksum zip 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58287c28d78507f5f91f2a4cf1e8310e2c76fd4c6932f93ac60fd1ceb402db7d"

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -176,28 +176,48 @@
 
   # Cursor colors
   #
-  # Colors which should be used to draw the terminal cursor. If these are
-  # unset, the cursor color will be the inverse of the cell color.
+  # Colors which should be used to draw the terminal cursor.
+  #
+  # Allowed values are CellForeground and CellBackground, which reference the
+  # affected cell, or hexadecimal colors like #ff00ff.
   #cursor:
-  #  text: '#000000'
-  #  cursor: '#ffffff'
+  #  text: CellBackground
+  #  cursor: CellForeground
 
   # Vi mode cursor colors
   #
-  # Colors for the cursor when the vi mode is active. If these are unset, the
-  # cursor color will be the inverse of the cell color.
+  # Colors for the cursor when the vi mode is active.
+  #
+  # Allowed values are CellForeground and CellBackground, which reference the
+  # affected cell, or hexadecimal colors like #ff00ff.
   #vi_mode_cursor:
-  #  text: '#000000'
-  #  cursor: '#ffffff'
+  #  text: CellBackground
+  #  cursor: CellForeground
 
   # Selection colors
   #
-  # Colors which should be used to draw the selection area. If selection
-  # background is unset, selection color will be the inverse of the cell colors.
-  # If only text is unset the cell text color will remain the same.
+  # Colors which should be used to draw the selection area.
+  #
+  # Allowed values are CellForeground and CellBackground, which reference the
+  # affected cell, or hexadecimal colors like #ff00ff.
   #selection:
-  #  text: '#eaeaea'
-  #  background: '#404040'
+  #  text: CellBackground
+  #  background: CellForeground
+
+  # Search colors
+  #
+  # Colors used for the search bar and match highlighting.
+  #
+  # Allowed values are CellForeground and CellBackground, which reference the
+  # affected cell, or hexadecimal colors like #ff00ff.
+  #search:
+  #  matches:
+  #    foreground: '#000000'
+  #    background: '#ffffff'
+  #
+  #  bar:
+  #    background: CellForeground
+  #    foreground: CellBackground
 
   # Normal colors
   #normal:
@@ -445,6 +465,8 @@
 # - `action`: Execute a predefined action
 #
 #   - ToggleViMode
+#   - Search
+#   - SearchReverse
 #   - Copy
 #   - Paste
 #   - PasteSelection
@@ -495,6 +517,10 @@
 #   - ToggleLineSelection
 #   - ToggleBlockSelection
 #   - ToggleSemanticSelection
+#   - SearchNext
+#   - SearchPrevious
+#   - SearchEndNext
+#   - SearchEndPrevious
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space
@@ -595,6 +621,10 @@
   #- { key: W,      mods: Shift,         mode: Vi, action: WordRight               }
   #- { key: E,      mods: Shift,         mode: Vi, action: WordRightEnd            }
   #- { key: Key5,   mods: Shift,         mode: Vi, action: Bracket                 }
+  #- { key: Slash,                       mode: Vi, action: Search                  }
+  #- { key: Slash,  mods: Shift,         mode: Vi, action: SearchReverse           }
+  #- { key: N,                           mode: Vi, action: SearchNext              }
+  #- { key: N,      mods: Shift,         mode: Vi, action: SearchPrevious          }
 
   # (Windows, Linux, and BSD only)
   #- { key: V,        mods: Control|Shift,           action: Paste            }

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -23,6 +23,7 @@ parking_lot = "0.10.2"
 font = { path = "../font" }
 urlocator = "0.1.3"
 copypasta = { version = "0.7.0", default-features = false }
+unicode-width = "0.1"
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -176,6 +176,12 @@ pub enum Action {
     /// Allow receiving char input.
     ReceiveChar,
 
+    /// Start a buffer search.
+    Search,
+
+    /// Start a reverse buffer search.
+    SearchReverse,
+
     /// No action.
     None,
 }
@@ -208,6 +214,14 @@ pub enum ViAction {
     ToggleBlockSelection,
     /// Toggle semantic vi selection.
     ToggleSemanticSelection,
+    /// Jump to the beginning of the next match.
+    SearchNext,
+    /// Jump to the beginning of the previous match.
+    SearchPrevious,
+    /// Jump to the end of the next match.
+    SearchEndNext,
+    /// Jump to the end of the previous match.
+    SearchEndPrevious,
     /// Launch the URL below the vi mode cursor.
     Open,
 }
@@ -364,10 +378,14 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         D,      ModifiersState::CTRL,  +TermMode::VI; Action::ScrollHalfPageDown;
         Y,                             +TermMode::VI; Action::Copy;
         Y,                             +TermMode::VI; Action::ClearSelection;
+        Slash,                         +TermMode::VI; Action::Search;
+        Slash,  ModifiersState::SHIFT, +TermMode::VI; Action::SearchReverse;
         V,                             +TermMode::VI; ViAction::ToggleNormalSelection;
         V,      ModifiersState::SHIFT, +TermMode::VI; ViAction::ToggleLineSelection;
         V,      ModifiersState::CTRL,  +TermMode::VI; ViAction::ToggleBlockSelection;
         V,      ModifiersState::ALT,   +TermMode::VI; ViAction::ToggleSemanticSelection;
+        N,                             +TermMode::VI; ViAction::SearchNext;
+        N,      ModifiersState::SHIFT, +TermMode::VI; ViAction::SearchPrevious;
         Return,                        +TermMode::VI; ViAction::Open;
         K,                             +TermMode::VI; ViMotion::Up;
         J,                             +TermMode::VI; ViMotion::Down;

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -453,19 +453,22 @@ impl Display {
         let size_info = self.size_info;
 
         let selection = !terminal.selection.as_ref().map(Selection::is_empty).unwrap_or(true);
-        let mouse_mode =
-            terminal.mode().intersects(TermMode::MOUSE_MODE) && !terminal.mode().contains(TermMode::VI);
+        let mouse_mode = terminal.mode().intersects(TermMode::MOUSE_MODE)
+            && !terminal.mode().contains(TermMode::VI);
 
-        let vi_mode_cursor =
-            if terminal.mode().contains(TermMode::VI) { Some(terminal.vi_mode_cursor) } else { None };
+        let vi_mode_cursor = if terminal.mode().contains(TermMode::VI) {
+            Some(terminal.vi_mode_cursor)
+        } else {
+            None
+        };
 
         // Update IME position.
         #[cfg(not(windows))]
         {
             let point = match &search_regex {
                 Some(regex) => {
-                    let column = min(regex.len() + SEARCH_LABEL.len(), terminal.num_cols().0 - 1);
-                    Point::new(terminal.num_lines() - 1, Column(column))
+                    let column = min(regex.len() + SEARCH_LABEL.len(), terminal.cols().0 - 1);
+                    Point::new(terminal.screen_lines() - 1, Column(column))
                 },
                 None => terminal.grid().cursor.point,
             };

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -454,10 +454,10 @@ impl Display {
 
         let selection = !terminal.selection.as_ref().map(Selection::is_empty).unwrap_or(true);
         let mouse_mode =
-            terminal.mode.intersects(TermMode::MOUSE_MODE) && !terminal.mode.contains(TermMode::VI);
+            terminal.mode().intersects(TermMode::MOUSE_MODE) && !terminal.mode().contains(TermMode::VI);
 
         let vi_mode_cursor =
-            if terminal.mode.contains(TermMode::VI) { Some(terminal.vi_mode_cursor) } else { None };
+            if terminal.mode().contains(TermMode::VI) { Some(terminal.vi_mode_cursor) } else { None };
 
         // Update IME position.
         #[cfg(not(windows))]

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -568,7 +568,7 @@ impl Display {
         config: &Config,
         size_info: &SizeInfo,
         message_bar_lines: usize,
-        search_regex: Option<String>
+        search_regex: Option<String>,
     ) {
         let search_regex = match search_regex {
             Some(search_regex) => search_regex,

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -443,7 +443,7 @@ impl Display {
         config: &Config,
         mouse: &Mouse,
         mods: ModifiersState,
-        search_regex: Option<String>,
+        search_regex: Option<&String>,
     ) {
         let grid_cells: Vec<RenderableCell> = terminal.renderable_cells(config).collect();
         let visual_bell_intensity = terminal.visual_bell.intensity();
@@ -465,7 +465,7 @@ impl Display {
         // Update IME position.
         #[cfg(not(windows))]
         {
-            let point = match &search_regex {
+            let point = match search_regex {
                 Some(regex) => {
                     let column = min(regex.len() + SEARCH_LABEL.len(), terminal.cols().0 - 1);
                     Point::new(terminal.screen_lines() - 1, Column(column))
@@ -609,7 +609,7 @@ impl Display {
         config: &Config,
         size_info: &SizeInfo,
         message_bar_lines: usize,
-        search_regex: Option<String>,
+        search_regex: Option<&String>,
     ) {
         let search_regex = match search_regex {
             Some(search_regex) => search_regex,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -338,8 +338,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
     #[inline]
     fn start_search(&mut self, direction: Direction) {
-        let num_lines = self.terminal.num_lines();
-        let num_cols = self.terminal.num_cols();
+        let num_lines = self.terminal.screen_lines();
+        let num_cols = self.terminal.cols();
 
         self.search_state.regex = Some(String::new());
         self.search_state.direction = direction;
@@ -486,8 +486,8 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
 
         // Reset vi mode cursor.
         let mut vi_cursor_point = self.search_state.vi_cursor_point;
-        vi_cursor_point.line = min(vi_cursor_point.line, self.terminal.num_lines() - 1);
-        vi_cursor_point.col = min(vi_cursor_point.col, self.terminal.num_cols() - 1);
+        vi_cursor_point.line = min(vi_cursor_point.line, self.terminal.screen_lines() - 1);
+        vi_cursor_point.col = min(vi_cursor_point.col, self.terminal.cols() - 1);
         self.terminal.vi_mode_cursor.point = vi_cursor_point;
 
         // Unschedule pending timers.
@@ -506,7 +506,7 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
 
         // Use original position as search origin.
         let mut vi_cursor_point = self.search_state.vi_cursor_point;
-        vi_cursor_point.line = min(vi_cursor_point.line, self.terminal.num_lines() - 1);
+        vi_cursor_point.line = min(vi_cursor_point.line, self.terminal.screen_lines() - 1);
         let mut origin = self.terminal.visible_to_buffer(vi_cursor_point);
         origin.line = (origin.line as isize + self.search_state.display_offset_delta) as usize;
 
@@ -1015,7 +1015,7 @@ impl<N: Notify + OnResize> Processor<N> {
         }
 
         // Compute cursor positions before resize.
-        let num_lines = terminal.num_lines();
+        let num_lines = terminal.screen_lines();
         let cursor_at_bottom = terminal.grid().cursor.point.line + 1 == num_lines;
         let origin_at_bottom = (!terminal.mode().contains(TermMode::VI)
             && self.search_state.direction == Direction::Left)

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -791,7 +791,7 @@ impl<N: Notify + OnResize> Processor<N> {
                     &self.config,
                     &self.mouse,
                     self.modifiers,
-                    self.search_state.regex.clone(),
+                    self.search_state.regex.as_ref(),
                 );
             }
         });

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -144,7 +144,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.terminal.scroll_display(scroll);
 
         // Update selection.
-        if self.terminal.mode.contains(TermMode::VI)
+        if self.terminal.mode().contains(TermMode::VI)
             && self.terminal.selection.as_ref().map(|s| s.is_empty()) != Some(true)
         {
             self.update_selection(self.terminal.vi_mode_cursor.point, Side::Right);
@@ -178,7 +178,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         let point = self.terminal.visible_to_buffer(point);
 
         // Update selection if one exists.
-        let vi_mode = self.terminal.mode.contains(TermMode::VI);
+        let vi_mode = self.terminal.mode().contains(TermMode::VI);
         if let Some(selection) = &mut self.terminal.selection {
             selection.update(point, side);
 
@@ -222,8 +222,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
     #[inline]
     fn mouse_mode(&self) -> bool {
-        self.terminal.mode.intersects(TermMode::MOUSE_MODE)
-            && !self.terminal.mode.contains(TermMode::VI)
+        self.terminal.mode().intersects(TermMode::MOUSE_MODE)
+            && !self.terminal.mode().contains(TermMode::VI)
     }
 
     #[inline]
@@ -345,7 +345,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.search_state.direction = direction;
 
         // Store original vi cursor position as search origin and for resetting.
-        self.search_state.vi_cursor_point = if self.terminal.mode.contains(TermMode::VI) {
+        self.search_state.vi_cursor_point = if self.terminal.mode().contains(TermMode::VI) {
             self.terminal.vi_mode_cursor.point
         } else {
             match direction {
@@ -361,7 +361,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[inline]
     fn confirm_search(&mut self) {
         // Enter vi mode once search is confirmed.
-        self.terminal.mode.insert(TermMode::VI);
+        self.terminal.set_vi_mode();
 
         // Force limitless search if the previous one was interrupted.
         if self.scheduler.scheduled(TimerId::DelayedSearch) {
@@ -1017,7 +1017,7 @@ impl<N: Notify + OnResize> Processor<N> {
         // Compute cursor positions before resize.
         let num_lines = terminal.num_lines();
         let cursor_at_bottom = terminal.grid().cursor.point.line + 1 == num_lines;
-        let origin_at_bottom = (!terminal.mode.contains(TermMode::VI)
+        let origin_at_bottom = (!terminal.mode().contains(TermMode::VI)
             && self.search_state.direction == Direction::Left)
             || terminal.vi_mode_cursor.point.line == num_lines - 1;
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -405,6 +405,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             None => return,
         };
 
+        // Hide cursor while typing into the search bar.
+        if self.config.ui_config.mouse.hide_when_typing {
+            self.window.set_mouse_visible(false);
+        }
+
         // Add new char to search string.
         regex.push(c);
 
@@ -423,6 +428,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             Some(regex) => regex,
             None => return,
         };
+
+        // Hide cursor while typing into the search bar.
+        if self.config.ui_config.mouse.hide_when_typing {
+            self.window.set_mouse_visible(false);
+        }
 
         // Remove last char from search string.
         regex.pop();

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -491,6 +491,7 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
     /// Reset terminal to state before search was started.
     fn search_reset_state(&mut self) {
         self.terminal.scroll_display(Scroll::Delta(self.search_state.display_offset_delta));
+        self.search_state.display_offset_delta = 0;
 
         let mut vi_cursor_point = self.search_state.vi_cursor_point;
         vi_cursor_point.line = min(vi_cursor_point.line, self.terminal.num_lines() - 1);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -28,7 +28,7 @@ use font::set_font_smoothing;
 use font::{self, Size};
 
 use alacritty_terminal::config::LOG_TARGET_CONFIG;
-use alacritty_terminal::event::{OnResize, Event as TerminalEvent, EventListener, Notify};
+use alacritty_terminal::event::{Event as TerminalEvent, EventListener, Notify, OnResize};
 use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Column, Direction, Line, Point, Side};
 use alacritty_terminal::message_bar::{Message, MessageBuffer};
@@ -805,8 +805,8 @@ impl<N: Notify + OnResize> Processor<N> {
                     let display_update_pending = &mut processor.ctx.display_update_pending;
 
                     // Push current font to update its DPR.
-                    let font = processor.ctx.config.font.clone().with_size(*processor.ctx.font_size);
-                    display_update_pending.set_font(font);
+                    let font = processor.ctx.config.font.clone();
+                    display_update_pending.set_font(font.with_size(*processor.ctx.font_size));
 
                     // Resize to event's dimensions, since no resize event is emitted on Wayland.
                     display_update_pending.set_dimensions(PhysicalSize::new(width, height));

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -245,7 +245,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollPageUp => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = term.grid().num_lines().0 as isize;
+                let scroll_lines = term.grid().screen_lines().0 as isize;
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::PageUp);
@@ -253,7 +253,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollPageDown => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = -(term.grid().num_lines().0 as isize);
+                let scroll_lines = -(term.grid().screen_lines().0 as isize);
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::PageDown);
@@ -261,7 +261,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollHalfPageUp => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = term.grid().num_lines().0 as isize / 2;
+                let scroll_lines = term.grid().screen_lines().0 as isize / 2;
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::Delta(scroll_lines));
@@ -269,7 +269,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollHalfPageDown => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = -(term.grid().num_lines().0 as isize / 2);
+                let scroll_lines = -(term.grid().screen_lines().0 as isize / 2);
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::Delta(scroll_lines));
@@ -278,7 +278,7 @@ impl<T: EventListener> Execute<T> for Action {
                 // Move vi mode cursor.
                 let term = ctx.terminal();
                 if term.grid().display_offset() != term.grid().history_size()
-                    && term.vi_mode_cursor.point.line + 1 != term.grid().num_lines()
+                    && term.vi_mode_cursor.point.line + 1 != term.grid().screen_lines()
                 {
                     ctx.terminal_mut().vi_mode_cursor.point.line += 1;
                 }
@@ -307,7 +307,7 @@ impl<T: EventListener> Execute<T> for Action {
 
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                term.vi_mode_cursor.point.line = term.grid().num_lines() - 1;
+                term.vi_mode_cursor.point.line = term.grid().screen_lines() - 1;
 
                 // Move to beginning twice, to always jump across linewraps.
                 term.vi_motion(ViMotion::FirstOccupied);
@@ -406,7 +406,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         self.update_url_state(&mouse_state);
         self.ctx.window_mut().set_mouse_cursor(mouse_state.into());
 
-        let last_term_line = self.ctx.terminal().grid().num_lines() - 1;
+        let last_term_line = self.ctx.terminal().grid().screen_lines() - 1;
         if (lmb_pressed || self.ctx.mouse().right_button_state == ElementState::Pressed)
             && (self.ctx.modifiers().shift() || !self.ctx.mouse_mode())
         {
@@ -566,7 +566,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             // Load mouse point, treating message bar and padding as the closest cell.
             let mouse = self.ctx.mouse();
             let mut point = self.ctx.size_info().pixels_to_coords(mouse.x, mouse.y);
-            point.line = min(point.line, self.ctx.terminal().grid().num_lines() - 1);
+            point.line = min(point.line, self.ctx.terminal().grid().screen_lines() - 1);
 
             match button {
                 MouseButton::Left => self.on_left_click(point),
@@ -779,7 +779,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
             // Reset cursor when message bar height changed or all messages are gone.
             let size = self.ctx.size_info();
-            let current_lines = (size.lines() - self.ctx.terminal().grid().num_lines()).0;
+            let current_lines = (size.lines() - self.ctx.terminal().grid().screen_lines()).0;
             let new_lines = self.ctx.message().map(|m| m.text(&size).len()).unwrap_or(0);
 
             let new_icon = match current_lines.cmp(&new_lines) {
@@ -957,7 +957,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
     /// Check if the cursor is hovering above the message bar.
     fn message_at_cursor(&mut self) -> bool {
-        self.ctx.mouse().line >= self.ctx.terminal().grid().num_lines()
+        self.ctx.mouse().line >= self.ctx.terminal().grid().screen_lines()
     }
 
     /// Whether the point is over the message bar's close button.
@@ -969,7 +969,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
         mouse.inside_grid
             && mouse.column + message_bar::CLOSE_BUTTON_TEXT.len() >= self.ctx.size_info().cols()
-            && mouse.line == self.ctx.terminal().grid().num_lines() + search_height
+            && mouse.line == self.ctx.terminal().grid().screen_lines() + search_height
     }
 
     /// Copy text selection.

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -854,12 +854,14 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         let suppress_chars = *self.ctx.suppress_chars();
         let search_active = self.ctx.search_active();
         if suppress_chars || self.ctx.terminal().mode.contains(TermMode::VI) || search_active {
-            // Skip control characters.
-            let c_decimal = c as isize;
-            let is_printable = (c_decimal >= 0x20 && c_decimal < 0x7f) || c_decimal >= 0xa0;
+            if search_active {
+                // Skip control characters.
+                let c_decimal = c as isize;
+                let is_printable = (c_decimal >= 0x20 && c_decimal < 0x7f) || c_decimal >= 0xa0;
 
-            if !suppress_chars && is_printable {
-                self.ctx.push_search(c);
+                if !suppress_chars && is_printable {
+                    self.ctx.push_search(c);
+                }
             }
 
             return;
@@ -962,7 +964,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
     fn message_close_at_cursor(&self) -> bool {
         let mouse = self.ctx.mouse();
 
-        // Offset button position by search height, since it sits above the message bar.
+        // Since search is above the message bar, the button is offset by search's height.
         let search_height = if self.ctx.search_active() { 1 } else { 0 };
 
         mouse.inside_grid

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -298,7 +298,7 @@ impl GlyphCache {
 
     pub fn update_font_size<L: LoadGlyph>(
         &mut self,
-        font: config::Font,
+        font: &config::Font,
         dpr: f64,
         loader: &mut L,
     ) -> Result<(), font::Error> {
@@ -307,7 +307,7 @@ impl GlyphCache {
 
         // Recompute font keys.
         let (regular, bold, italic, bold_italic) =
-            Self::compute_font_keys(&font, &mut self.rasterizer)?;
+            Self::compute_font_keys(font, &mut self.rasterizer)?;
 
         self.rasterizer.get_glyph(GlyphKey { font_key: regular, c: 'm', size: font.size })?;
         let metrics = self.rasterizer.metrics(regular, font.size)?;

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -968,29 +968,29 @@ impl<'a, C> RenderApi<'a, C> {
     /// errors.
     pub fn render_string(
         &mut self,
-        string: &str,
-        line: Line,
         glyph_cache: &mut GlyphCache,
-        color: Option<Rgb>,
+        line: Line,
+        string: &str,
+        fg: Rgb,
+        bg: Option<Rgb>,
     ) {
-        let bg_alpha = color.map(|_| 1.0).unwrap_or(0.0);
-        let col = Column(0);
+        let bg_alpha = bg.map(|_| 1.0).unwrap_or(0.0);
 
         let cells = string
             .chars()
             .enumerate()
             .map(|(i, c)| RenderableCell {
                 line,
-                column: col + i,
+                column: Column(i),
                 inner: RenderableCellContent::Chars({
                     let mut chars = [' '; cell::MAX_ZEROWIDTH_CHARS + 1];
                     chars[0] = c;
                     chars
                 }),
-                bg: color.unwrap_or(Rgb { r: 0, g: 0, b: 0 }),
-                fg: Rgb { r: 0, g: 0, b: 0 },
                 flags: Flags::empty(),
                 bg_alpha,
+                fg,
+                bg: bg.unwrap_or(Rgb { r: 0, g: 0, b: 0 }),
             })
             .collect::<Vec<_>>();
 

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -9,6 +9,22 @@ use crate::event::Event as AlacrittyEvent;
 
 type Event = GlutinEvent<'static, AlacrittyEvent>;
 
+/// ID uniquely identifying a timer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum TimerId {
+    SelectionScrolling,
+    DelayedSearch,
+}
+
+/// Event scheduled to be emitted at a specific time.
+pub struct Timer {
+    pub deadline: Instant,
+    pub event: Event,
+
+    interval: Option<Duration>,
+    id: TimerId,
+}
+
 /// Scheduler tracking all pending timers.
 pub struct Scheduler {
     timers: VecDeque<Timer>,
@@ -74,23 +90,13 @@ impl Scheduler {
         self.timers.remove(index).map(|timer| timer.event)
     }
 
+    /// Check if a timer is already scheduled.
+    pub fn scheduled(&mut self, id: TimerId) -> bool {
+        self.timers.iter().any(|timer| timer.id == id)
+    }
+
     /// Access a staged event by ID.
     pub fn get_mut(&mut self, id: TimerId) -> Option<&mut Timer> {
         self.timers.iter_mut().find(|timer| timer.id == id)
     }
-}
-
-/// ID uniquely identifying a timer.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum TimerId {
-    SelectionScrolling,
-}
-
-/// Event scheduled to be emitted at a specific time.
-pub struct Timer {
-    pub deadline: Instant,
-    pub event: Event,
-
-    interval: Option<Duration>,
-    id: TimerId,
 }

--- a/alacritty/src/url.rs
+++ b/alacritty/src/url.rs
@@ -90,7 +90,7 @@ impl Urls {
         self.last_point = Some(end);
 
         // Extend current state if a wide char spacer is encountered.
-        if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+        if cell.flags.intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER) {
             if let UrlLocation::Url(_, mut end_offset) = self.state {
                 if end_offset != 0 {
                     end_offset += 1;

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -35,7 +35,9 @@ use winapi::shared::minwindef::WORD;
 
 use alacritty_terminal::config::{Decorations, StartupMode, WindowConfig};
 #[cfg(not(windows))]
-use alacritty_terminal::term::{SizeInfo, Term};
+use alacritty_terminal::index::Point;
+#[cfg(not(windows))]
+use alacritty_terminal::term::SizeInfo;
 
 use crate::config::Config;
 use crate::gl;
@@ -398,8 +400,7 @@ impl Window {
 
     /// Adjust the IME editor position according to the new location of the cursor.
     #[cfg(not(windows))]
-    pub fn update_ime_position<T>(&mut self, terminal: &Term<T>, size_info: &SizeInfo) {
-        let point = terminal.grid().cursor.point;
+    pub fn update_ime_position(&mut self, point: Point, size_info: &SizeInfo) {
         let SizeInfo { cell_width, cell_height, padding_x, padding_y, .. } = size_info;
 
         let nspot_x = f64::from(padding_x + point.col.0 as f32 * cell_width);

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 unicode-width = "0.1"
 base64 = "0.12.0"
 terminfo = "0.7.1"
+regex-automata = "0.1.9"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17.0"

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -1,8 +1,9 @@
 use log::error;
 use serde::{Deserialize, Deserializer};
+use serde_yaml::Value;
 
 use crate::config::{failure_default, LOG_TARGET_CONFIG};
-use crate::term::color::Rgb;
+use crate::term::color::{CellRgb, Rgb};
 
 #[serde(default)]
 #[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
@@ -23,6 +24,8 @@ pub struct Colors {
     pub dim: Option<AnsiColors>,
     #[serde(deserialize_with = "failure_default")]
     pub indexed_colors: Vec<IndexedColor>,
+    #[serde(deserialize_with = "failure_default")]
+    pub search: SearchColors,
 }
 
 impl Colors {
@@ -32,6 +35,32 @@ impl Colors {
 
     pub fn bright(&self) -> &AnsiColors {
         &self.bright.0
+    }
+
+    pub fn search_bar_foreground(&self) -> Rgb {
+        self.search.bar.foreground.unwrap_or(self.primary.background)
+    }
+
+    pub fn search_bar_background(&self) -> Rgb {
+        self.search.bar.background.unwrap_or(self.primary.foreground)
+    }
+}
+
+#[derive(Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
+struct DefaultForegroundCellRgb(CellRgb);
+
+impl Default for DefaultForegroundCellRgb {
+    fn default() -> Self {
+        Self(CellRgb::CellForeground)
+    }
+}
+
+#[derive(Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
+struct DefaultBackgroundCellRgb(CellRgb);
+
+impl Default for DefaultBackgroundCellRgb {
+    fn default() -> Self {
+        Self(CellRgb::CellBackground)
     }
 }
 
@@ -44,11 +73,11 @@ pub struct IndexedColor {
     pub color: Rgb,
 }
 
-fn deserialize_color_index<'a, D>(deserializer: D) -> ::std::result::Result<u8, D::Error>
+fn deserialize_color_index<'a, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: Deserializer<'a>,
 {
-    let value = serde_yaml::Value::deserialize(deserializer)?;
+    let value = Value::deserialize(deserializer)?;
     match u8::deserialize(value) {
         Ok(index) => {
             if index < 16 {
@@ -78,26 +107,91 @@ where
 #[derive(Deserialize, Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub struct CursorColors {
     #[serde(deserialize_with = "failure_default")]
-    pub text: Option<Rgb>,
+    text: DefaultBackgroundCellRgb,
     #[serde(deserialize_with = "failure_default")]
-    pub cursor: Option<Rgb>,
+    cursor: DefaultForegroundCellRgb,
+}
+
+impl CursorColors {
+    pub fn text(self) -> CellRgb {
+        self.text.0
+    }
+
+    pub fn cursor(self) -> CellRgb {
+        self.cursor.0
+    }
 }
 
 #[serde(default)]
 #[derive(Deserialize, Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub struct SelectionColors {
     #[serde(deserialize_with = "failure_default")]
-    pub text: Option<Rgb>,
+    text: DefaultBackgroundCellRgb,
     #[serde(deserialize_with = "failure_default")]
-    pub background: Option<Rgb>,
+    background: DefaultForegroundCellRgb,
+}
+
+impl SelectionColors {
+    pub fn text(self) -> CellRgb {
+        self.text.0
+    }
+
+    pub fn background(self) -> CellRgb {
+        self.background.0
+    }
+}
+
+#[serde(default)]
+#[derive(Deserialize, Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub struct SearchColors {
+    #[serde(deserialize_with = "failure_default")]
+    pub matches: MatchColors,
+    #[serde(deserialize_with = "failure_default")]
+    bar: BarColors,
+}
+
+#[serde(default)]
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct MatchColors {
+    #[serde(deserialize_with = "failure_default")]
+    pub foreground: CellRgb,
+    #[serde(deserialize_with = "deserialize_match_background")]
+    pub background: CellRgb,
+}
+
+impl Default for MatchColors {
+    fn default() -> Self {
+        Self { foreground: CellRgb::default(), background: default_match_background() }
+    }
+}
+
+fn deserialize_match_background<'a, D>(deserializer: D) -> Result<CellRgb, D::Error>
+where
+    D: Deserializer<'a>,
+{
+    let value = Value::deserialize(deserializer)?;
+    Ok(CellRgb::deserialize(value).unwrap_or_else(|_| default_match_background()))
+}
+
+fn default_match_background() -> CellRgb {
+    CellRgb::Rgb(Rgb { r: 0xff, g: 0xff, b: 0xff })
+}
+
+#[serde(default)]
+#[derive(Deserialize, Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub struct BarColors {
+    #[serde(deserialize_with = "failure_default")]
+    foreground: Option<Rgb>,
+    #[serde(deserialize_with = "failure_default")]
+    background: Option<Rgb>,
 }
 
 #[serde(default)]
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct PrimaryColors {
-    #[serde(default = "default_background", deserialize_with = "failure_default")]
+    #[serde(deserialize_with = "failure_default")]
     pub background: Rgb,
-    #[serde(default = "default_foreground", deserialize_with = "failure_default")]
+    #[serde(deserialize_with = "failure_default")]
     pub foreground: Rgb,
     #[serde(deserialize_with = "failure_default")]
     pub bright_foreground: Option<Rgb>,
@@ -108,20 +202,12 @@ pub struct PrimaryColors {
 impl Default for PrimaryColors {
     fn default() -> Self {
         PrimaryColors {
-            background: default_background(),
-            foreground: default_foreground(),
+            background: Rgb { r: 0x1d, g: 0x1f, b: 0x21 },
+            foreground: Rgb { r: 0xc5, g: 0xc8, b: 0xc6 },
             bright_foreground: Default::default(),
             dim_foreground: Default::default(),
         }
     }
-}
-
-fn default_background() -> Rgb {
-    Rgb { r: 0x1d, g: 0x1f, b: 0x21 }
-}
-
-fn default_foreground() -> Rgb {
-    Rgb { r: 0xc5, g: 0xc8, b: 0xc6 }
 }
 
 /// The 8-colors sections of config.

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -13,7 +13,7 @@ mod scrolling;
 mod visual_bell;
 mod window;
 
-use crate::ansi::{CursorStyle, NamedColor};
+use crate::ansi::CursorStyle;
 
 pub use crate::config::colors::Colors;
 pub use crate::config::debug::Debug;
@@ -21,7 +21,6 @@ pub use crate::config::font::{Font, FontDescription};
 pub use crate::config::scrolling::Scrolling;
 pub use crate::config::visual_bell::{VisualBellAnimation, VisualBellConfig};
 pub use crate::config::window::{Decorations, Dimensions, StartupMode, WindowConfig, DEFAULT_NAME};
-use crate::term::color::Rgb;
 
 pub const LOG_TARGET_CONFIG: &str = "alacritty_config";
 const MAX_SCROLLBACK_LINES: u32 = 100_000;
@@ -154,30 +153,6 @@ impl<T> Config<T> {
     #[inline]
     pub fn dynamic_title(&self) -> bool {
         self.dynamic_title.0
-    }
-
-    /// Cursor foreground color.
-    #[inline]
-    pub fn cursor_text_color(&self) -> Option<Rgb> {
-        self.colors.cursor.text
-    }
-
-    /// Cursor background color.
-    #[inline]
-    pub fn cursor_cursor_color(&self) -> Option<NamedColor> {
-        self.colors.cursor.cursor.map(|_| NamedColor::Cursor)
-    }
-
-    /// Vi mode cursor foreground color.
-    #[inline]
-    pub fn vi_mode_cursor_text_color(&self) -> Option<Rgb> {
-        self.colors.vi_mode_cursor.text
-    }
-
-    /// Vi mode cursor background color.
-    #[inline]
-    pub fn vi_mode_cursor_cursor_color(&self) -> Option<Rgb> {
-        self.colors.vi_mode_cursor.cursor
     }
 
     #[inline]

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -66,7 +66,7 @@ pub struct Cursor {
     /// The location of this cursor.
     pub point: Point,
 
-    /// Template cell when usingscreen_linessor.
+    /// Template cell when using this cursor.
     pub template: Cell,
 
     /// Currently configured graphic character sets.

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -180,7 +180,6 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
         }
     }
 
-
     /// Update the size of the scrollback history.
     pub fn update_history(&mut self, history_size: usize) {
         let current_history_size = self.history_size();

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -232,7 +232,9 @@ impl<T> Storage<T> {
 
     /// Rotate the grid up, moving all existing lines down in history.
     ///
-    /// This is a faster, specialized version of [`rotate`].
+    /// This is a faster, specialized version of [`rotate_left`].
+    ///
+    /// [`rotate_left`]: https://doc.rust-lang.org/std/vec/struct.Vec.html#method.rotate_left
     #[inline]
     pub fn rotate_up(&mut self, count: usize) {
         self.zero = (self.zero + count) % self.inner.len();

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -1,7 +1,6 @@
 //! Tests for the Grid.
 
-use super::{BidirectionalIterator, Grid};
-use crate::grid::GridCell;
+use super::{BidirectionalIterator, Dimensions, Grid, GridCell};
 use crate::index::{Column, Line, Point};
 use crate::term::cell::{Cell, Flags};
 
@@ -171,7 +170,7 @@ fn shrink_reflow() {
 
     grid.resize(true, Line(1), Column(2));
 
-    assert_eq!(grid.len(), 3);
+    assert_eq!(grid.total_lines(), 3);
 
     assert_eq!(grid[2].len(), 2);
     assert_eq!(grid[2][Column(0)], cell('1'));
@@ -198,7 +197,7 @@ fn shrink_reflow_twice() {
     grid.resize(true, Line(1), Column(4));
     grid.resize(true, Line(1), Column(2));
 
-    assert_eq!(grid.len(), 3);
+    assert_eq!(grid.total_lines(), 3);
 
     assert_eq!(grid[2].len(), 2);
     assert_eq!(grid[2][Column(0)], cell('1'));
@@ -224,7 +223,7 @@ fn shrink_reflow_empty_cell_inside_line() {
 
     grid.resize(true, Line(1), Column(2));
 
-    assert_eq!(grid.len(), 2);
+    assert_eq!(grid.total_lines(), 2);
 
     assert_eq!(grid[1].len(), 2);
     assert_eq!(grid[1][Column(0)], cell('1'));
@@ -236,7 +235,7 @@ fn shrink_reflow_empty_cell_inside_line() {
 
     grid.resize(true, Line(1), Column(1));
 
-    assert_eq!(grid.len(), 4);
+    assert_eq!(grid.total_lines(), 4);
 
     assert_eq!(grid[3].len(), 1);
     assert_eq!(grid[3][Column(0)], wrap_cell('1'));
@@ -261,7 +260,7 @@ fn grow_reflow() {
 
     grid.resize(true, Line(2), Column(3));
 
-    assert_eq!(grid.len(), 2);
+    assert_eq!(grid.total_lines(), 2);
 
     assert_eq!(grid[1].len(), 3);
     assert_eq!(grid[1][Column(0)], cell('1'));
@@ -287,7 +286,7 @@ fn grow_reflow_multiline() {
 
     grid.resize(true, Line(3), Column(6));
 
-    assert_eq!(grid.len(), 3);
+    assert_eq!(grid.total_lines(), 3);
 
     assert_eq!(grid[2].len(), 6);
     assert_eq!(grid[2][Column(0)], cell('1'));
@@ -318,7 +317,7 @@ fn grow_reflow_disabled() {
 
     grid.resize(false, Line(2), Column(3));
 
-    assert_eq!(grid.len(), 2);
+    assert_eq!(grid.total_lines(), 2);
 
     assert_eq!(grid[1].len(), 3);
     assert_eq!(grid[1][Column(0)], cell('1'));
@@ -342,7 +341,7 @@ fn shrink_reflow_disabled() {
 
     grid.resize(false, Line(1), Column(2));
 
-    assert_eq!(grid.len(), 1);
+    assert_eq!(grid.total_lines(), 1);
 
     assert_eq!(grid[0].len(), 2);
     assert_eq!(grid[0][Column(0)], cell('1'));

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -45,7 +45,7 @@ pub enum Boundary {
 }
 
 /// Index in the grid using row, column notation.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, PartialOrd)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Point<L = Line> {
     pub line: L,
     pub col: Column,
@@ -136,13 +136,32 @@ impl Point<usize> {
     }
 }
 
+impl PartialOrd for Point {
+    fn partial_cmp(&self, other: &Point) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl Ord for Point {
     fn cmp(&self, other: &Point) -> Ordering {
         match (self.line.cmp(&other.line), self.col.cmp(&other.col)) {
-            (Ordering::Equal, Ordering::Equal) => Ordering::Equal,
-            (Ordering::Equal, ord) | (ord, Ordering::Equal) => ord,
-            (Ordering::Less, _) => Ordering::Less,
-            (Ordering::Greater, _) => Ordering::Greater,
+            (Ordering::Equal, ord) | (ord, _) => ord,
+        }
+    }
+}
+
+impl PartialOrd for Point<usize> {
+    fn partial_cmp(&self, other: &Point<usize>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Point<usize> {
+    fn cmp(&self, other: &Point<usize>) -> Ordering {
+        match (self.line.cmp(&other.line), self.col.cmp(&other.col)) {
+            (Ordering::Equal, ord) => ord,
+            (Ordering::Less, _) => Ordering::Greater,
+            (Ordering::Greater, _) => Ordering::Less,
         }
     }
 }

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -29,6 +29,21 @@ impl Direction {
     }
 }
 
+/// Behavior for handling grid boundaries.
+pub enum Boundary {
+    /// Clamp to grid boundaries.
+    ///
+    /// When an operation exceeds the grid boundaries, the last point will be returned no matter
+    /// how far the boundaries were exceeded.
+    Clamp,
+
+    /// Wrap around grid bondaries.
+    ///
+    /// When an operation exceeds the grid boundaries, the point will wrap around the entire grid
+    /// history and continue at the other side.
+    Wrap,
+}
+
 /// Index in the grid using row, column notation.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, PartialOrd)]
 pub struct Point<L = Line> {
@@ -79,7 +94,7 @@ impl Point<usize> {
         D: Dimensions,
     {
         let total_lines = dimensions.total_lines();
-        let num_cols = dimensions.num_cols().0;
+        let num_cols = dimensions.cols().0;
 
         self.line += (rhs + num_cols - 1).saturating_sub(self.col.0) / num_cols;
         self.col = Column((num_cols + self.col.0 - rhs % num_cols) % num_cols);
@@ -100,7 +115,7 @@ impl Point<usize> {
     where
         D: Dimensions,
     {
-        let num_cols = dimensions.num_cols();
+        let num_cols = dimensions.cols();
 
         let line_delta = (rhs + self.col.0) / num_cols.0;
 
@@ -119,21 +134,6 @@ impl Point<usize> {
             }
         }
     }
-}
-
-/// Behavior for handling grid boundaries.
-pub enum Boundary {
-    /// Clamp to grid boundaries.
-    ///
-    /// When an operation exceeds the grid boundaries, the last point will be returned no matter
-    /// how far the boundaries were exceeded.
-    Clamp,
-
-    /// Wrap around grid bondaries.
-    ///
-    /// When an operation exceeds the grid boundaries, the point will wrap around the entire grid
-    /// history and continue at the other side.
-    Wrap,
 }
 
 impl Ord for Point {

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -7,16 +7,20 @@ use std::ops::{self, Add, AddAssign, Deref, Range, Sub, SubAssign};
 
 use serde::{Deserialize, Serialize};
 
+use crate::grid::Dimensions;
 use crate::term::RenderableCell;
 
 /// The side of a cell.
+pub type Side = Direction;
+
+/// Horizontal direction.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum Side {
+pub enum Direction {
     Left,
     Right,
 }
 
-impl Side {
+impl Direction {
     pub fn opposite(self) -> Self {
         match self {
             Side::Right => Side::Left,
@@ -65,34 +69,71 @@ impl<L> Point<L> {
         self.col = Column((self.col.0 + rhs) % num_cols);
         self
     }
+}
 
+impl Point<usize> {
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn sub_absolute(mut self, num_cols: Column, rhs: usize) -> Point<L>
+    pub fn sub_absolute<D>(mut self, dimensions: &D, boundary: Boundary, rhs: usize) -> Point<usize>
     where
-        L: Copy + Default + Into<Line> + Add<usize, Output = L> + Sub<usize, Output = L>,
+        D: Dimensions,
     {
-        let num_cols = num_cols.0;
-        self.line = self.line + ((rhs + num_cols - 1).saturating_sub(self.col.0) / num_cols);
+        let total_lines = dimensions.total_lines();
+        let num_cols = dimensions.num_cols().0;
+
+        self.line += (rhs + num_cols - 1).saturating_sub(self.col.0) / num_cols;
         self.col = Column((num_cols + self.col.0 - rhs % num_cols) % num_cols);
-        self
+
+        if self.line >= total_lines {
+            match boundary {
+                Boundary::Clamp => Point::new(total_lines - 1, Column(0)),
+                Boundary::Wrap => Point::new(self.line - total_lines, self.col),
+            }
+        } else {
+            self
+        }
     }
 
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn add_absolute(mut self, num_cols: Column, rhs: usize) -> Point<L>
+    pub fn add_absolute<D>(mut self, dimensions: &D, boundary: Boundary, rhs: usize) -> Point<usize>
     where
-        L: Copy + Default + Into<Line> + Add<usize, Output = L> + Sub<usize, Output = L>,
+        D: Dimensions,
     {
-        let line_changes = (rhs + self.col.0) / num_cols.0;
-        if self.line.into() >= Line(line_changes) {
-            self.line = self.line - line_changes;
+        let num_cols = dimensions.num_cols();
+
+        let line_delta = (rhs + self.col.0) / num_cols.0;
+
+        if self.line >= line_delta {
+            self.line -= line_delta;
             self.col = Column((self.col.0 + rhs) % num_cols.0);
             self
         } else {
-            Point::new(L::default(), num_cols - 1)
+            match boundary {
+                Boundary::Clamp => Point::new(0, num_cols - 1),
+                Boundary::Wrap => {
+                    let col = Column((self.col.0 + rhs) % num_cols.0);
+                    let line = dimensions.total_lines() + self.line - line_delta;
+                    Point::new(line, col)
+                },
+            }
         }
     }
+}
+
+/// Behavior for handling grid boundaries.
+pub enum Boundary {
+    /// Clamp to grid boundaries.
+    ///
+    /// When an operation exceeds the grid boundaries, the last point will be returned no matter
+    /// how far the boundaries were exceeded.
+    Clamp,
+
+    /// Wrap around grid bondaries.
+    ///
+    /// When an operation exceeds the grid boundaries, the point will wrap around the entire grid
+    /// history and continue at the other side.
+    Wrap,
 }
 
 impl Ord for Point {
@@ -429,7 +470,7 @@ ops!(Linear, Linear);
 
 #[cfg(test)]
 mod tests {
-    use super::{Column, Line, Point};
+    use super::*;
 
     #[test]
     fn location_ordering() {
@@ -493,51 +534,100 @@ mod tests {
 
     #[test]
     fn add_absolute() {
-        let num_cols = Column(42);
         let point = Point::new(0, Column(13));
 
-        let result = point.add_absolute(num_cols, 1);
+        let result = point.add_absolute(&(Line(1), Column(42)), Boundary::Clamp, 1);
 
         assert_eq!(result, Point::new(0, point.col + 1));
     }
 
     #[test]
-    fn add_absolute_wrap() {
-        let num_cols = Column(42);
-        let point = Point::new(1, num_cols - 1);
+    fn add_absolute_wrapline() {
+        let point = Point::new(1, Column(41));
 
-        let result = point.add_absolute(num_cols, 1);
+        let result = point.add_absolute(&(Line(2), Column(42)), Boundary::Clamp, 1);
+
+        assert_eq!(result, Point::new(0, Column(0)));
+    }
+
+    #[test]
+    fn add_absolute_multiline_wrapline() {
+        let point = Point::new(2, Column(9));
+
+        let result = point.add_absolute(&(Line(3), Column(10)), Boundary::Clamp, 11);
 
         assert_eq!(result, Point::new(0, Column(0)));
     }
 
     #[test]
     fn add_absolute_clamp() {
-        let num_cols = Column(42);
-        let point = Point::new(0, num_cols - 1);
+        let point = Point::new(0, Column(41));
 
-        let result = point.add_absolute(num_cols, 1);
+        let result = point.add_absolute(&(Line(1), Column(42)), Boundary::Clamp, 1);
 
         assert_eq!(result, point);
     }
 
     #[test]
+    fn add_absolute_wrap() {
+        let point = Point::new(0, Column(41));
+
+        let result = point.add_absolute(&(Line(3), Column(42)), Boundary::Wrap, 1);
+
+        assert_eq!(result, Point::new(2, Column(0)));
+    }
+
+    #[test]
+    fn add_absolute_multiline_wrap() {
+        let point = Point::new(0, Column(9));
+
+        let result = point.add_absolute(&(Line(3), Column(10)), Boundary::Wrap, 11);
+
+        assert_eq!(result, Point::new(1, Column(0)));
+    }
+
+    #[test]
     fn sub_absolute() {
-        let num_cols = Column(42);
         let point = Point::new(0, Column(13));
 
-        let result = point.sub_absolute(num_cols, 1);
+        let result = point.sub_absolute(&(Line(1), Column(42)), Boundary::Clamp, 1);
 
         assert_eq!(result, Point::new(0, point.col - 1));
     }
 
     #[test]
-    fn sub_absolute_wrap() {
-        let num_cols = Column(42);
+    fn sub_absolute_wrapline() {
         let point = Point::new(0, Column(0));
 
-        let result = point.sub_absolute(num_cols, 1);
+        let result = point.sub_absolute(&(Line(2), Column(42)), Boundary::Clamp, 1);
 
-        assert_eq!(result, Point::new(1, num_cols - 1));
+        assert_eq!(result, Point::new(1, Column(41)));
+    }
+
+    #[test]
+    fn sub_absolute_multiline_wrapline() {
+        let point = Point::new(0, Column(0));
+
+        let result = point.sub_absolute(&(Line(3), Column(10)), Boundary::Clamp, 11);
+
+        assert_eq!(result, Point::new(2, Column(9)));
+    }
+
+    #[test]
+    fn sub_absolute_wrap() {
+        let point = Point::new(2, Column(0));
+
+        let result = point.sub_absolute(&(Line(3), Column(42)), Boundary::Wrap, 1);
+
+        assert_eq!(result, Point::new(0, Column(41)));
+    }
+
+    #[test]
+    fn sub_absolute_multiline_wrap() {
+        let point = Point::new(2, Column(0));
+
+        let result = point.sub_absolute(&(Line(3), Column(10)), Boundary::Wrap, 11);
+
+        assert_eq!(result, Point::new(1, Column(9)));
     }
 }

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -9,8 +9,9 @@ use std::convert::TryFrom;
 use std::mem;
 use std::ops::{Bound, Range, RangeBounds};
 
+use crate::grid::Dimensions;
 use crate::index::{Column, Line, Point, Side};
-use crate::term::{Search, Term};
+use crate::term::Term;
 
 /// A Point and side within that point.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -98,20 +99,19 @@ impl Selection {
         self.region.end = Anchor::new(point, side);
     }
 
-    pub fn rotate(
+    pub fn rotate<D: Dimensions>(
         mut self,
-        num_lines: Line,
-        num_cols: Column,
+        dimensions: &D,
         range: &Range<Line>,
         delta: isize,
     ) -> Option<Selection> {
+        let num_lines = dimensions.num_lines().0;
+        let num_cols = dimensions.num_cols().0;
         let range_bottom = range.start.0;
         let range_top = range.end.0;
-        let num_lines = num_lines.0;
-        let num_cols = num_cols.0;
 
         let (mut start, mut end) = (&mut self.region.start, &mut self.region.end);
-        if Self::points_need_swap(start.point, end.point) {
+        if Selection::points_need_swap(start.point, end.point) {
             mem::swap(&mut start, &mut end);
         }
 
@@ -250,7 +250,7 @@ impl Selection {
 
         // Clamp to inside the grid buffer.
         let is_block = self.ty == SelectionType::Block;
-        let (start, end) = Self::grid_clamp(start, end, is_block, grid.len()).ok()?;
+        let (start, end) = Self::grid_clamp(start, end, is_block, grid.total_lines()).ok()?;
 
         match self.ty {
             SelectionType::Simple => self.range_simple(start, end, num_cols),
@@ -408,7 +408,7 @@ mod tests {
         fn send_event(&self, _event: Event) {}
     }
 
-    fn term(width: usize, height: usize) -> Term<Mock> {
+    fn term(height: usize, width: usize) -> Term<Mock> {
         let size = SizeInfo {
             width: width as f32,
             height: height as f32,
@@ -468,7 +468,7 @@ mod tests {
             Selection::new(SelectionType::Simple, Point::new(0, Column(0)), Side::Right);
         selection.update(Point::new(0, Column(1)), Side::Left);
 
-        assert_eq!(selection.to_range(&term(2, 1)), None);
+        assert_eq!(selection.to_range(&term(1, 2)), None);
     }
 
     /// Test adjacent cell selection from right to left.
@@ -482,7 +482,7 @@ mod tests {
             Selection::new(SelectionType::Simple, Point::new(0, Column(1)), Side::Left);
         selection.update(Point::new(0, Column(0)), Side::Right);
 
-        assert_eq!(selection.to_range(&term(2, 1)), None);
+        assert_eq!(selection.to_range(&term(1, 2)), None);
     }
 
     /// Test selection across adjacent lines.
@@ -499,7 +499,7 @@ mod tests {
             Selection::new(SelectionType::Simple, Point::new(1, Column(1)), Side::Right);
         selection.update(Point::new(0, Column(1)), Side::Right);
 
-        assert_eq!(selection.to_range(&term(5, 2)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(2, 5)).unwrap(), SelectionRange {
             start: Point::new(1, Column(2)),
             end: Point::new(0, Column(1)),
             is_block: false,
@@ -523,7 +523,7 @@ mod tests {
         selection.update(Point::new(1, Column(1)), Side::Right);
         selection.update(Point::new(1, Column(0)), Side::Right);
 
-        assert_eq!(selection.to_range(&term(5, 2)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(2, 5)).unwrap(), SelectionRange {
             start: Point::new(1, Column(1)),
             end: Point::new(0, Column(1)),
             is_block: false,
@@ -532,14 +532,13 @@ mod tests {
 
     #[test]
     fn line_selection() {
-        let num_lines = Line(10);
-        let num_cols = Column(5);
+        let size = (Line(10), Column(5));
         let mut selection =
             Selection::new(SelectionType::Lines, Point::new(0, Column(1)), Side::Left);
         selection.update(Point::new(5, Column(1)), Side::Right);
-        selection = selection.rotate(num_lines, num_cols, &(Line(0)..num_lines), 7).unwrap();
+        selection = selection.rotate(&size, &(Line(0)..size.0), 7).unwrap();
 
-        assert_eq!(selection.to_range(&term(num_cols.0, num_lines.0)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(*size.0, *size.1)).unwrap(), SelectionRange {
             start: Point::new(9, Column(0)),
             end: Point::new(7, Column(4)),
             is_block: false,
@@ -548,14 +547,13 @@ mod tests {
 
     #[test]
     fn semantic_selection() {
-        let num_lines = Line(10);
-        let num_cols = Column(5);
+        let size = (Line(10), Column(5));
         let mut selection =
             Selection::new(SelectionType::Semantic, Point::new(0, Column(3)), Side::Left);
         selection.update(Point::new(5, Column(1)), Side::Right);
-        selection = selection.rotate(num_lines, num_cols, &(Line(0)..num_lines), 7).unwrap();
+        selection = selection.rotate(&size, &(Line(0)..size.0), 7).unwrap();
 
-        assert_eq!(selection.to_range(&term(num_cols.0, num_lines.0)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(*size.0, *size.1)).unwrap(), SelectionRange {
             start: Point::new(9, Column(0)),
             end: Point::new(7, Column(3)),
             is_block: false,
@@ -564,14 +562,13 @@ mod tests {
 
     #[test]
     fn simple_selection() {
-        let num_lines = Line(10);
-        let num_cols = Column(5);
+        let size = (Line(10), Column(5));
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(0, Column(3)), Side::Right);
         selection.update(Point::new(5, Column(1)), Side::Right);
-        selection = selection.rotate(num_lines, num_cols, &(Line(0)..num_lines), 7).unwrap();
+        selection = selection.rotate(&size, &(Line(0)..size.0), 7).unwrap();
 
-        assert_eq!(selection.to_range(&term(num_cols.0, num_lines.0)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(*size.0, *size.1)).unwrap(), SelectionRange {
             start: Point::new(9, Column(0)),
             end: Point::new(7, Column(3)),
             is_block: false,
@@ -580,14 +577,13 @@ mod tests {
 
     #[test]
     fn block_selection() {
-        let num_lines = Line(10);
-        let num_cols = Column(5);
+        let size = (Line(10), Column(5));
         let mut selection =
             Selection::new(SelectionType::Block, Point::new(0, Column(3)), Side::Right);
         selection.update(Point::new(5, Column(1)), Side::Right);
-        selection = selection.rotate(num_lines, num_cols, &(Line(0)..num_lines), 7).unwrap();
+        selection = selection.rotate(&size, &(Line(0)..size.0), 7).unwrap();
 
-        assert_eq!(selection.to_range(&term(num_cols.0, num_lines.0)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(*size.0, *size.1)).unwrap(), SelectionRange {
             start: Point::new(9, Column(2)),
             end: Point::new(7, Column(3)),
             is_block: true
@@ -624,14 +620,13 @@ mod tests {
 
     #[test]
     fn rotate_in_region_up() {
-        let num_lines = Line(10);
-        let num_cols = Column(5);
+        let size = (Line(10), Column(5));
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(2, Column(3)), Side::Right);
         selection.update(Point::new(5, Column(1)), Side::Right);
-        selection = selection.rotate(num_lines, num_cols, &(Line(1)..(num_lines - 1)), 4).unwrap();
+        selection = selection.rotate(&size, &(Line(1)..(size.0 - 1)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(num_cols.0, num_lines.0)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(*size.0, *size.1)).unwrap(), SelectionRange {
             start: Point::new(8, Column(0)),
             end: Point::new(6, Column(3)),
             is_block: false,
@@ -640,30 +635,28 @@ mod tests {
 
     #[test]
     fn rotate_in_region_down() {
-        let num_lines = Line(10);
-        let num_cols = Column(5);
+        let size = (Line(10), Column(5));
         let mut selection =
             Selection::new(SelectionType::Simple, Point::new(5, Column(3)), Side::Right);
         selection.update(Point::new(8, Column(1)), Side::Left);
-        selection = selection.rotate(num_lines, num_cols, &(Line(1)..(num_lines - 1)), -5).unwrap();
+        selection = selection.rotate(&size, &(Line(1)..(size.0 - 1)), -5).unwrap();
 
-        assert_eq!(selection.to_range(&term(num_cols.0, num_lines.0)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(*size.0, *size.1)).unwrap(), SelectionRange {
             start: Point::new(3, Column(1)),
-            end: Point::new(1, num_cols - 1),
+            end: Point::new(1, size.1 - 1),
             is_block: false,
         });
     }
 
     #[test]
     fn rotate_in_region_up_block() {
-        let num_lines = Line(10);
-        let num_cols = Column(5);
+        let size = (Line(10), Column(5));
         let mut selection =
             Selection::new(SelectionType::Block, Point::new(2, Column(3)), Side::Right);
         selection.update(Point::new(5, Column(1)), Side::Right);
-        selection = selection.rotate(num_lines, num_cols, &(Line(1)..(num_lines - 1)), 4).unwrap();
+        selection = selection.rotate(&size, &(Line(1)..(size.0 - 1)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(num_cols.0, num_lines.0)).unwrap(), SelectionRange {
+        assert_eq!(selection.to_range(&term(*size.0, *size.1)).unwrap(), SelectionRange {
             start: Point::new(8, Column(2)),
             end: Point::new(6, Column(3)),
             is_block: true,

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -105,8 +105,8 @@ impl Selection {
         range: &Range<Line>,
         delta: isize,
     ) -> Option<Selection> {
-        let num_lines = dimensions.num_lines().0;
-        let num_cols = dimensions.num_cols().0;
+        let num_lines = dimensions.screen_lines().0;
+        let num_cols = dimensions.cols().0;
         let range_bottom = range.start.0;
         let range_top = range.end.0;
 
@@ -238,7 +238,7 @@ impl Selection {
     /// Convert selection to grid coordinates.
     pub fn to_range<T>(&self, term: &Term<T>) -> Option<SelectionRange> {
         let grid = term.grid();
-        let num_cols = grid.num_cols();
+        let num_cols = grid.cols();
 
         // Order start above the end.
         let mut start = self.region.start;

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -12,18 +12,19 @@ pub const MAX_ZEROWIDTH_CHARS: usize = 5;
 bitflags! {
     #[derive(Serialize, Deserialize)]
     pub struct Flags: u16 {
-        const INVERSE           = 0b00_0000_0001;
-        const BOLD              = 0b00_0000_0010;
-        const ITALIC            = 0b00_0000_0100;
-        const BOLD_ITALIC       = 0b00_0000_0110;
-        const UNDERLINE         = 0b00_0000_1000;
-        const WRAPLINE          = 0b00_0001_0000;
-        const WIDE_CHAR         = 0b00_0010_0000;
-        const WIDE_CHAR_SPACER  = 0b00_0100_0000;
-        const DIM               = 0b00_1000_0000;
-        const DIM_BOLD          = 0b00_1000_0010;
-        const HIDDEN            = 0b01_0000_0000;
-        const STRIKEOUT         = 0b10_0000_0000;
+        const INVERSE                   = 0b000_0000_0001;
+        const BOLD                      = 0b000_0000_0010;
+        const ITALIC                    = 0b000_0000_0100;
+        const BOLD_ITALIC               = 0b000_0000_0110;
+        const UNDERLINE                 = 0b000_0000_1000;
+        const WRAPLINE                  = 0b000_0001_0000;
+        const WIDE_CHAR                 = 0b000_0010_0000;
+        const WIDE_CHAR_SPACER          = 0b000_0100_0000;
+        const DIM                       = 0b000_1000_0000;
+        const DIM_BOLD                  = 0b000_1000_0010;
+        const HIDDEN                    = 0b001_0000_0000;
+        const STRIKEOUT                 = 0b010_0000_0000;
+        const LEADING_WIDE_CHAR_SPACER  = 0b100_0000_0000;
     }
 }
 
@@ -59,7 +60,8 @@ impl GridCell for Cell {
                     | Flags::UNDERLINE
                     | Flags::STRIKEOUT
                     | Flags::WRAPLINE
-                    | Flags::WIDE_CHAR_SPACER,
+                    | Flags::WIDE_CHAR_SPACER
+                    | Flags::LEADING_WIDE_CHAR_SPACER,
             )
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1,11 +1,11 @@
 //! Exports the `Term` type which is a high-level API for the Grid.
 
 use std::cmp::{max, min};
+use std::iter::Peekable;
 use std::ops::{Index, IndexMut, Range, RangeInclusive};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{io, iter, mem, ptr, str};
-use std::iter::Peekable;
 
 use log::{debug, trace};
 use serde::{Deserialize, Serialize};
@@ -90,9 +90,10 @@ impl<'a> RenderableSearch<'a> {
         end.line = max(end.line, viewport_end.saturating_sub(MAX_SEARCH_LINES));
 
         // Create an iterater for the current regex search for all visible matches.
-        let iter: MatchIter<'a> = Box::new(RegexIter::new(start, end, Direction::Right, &term)
-            .skip_while(move |rm| rm.end().line > viewport_start)
-            .take_while(move |rm| rm.start().line >= viewport_end)
+        let iter: MatchIter<'a> = Box::new(
+            RegexIter::new(start, end, Direction::Right, &term)
+                .skip_while(move |rm| rm.end().line > viewport_start)
+                .take_while(move |rm| rm.start().line >= viewport_end),
         );
 
         Self { iter: iter.peekable() }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1,37 +1,37 @@
 //! Exports the `Term` type which is a high-level API for the Grid.
 
 use std::cmp::{max, min};
-use std::ops::{Index, IndexMut, Range};
+use std::ops::{Index, IndexMut, Range, RangeInclusive};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{io, mem, ptr, str};
+use std::{io, iter, mem, ptr, str};
 
 use log::{debug, trace};
 use serde::{Deserialize, Serialize};
 use unicode_width::UnicodeWidthChar;
 
 use crate::ansi::{
-    self, Attr, CharsetIndex, Color, CursorStyle, Handler, NamedColor, StandardCharset, TermInfo,
+    self, Attr, CharsetIndex, Color, CursorStyle, Handler, NamedColor, StandardCharset,
 };
 use crate::config::{Config, VisualBellAnimation};
 use crate::event::{Event, EventListener};
-use crate::grid::{
-    BidirectionalIterator, DisplayIter, Grid, GridCell, IndexRegion, Indexed, Scroll,
-};
-use crate::index::{self, Column, IndexRange, Line, Point, Side};
+use crate::grid::{Dimensions, DisplayIter, Grid, IndexRegion, Indexed, Scroll};
+use crate::index::{self, Boundary, Column, Direction, IndexRange, Line, Point, Side};
 use crate::selection::{Selection, SelectionRange};
 use crate::term::cell::{Cell, Flags, LineLength};
-use crate::term::color::{Rgb, DIM_FACTOR};
+use crate::term::color::{CellRgb, Rgb, DIM_FACTOR};
+use crate::term::search::{Match, RegexIter, RegexSearch};
 use crate::vi_mode::{ViModeCursor, ViMotion};
 
 pub mod cell;
 pub mod color;
-
-/// Used to match equal brackets, when performing a bracket-pair selection.
-const BRACKET_PAIRS: [(char, char); 4] = [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
+mod search;
 
 /// Max size of the window title stack.
 const TITLE_STACK_MAX_DEPTH: usize = 4096;
+
+/// Maximum number of linewraps followed outside of the viewport during search highlighting.
+const MAX_SEARCH_LINES: usize = 100;
 
 /// Default tab interval, corresponding to terminfo `it` value.
 const INITIAL_TABSTOPS: usize = 8;
@@ -39,145 +39,11 @@ const INITIAL_TABSTOPS: usize = 8;
 /// Minimum number of columns and lines.
 const MIN_SIZE: usize = 2;
 
-/// A type that can expand a given point to a region.
-///
-/// Usually this is implemented for some 2-D array type since
-/// points are two dimensional indices.
-pub trait Search {
-    /// Find the nearest semantic boundary _to the left_ of provided point.
-    fn semantic_search_left(&self, _: Point<usize>) -> Point<usize>;
-    /// Find the nearest semantic boundary _to the point_ of provided point.
-    fn semantic_search_right(&self, _: Point<usize>) -> Point<usize>;
-    /// Find the beginning of a line, following line wraps.
-    fn line_search_left(&self, _: Point<usize>) -> Point<usize>;
-    /// Find the end of a line, following line wraps.
-    fn line_search_right(&self, _: Point<usize>) -> Point<usize>;
-    /// Find the nearest matching bracket.
-    fn bracket_search(&self, _: Point<usize>) -> Option<Point<usize>>;
-}
-
-impl<T> Search for Term<T> {
-    fn semantic_search_left(&self, mut point: Point<usize>) -> Point<usize> {
-        // Limit the starting point to the last line in the history.
-        point.line = min(point.line, self.grid.len() - 1);
-
-        let mut iter = self.grid.iter_from(point);
-        let last_col = self.grid.num_cols() - Column(1);
-
-        while let Some(cell) = iter.prev() {
-            if !cell.flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER)
-                && self.semantic_escape_chars.contains(cell.c)
-            {
-                break;
-            }
-
-            if iter.point().col == last_col && !cell.flags.contains(Flags::WRAPLINE) {
-                // Cut off if on new line or hit escape char.
-                break;
-            }
-
-            point = iter.point();
-        }
-
-        point
-    }
-
-    fn semantic_search_right(&self, mut point: Point<usize>) -> Point<usize> {
-        // Limit the starting point to the last line in the history.
-        point.line = min(point.line, self.grid.len() - 1);
-
-        let mut iter = self.grid.iter_from(point);
-        let last_col = self.grid.num_cols() - 1;
-
-        while let Some(cell) = iter.next() {
-            if !cell.flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER)
-                && self.semantic_escape_chars.contains(cell.c)
-            {
-                break;
-            }
-
-            point = iter.point();
-
-            if point.col == last_col && !cell.flags.contains(Flags::WRAPLINE) {
-                // Cut off if on new line or hit escape char.
-                break;
-            }
-        }
-
-        point
-    }
-
-    fn line_search_left(&self, mut point: Point<usize>) -> Point<usize> {
-        while point.line + 1 < self.grid.len()
-            && self.grid[point.line + 1][self.grid.num_cols() - 1].flags.contains(Flags::WRAPLINE)
-        {
-            point.line += 1;
-        }
-
-        point.col = Column(0);
-
-        point
-    }
-
-    fn line_search_right(&self, mut point: Point<usize>) -> Point<usize> {
-        while self.grid[point.line][self.grid.num_cols() - 1].flags.contains(Flags::WRAPLINE) {
-            point.line -= 1;
-        }
-
-        point.col = self.grid.num_cols() - 1;
-
-        point
-    }
-
-    fn bracket_search(&self, point: Point<usize>) -> Option<Point<usize>> {
-        let start_char = self.grid[point.line][point.col].c;
-
-        // Find the matching bracket we're looking for.
-        let (forwards, end_char) = BRACKET_PAIRS.iter().find_map(|(open, close)| {
-            if open == &start_char {
-                Some((true, *close))
-            } else if close == &start_char {
-                Some((false, *open))
-            } else {
-                None
-            }
-        })?;
-
-        let mut iter = self.grid.iter_from(point);
-
-        // For every character match that equals the starting bracket, we
-        // ignore one bracket of the opposite type.
-        let mut skip_pairs = 0;
-
-        loop {
-            // Check the next cell.
-            let cell = if forwards { iter.next() } else { iter.prev() };
-
-            // Break if there are no more cells.
-            let c = match cell {
-                Some(cell) => cell.c,
-                None => break,
-            };
-
-            // Check if the bracket matches.
-            if c == end_char && skip_pairs == 0 {
-                return Some(iter.point());
-            } else if c == start_char {
-                skip_pairs += 1;
-            } else if c == end_char {
-                skip_pairs -= 1;
-            }
-        }
-
-        None
-    }
-}
-
 /// Cursor storing all information relevant for rendering.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize)]
 struct RenderableCursor {
-    text_color: Option<Rgb>,
-    cursor_color: Option<Rgb>,
+    text_color: CellRgb,
+    cursor_color: CellRgb,
     key: CursorKey,
     point: Point,
     rendered: bool,
@@ -188,6 +54,64 @@ struct RenderableCursor {
 pub struct CursorKey {
     pub style: CursorStyle,
     pub is_wide: bool,
+}
+
+/// Regex search highlight tracking.
+pub struct RenderableSearch<'a> {
+    iter: Box<dyn Iterator<Item = Match> + 'a>,
+    active_match: Option<RangeInclusive<Point>>,
+}
+
+impl<'a> RenderableSearch<'a> {
+    /// Create a new renderable search iterator.
+    pub fn new<T>(term: &'a Term<T>) -> Self {
+        let mut renderable_search = Self { iter: Self::new_iter(term), active_match: None };
+
+        // Load the first match, so the active match is only `None` once done.
+        renderable_search.advance_match(term.grid());
+
+        renderable_search
+    }
+
+    /// Move the current regex match to the next result.
+    pub fn advance_match<G>(&mut self, grid: &Grid<G>) {
+        self.active_match = self.iter.next().map(|rm| {
+            let start = grid.clamp_buffer_to_visible(*rm.start());
+            let end = grid.clamp_buffer_to_visible(*rm.end());
+            start..=end
+        });
+    }
+
+    /// Create the underlying iterator.
+    fn new_iter<'t, T>(term: &'t Term<T>) -> Box<dyn Iterator<Item = Match> + 't> {
+        let viewport_end = term.grid().display_offset();
+        let viewport_start = viewport_end + term.grid().num_lines().0 - 1;
+
+        // Compute start of the first and end of the last line.
+        let start_point = Point::new(viewport_start, Column(0));
+        let mut start = term.line_search_left(start_point);
+        let end_point = Point::new(viewport_end, term.grid().num_cols() - 1);
+        let mut end = term.line_search_right(end_point);
+
+        // Set upper bound on search before/after the viewport to prevent excessive blocking.
+        if start.line > viewport_start + MAX_SEARCH_LINES {
+            if start.line == 0 {
+                // Do not highlight anything if this line is the last.
+                return Box::new(iter::empty());
+            } else {
+                // Start at next line if this one is too long.
+                start.line -= 1;
+            }
+        }
+        end.line = max(end.line, viewport_end.saturating_sub(MAX_SEARCH_LINES));
+
+        // Create an iterater for the current regex search for all visible matches.
+        Box::new(
+            RegexIter::new(start, end, Direction::Right, &term)
+                .skip_while(move |rm| rm.end().line > viewport_start)
+                .take_while(move |rm| rm.start().line >= viewport_end),
+        )
+    }
 }
 
 /// Iterator that yields cells needing render.
@@ -205,6 +129,7 @@ pub struct RenderableCellsIter<'a, C> {
     config: &'a Config<C>,
     colors: &'a color::List,
     selection: Option<SelectionRange<Line>>,
+    search: RenderableSearch<'a>,
 }
 
 impl<'a, C> RenderableCellsIter<'a, C> {
@@ -212,14 +137,15 @@ impl<'a, C> RenderableCellsIter<'a, C> {
     ///
     /// The cursor and terminal mode are required for properly displaying the
     /// cursor.
-    fn new<'b, T>(
-        term: &'b Term<T>,
-        config: &'b Config<C>,
+    fn new<T>(
+        term: &'a Term<T>,
+        config: &'a Config<C>,
         selection: Option<SelectionRange>,
-    ) -> RenderableCellsIter<'b, C> {
+    ) -> RenderableCellsIter<'a, C> {
         let grid = &term.grid;
 
-        let inner = grid.display_iter();
+        let viewport_end = grid.display_offset();
+        let viewport_start = viewport_end + grid.num_lines().0 - 1;
 
         let selection_range = selection.and_then(|span| {
             let (limit_start, limit_end) = if span.is_block {
@@ -229,9 +155,7 @@ impl<'a, C> RenderableCellsIter<'a, C> {
             };
 
             // Do not render completely offscreen selection.
-            let viewport_start = grid.display_offset();
-            let viewport_end = viewport_start + grid.num_lines().0;
-            if span.end.line >= viewport_end || span.start.line < viewport_start {
+            if span.end.line > viewport_start || span.start.line < viewport_end {
                 return None;
             }
 
@@ -249,11 +173,27 @@ impl<'a, C> RenderableCellsIter<'a, C> {
         RenderableCellsIter {
             cursor: term.renderable_cursor(config),
             grid,
-            inner,
+            inner: grid.display_iter(),
             selection: selection_range,
             config,
             colors: &term.colors,
+            search: RenderableSearch::new(term),
         }
+    }
+
+    /// Check if point is part of a search match.
+    fn is_matched(&mut self, point: Point) -> bool {
+        while let Some(regex_match) = &self.search.active_match {
+            if regex_match.start() > &point {
+                break;
+            } else if regex_match.end() < &point {
+                self.search.advance_match(self.grid);
+            } else {
+                return true;
+            }
+        }
+
+        false
     }
 
     /// Check selection state of a cell.
@@ -285,15 +225,13 @@ impl<'a, C> RenderableCellsIter<'a, C> {
 
         // Check if wide char's spacers are selected.
         if cell.flags.contains(Flags::WIDE_CHAR) {
-            let prevprev = point.sub(num_cols, 2);
             let prev = point.sub(num_cols, 1);
             let next = point.add(num_cols, 1);
 
             // Check trailing spacer.
             selection.contains(next.col, next.line)
                 // Check line-wrapping, leading spacer.
-                || (self.grid[&prev].flags.contains(Flags::WIDE_CHAR_SPACER)
-                    && !self.grid[&prevprev].flags.contains(Flags::WIDE_CHAR)
+                || (self.grid[&prev].flags.contains(Flags::LEADING_WIDE_CHAR_SPACER)
                     && selection.contains(prev.col, prev.line))
         } else if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
             // Check if spacer's wide char is selected.
@@ -312,7 +250,7 @@ impl<'a, C> RenderableCellsIter<'a, C> {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RenderableCellContent {
     Chars([char; cell::MAX_ZEROWIDTH_CHARS + 1]),
     Cursor(CursorKey),
@@ -331,39 +269,39 @@ pub struct RenderableCell {
 }
 
 impl RenderableCell {
-    fn new<C>(
-        config: &Config<C>,
-        colors: &color::List,
-        cell: Indexed<Cell>,
-        selected: bool,
-    ) -> Self {
+    fn new<'a, C>(iter: &mut RenderableCellsIter<'a, C>, cell: Indexed<Cell>) -> Self {
+        let point = Point::new(cell.line, cell.column);
+        let matched = iter.is_matched(point);
+
+        let config = &iter.config;
+        let colors = &iter.colors;
+
         // Lookup RGB values.
         let mut fg_rgb = Self::compute_fg_rgb(config, colors, cell.fg, cell.flags);
         let mut bg_rgb = Self::compute_bg_rgb(colors, cell.bg);
-        let mut bg_alpha = Self::compute_bg_alpha(cell.bg);
 
-        let selection_background = config.colors.selection.background;
-        if let (true, Some(col)) = (selected, selection_background) {
-            // Override selection background with config colors.
-            bg_rgb = col;
-            bg_alpha = 1.0;
-        } else if selected ^ cell.inverse() {
+        if cell.inverse() {
+            mem::swap(&mut fg_rgb, &mut bg_rgb);
+        }
+
+        if iter.is_selected(point) {
+            let selected_fg = config.colors.selection.text().color(fg_rgb, bg_rgb);
+            bg_rgb = config.colors.selection.background().color(fg_rgb, bg_rgb);
+            fg_rgb = selected_fg;
+
             if fg_rgb == bg_rgb && !cell.flags.contains(Flags::HIDDEN) {
                 // Reveal inversed text when fg/bg is the same.
                 fg_rgb = colors[NamedColor::Background];
                 bg_rgb = colors[NamedColor::Foreground];
-            } else {
-                // Invert cell fg and bg colors.
-                mem::swap(&mut fg_rgb, &mut bg_rgb);
             }
-
-            bg_alpha = 1.0;
+        } else if matched {
+            let selected_fg = config.colors.search.matches.foreground.color(fg_rgb, bg_rgb);
+            bg_rgb = config.colors.search.matches.background.color(fg_rgb, bg_rgb);
+            fg_rgb = selected_fg;
         }
 
-        // Override selection text with config colors.
-        if let (true, Some(col)) = (selected, config.colors.selection.text) {
-            fg_rgb = col;
-        }
+        // Set background transparent if it matches the terminal background.
+        let bg_alpha = if bg_rgb == colors[NamedColor::Background] { 0. } else { 1. };
 
         RenderableCell {
             line: cell.line,
@@ -374,6 +312,12 @@ impl RenderableCell {
             bg_alpha,
             flags: cell.flags,
         }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bg_alpha == 0.
+            && !self.flags.intersects(Flags::UNDERLINE | Flags::STRIKEOUT)
+            && self.inner == RenderableCellContent::Chars([' '; cell::MAX_ZEROWIDTH_CHARS + 1])
     }
 
     fn compute_fg_rgb<C>(config: &Config<C>, colors: &color::List, fg: Color, flags: Flags) -> Rgb {
@@ -417,15 +361,6 @@ impl RenderableCell {
     }
 
     #[inline]
-    fn compute_bg_alpha(bg: Color) -> f32 {
-        if bg == Color::Named(NamedColor::Background) {
-            0.
-        } else {
-            1.
-        }
-    }
-
-    #[inline]
     fn compute_bg_rgb(colors: &color::List, bg: Color) -> Rgb {
         match bg {
             Color::Spec(rgb) => rgb,
@@ -448,19 +383,13 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
             if self.cursor.point.line == self.inner.line()
                 && self.cursor.point.col == self.inner.column()
             {
-                let selected = self.is_selected(self.cursor.point);
-
                 // Handle cell below cursor.
                 if self.cursor.rendered {
-                    let mut cell =
-                        RenderableCell::new(self.config, self.colors, self.inner.next()?, selected);
+                    let cell = self.inner.next()?;
+                    let mut cell = RenderableCell::new(self, cell);
 
                     if self.cursor.key.style == CursorStyle::Block {
-                        mem::swap(&mut cell.bg, &mut cell.fg);
-
-                        if let Some(color) = self.cursor.text_color {
-                            cell.fg = color;
-                        }
+                        cell.fg = self.cursor.text_color.color(cell.fg, cell.bg);
                     }
 
                     return Some(cell);
@@ -475,24 +404,18 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                         line: self.cursor.point.line,
                     };
 
-                    let mut renderable_cell =
-                        RenderableCell::new(self.config, self.colors, cell, selected);
+                    let mut cell = RenderableCell::new(self, cell);
+                    cell.inner = RenderableCellContent::Cursor(self.cursor.key);
+                    cell.fg = self.cursor.cursor_color.color(cell.fg, cell.bg);
 
-                    renderable_cell.inner = RenderableCellContent::Cursor(self.cursor.key);
-
-                    if let Some(color) = self.cursor.cursor_color {
-                        renderable_cell.fg = color;
-                    }
-
-                    return Some(renderable_cell);
+                    return Some(cell);
                 }
             } else {
                 let cell = self.inner.next()?;
+                let cell = RenderableCell::new(self, cell);
 
-                let selected = self.is_selected(Point::new(cell.line, cell.column));
-
-                if !cell.is_empty() || selected {
-                    return Some(RenderableCell::new(self.config, self.colors, cell, selected));
+                if !cell.is_empty() {
+                    return Some(cell);
                 }
             }
         }
@@ -760,7 +683,7 @@ pub struct Term<T> {
     tabs: TabStops,
 
     /// Mode flags.
-    mode: TermMode,
+    pub mode: TermMode,
 
     /// Scroll region.
     ///
@@ -802,6 +725,9 @@ pub struct Term<T> {
     /// Stack of saved window titles. When a title is popped from this stack, the `title` for the
     /// term is set, and the Glutin window's title attribute is changed through the event listener.
     title_stack: Vec<Option<String>>,
+
+    /// Current forwards and backwards buffer search regexes.
+    regex_search: Option<RegexSearch>,
 }
 
 impl<T> Term<T> {
@@ -810,8 +736,8 @@ impl<T> Term<T> {
     where
         T: EventListener,
     {
-        self.event_proxy.send_event(Event::MouseCursorDirty);
         self.grid.scroll_display(scroll);
+        self.event_proxy.send_event(Event::MouseCursorDirty);
         self.dirty = true;
     }
 
@@ -853,6 +779,7 @@ impl<T> Term<T> {
             default_title: config.window.title.clone(),
             title_stack: Vec::new(),
             selection: None,
+            regex_search: None,
         }
     }
 
@@ -904,7 +831,7 @@ impl<T> Term<T> {
                 res += &self.line_to_string(line, start.col..end.col, start.col.0 != 0);
 
                 // If the last column is included, newline is appended automatically.
-                if end.col != self.cols() - 1 {
+                if end.col != self.num_cols() - 1 {
                     res += "\n";
                 }
             }
@@ -922,7 +849,7 @@ impl<T> Term<T> {
 
         for line in (end.line..=start.line).rev() {
             let start_col = if line == start.line { start.col } else { Column(0) };
-            let end_col = if line == end.line { end.col } else { self.cols() - 1 };
+            let end_col = if line == end.line { end.col } else { self.num_cols() - 1 };
 
             res += &self.line_to_string(line, start_col..end_col, line == end.line);
         }
@@ -964,7 +891,7 @@ impl<T> Term<T> {
                 tab_mode = true;
             }
 
-            if !cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+            if !cell.flags.intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER) {
                 // Push cells primary character.
                 text.push(cell.c);
 
@@ -975,7 +902,7 @@ impl<T> Term<T> {
             }
         }
 
-        if cols.end >= self.cols() - 1
+        if cols.end >= self.num_cols() - 1
             && (line_length.0 == 0
                 || !self.grid[line][line_length - 1].flags.contains(Flags::WRAPLINE))
         {
@@ -983,10 +910,9 @@ impl<T> Term<T> {
         }
 
         // If wide char is not part of the selection, but leading spacer is, include it.
-        if line_length == self.grid.num_cols()
+        if line_length == self.num_cols()
             && line_length.0 >= 2
-            && grid_line[line_length - 1].flags.contains(Flags::WIDE_CHAR_SPACER)
-            && !grid_line[line_length - 2].flags.contains(Flags::WIDE_CHAR)
+            && grid_line[line_length - 1].flags.contains(Flags::LEADING_WIDE_CHAR_SPACER)
             && include_wrapped_wide
         {
             text.push(self.grid[line - 1][Column(0)].c);
@@ -1026,8 +952,8 @@ impl<T> Term<T> {
 
     /// Resize terminal to new dimensions.
     pub fn resize(&mut self, size: &SizeInfo) {
-        let old_cols = self.grid.num_cols();
-        let old_lines = self.grid.num_lines();
+        let old_cols = self.num_cols();
+        let old_lines = self.num_lines();
         let num_cols = max(size.cols(), Column(MIN_SIZE));
         let num_lines = max(size.lines(), Line(MIN_SIZE));
 
@@ -1047,17 +973,16 @@ impl<T> Term<T> {
         self.vi_mode_cursor.point.col = min(self.vi_mode_cursor.point.col, num_cols - 1);
         self.vi_mode_cursor.point.line = min(self.vi_mode_cursor.point.line, num_lines - 1);
 
-        // Recreate tabs list.
-        self.tabs.resize(self.grid.num_cols());
+        // Reset scrolling region.
+        self.scroll_region = Line(0)..self.num_lines();
 
-        // Reset scrolling region and selection.
-        self.scroll_region = Line(0)..self.grid.num_lines();
-        self.selection = None;
-    }
+        // Invalidate selection and tabs only when necessary.
+        if old_cols != num_cols {
+            self.selection = None;
 
-    #[inline]
-    pub fn mode(&self) -> &TermMode {
-        &self.mode
+            // Recreate tabs list.
+            self.tabs.resize(self.num_cols());
+        }
     }
 
     /// Swap primary and alternate screen buffer.
@@ -1087,8 +1012,7 @@ impl<T> Term<T> {
     fn scroll_down_relative(&mut self, origin: Line, mut lines: Line) {
         trace!("Scrolling down relative: origin={}, lines={}", origin, lines);
 
-        let num_lines = self.grid.num_lines();
-        let num_cols = self.grid.num_cols();
+        let num_lines = self.num_lines();
 
         lines = min(lines, self.scroll_region.end - self.scroll_region.start);
         lines = min(lines, self.scroll_region.end - origin);
@@ -1100,7 +1024,7 @@ impl<T> Term<T> {
         self.selection = self
             .selection
             .take()
-            .and_then(|s| s.rotate(num_lines, num_cols, &absolute_region, -(lines.0 as isize)));
+            .and_then(|s| s.rotate(self, &absolute_region, -(lines.0 as isize)));
 
         // Scroll between origin and bottom
         let template = Cell { bg: self.grid.cursor.template.bg, ..Cell::default() };
@@ -1114,8 +1038,8 @@ impl<T> Term<T> {
     #[inline]
     fn scroll_up_relative(&mut self, origin: Line, mut lines: Line) {
         trace!("Scrolling up relative: origin={}, lines={}", origin, lines);
-        let num_lines = self.grid.num_lines();
-        let num_cols = self.grid.num_cols();
+
+        let num_lines = self.num_lines();
 
         lines = min(lines, self.scroll_region.end - self.scroll_region.start);
 
@@ -1123,10 +1047,8 @@ impl<T> Term<T> {
         let absolute_region = (num_lines - region.end)..(num_lines - region.start);
 
         // Scroll selection.
-        self.selection = self
-            .selection
-            .take()
-            .and_then(|s| s.rotate(num_lines, num_cols, &absolute_region, lines.0 as isize));
+        self.selection =
+            self.selection.take().and_then(|s| s.rotate(self, &absolute_region, lines.0 as isize));
 
         // Scroll from origin to bottom less number of lines.
         let template = Cell { bg: self.grid.cursor.template.bg, ..Cell::default() };
@@ -1139,7 +1061,7 @@ impl<T> Term<T> {
     {
         // Setting 132 column font makes no sense, but run the other side effects.
         // Clear scrolling region.
-        self.set_scrolling_region(1, self.grid.num_lines().0);
+        self.set_scrolling_region(1, None);
 
         // Clear grid.
         let template = self.grid.cursor.template;
@@ -1163,13 +1085,21 @@ impl<T> Term<T> {
     #[inline]
     pub fn toggle_vi_mode(&mut self) {
         self.mode ^= TermMode::VI;
-        self.selection = None;
 
-        // Reset vi mode cursor position to match primary cursor.
-        if self.mode.contains(TermMode::VI) {
+        let vi_mode = self.mode.contains(TermMode::VI);
+
+        // Do not clear selection when entering search.
+        if self.regex_search.is_none() || !vi_mode {
+            self.selection = None;
+        }
+
+        if vi_mode {
+            // Reset vi mode cursor position to match primary cursor.
             let cursor = self.grid.cursor.point;
-            let line = min(cursor.line + self.grid.display_offset(), self.lines() - 1);
+            let line = min(cursor.line + self.grid.display_offset(), self.num_lines() - 1);
             self.vi_mode_cursor = ViModeCursor::new(Point::new(line, cursor.col));
+        } else {
+            self.cancel_search();
         }
 
         self.dirty = true;
@@ -1188,18 +1118,89 @@ impl<T> Term<T> {
 
         // Move cursor.
         self.vi_mode_cursor = self.vi_mode_cursor.motion(self, motion);
-
-        // Update selection if one is active.
-        let viewport_point = self.visible_to_buffer(self.vi_mode_cursor.point);
-        if let Some(selection) = &mut self.selection {
-            // Do not extend empty selections started by a single mouse click.
-            if !selection.is_empty() {
-                selection.update(viewport_point, Side::Left);
-                selection.include_all();
-            }
-        }
+        self.vi_mode_recompute_selection();
 
         self.dirty = true;
+    }
+
+    /// Move vi cursor to absolute point in grid.
+    #[inline]
+    pub fn vi_goto_point(&mut self, point: Point<usize>)
+    where
+        T: EventListener,
+    {
+        // Move viewport to make point visible.
+        self.scroll_to_point(point);
+
+        // Move vi cursor to the point.
+        self.vi_mode_cursor.point = self.grid.clamp_buffer_to_visible(point);
+
+        self.vi_mode_recompute_selection();
+
+        self.dirty = true;
+    }
+
+    /// Update the active selection to match the vi mode cursor position.
+    #[inline]
+    fn vi_mode_recompute_selection(&mut self) {
+        // Require vi mode to be active.
+        if !self.mode.contains(TermMode::VI) {
+            return;
+        }
+
+        let viewport_point = self.visible_to_buffer(self.vi_mode_cursor.point);
+
+        // Update only if non-empty selection is present.
+        let selection = match &mut self.selection {
+            Some(selection) if !selection.is_empty() => selection,
+            _ => return,
+        };
+
+        selection.update(viewport_point, Side::Left);
+        selection.include_all();
+    }
+
+    /// Scroll display to point if it is outside of viewport.
+    pub fn scroll_to_point(&mut self, point: Point<usize>)
+    where
+        T: EventListener,
+    {
+        let display_offset = self.grid.display_offset();
+        let num_lines = self.num_lines().0;
+
+        if point.line >= display_offset + num_lines {
+            let lines = point.line.saturating_sub(display_offset + num_lines - 1);
+            self.scroll_display(Scroll::Delta(lines as isize));
+        } else if point.line < display_offset {
+            let lines = display_offset.saturating_sub(point.line);
+            self.scroll_display(Scroll::Delta(-(lines as isize)));
+        }
+    }
+
+    /// Jump to the end of a wide cell.
+    pub fn expand_wide(&self, mut point: Point<usize>, direction: Direction) -> Point<usize> {
+        let flags = self.grid[point.line][point.col].flags;
+
+        match direction {
+            Direction::Right if flags.contains(Flags::LEADING_WIDE_CHAR_SPACER) => {
+                point.col = Column(1);
+                point.line -= 1;
+            },
+            Direction::Right if flags.contains(Flags::WIDE_CHAR) => point.col += 1,
+            Direction::Left if flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER) => {
+                if flags.contains(Flags::WIDE_CHAR_SPACER) {
+                    point.col -= 1;
+                }
+
+                let prev = point.sub_absolute(self, Boundary::Clamp, 1);
+                if self.grid[prev].flags.contains(Flags::LEADING_WIDE_CHAR_SPACER) {
+                    point = prev;
+                }
+            },
+            _ => (),
+        }
+
+        point
     }
 
     #[inline]
@@ -1260,7 +1261,7 @@ impl<T> Term<T> {
         };
 
         // Cursor shape.
-        let hidden = !self.mode.contains(TermMode::SHOW_CURSOR) || point.line >= self.lines();
+        let hidden = !self.mode.contains(TermMode::SHOW_CURSOR) || point.line >= self.num_lines();
         let cursor_style = if hidden && !vi_mode {
             point.line = Line(0);
             CursorStyle::Hidden
@@ -1277,19 +1278,18 @@ impl<T> Term<T> {
         };
 
         // Cursor colors.
-        let (text_color, cursor_color) = if vi_mode {
-            (config.vi_mode_cursor_text_color(), config.vi_mode_cursor_cursor_color())
+        let color = if vi_mode { config.colors.vi_mode_cursor } else { config.colors.cursor };
+        let cursor_color = if self.color_modified[NamedColor::Cursor as usize] {
+            CellRgb::Rgb(self.colors[NamedColor::Cursor])
         } else {
-            let cursor_cursor_color = config.cursor_cursor_color().map(|c| self.colors[c]);
-            (config.cursor_text_color(), cursor_cursor_color)
+            color.cursor()
         };
+        let text_color = color.text();
 
         // Expand across wide cell when inside wide char or spacer.
         let buffer_point = self.visible_to_buffer(point);
         let cell = self.grid[buffer_point.line][buffer_point.col];
-        let is_wide = if cell.flags.contains(Flags::WIDE_CHAR_SPACER)
-            && self.grid[buffer_point.line][buffer_point.col - 1].flags.contains(Flags::WIDE_CHAR)
-        {
+        let is_wide = if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
             point.col -= 1;
             true
         } else {
@@ -1306,15 +1306,20 @@ impl<T> Term<T> {
     }
 }
 
-impl<T> TermInfo for Term<T> {
+impl<T> Dimensions for Term<T> {
     #[inline]
-    fn lines(&self) -> Line {
+    fn num_cols(&self) -> Column {
+        self.grid.num_cols()
+    }
+
+    #[inline]
+    fn num_lines(&self) -> Line {
         self.grid.num_lines()
     }
 
     #[inline]
-    fn cols(&self) -> Column {
-        self.grid.num_cols()
+    fn total_lines(&self) -> usize {
+        self.grid.total_lines()
     }
 }
 
@@ -1344,7 +1349,7 @@ impl<T: EventListener> Handler for Term<T> {
             self.wrapline();
         }
 
-        let num_cols = self.grid.num_cols();
+        let num_cols = self.num_cols();
 
         // If in insert mode, first shift cells to the right.
         if self.mode.contains(TermMode::INSERT) && self.grid.cursor.point.col + width < num_cols {
@@ -1365,7 +1370,7 @@ impl<T: EventListener> Handler for Term<T> {
             if self.grid.cursor.point.col + 1 >= num_cols {
                 if self.mode.contains(TermMode::LINE_WRAP) {
                     // Insert placeholder before wide char if glyph does not fit in this row.
-                    self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
+                    self.write_at_cursor(' ').flags.insert(Flags::LEADING_WIDE_CHAR_SPACER);
                     self.wrapline();
                 } else {
                     // Prevent out of bounds crash when linewrapping is disabled.
@@ -1403,11 +1408,11 @@ impl<T: EventListener> Handler for Term<T> {
         let (y_offset, max_y) = if self.mode.contains(TermMode::ORIGIN) {
             (self.scroll_region.start, self.scroll_region.end - 1)
         } else {
-            (Line(0), self.grid.num_lines() - 1)
+            (Line(0), self.num_lines() - 1)
         };
 
         self.grid.cursor.point.line = min(line + y_offset, max_y);
-        self.grid.cursor.point.col = min(col, self.grid.num_cols() - 1);
+        self.grid.cursor.point.col = min(col, self.num_cols() - 1);
         self.grid.cursor.input_needs_wrap = false;
     }
 
@@ -1428,11 +1433,11 @@ impl<T: EventListener> Handler for Term<T> {
         let cursor = self.grid.cursor;
 
         // Ensure inserting within terminal bounds
-        let count = min(count, self.grid.num_cols() - cursor.point.col);
+        let count = min(count, self.num_cols() - cursor.point.col);
 
         let source = cursor.point.col;
         let destination = cursor.point.col + count;
-        let num_cells = (self.grid.num_cols() - destination).0;
+        let num_cells = (self.num_cols() - destination).0;
 
         let line = &mut self.grid[cursor.point.line];
 
@@ -1467,7 +1472,7 @@ impl<T: EventListener> Handler for Term<T> {
     #[inline]
     fn move_forward(&mut self, cols: Column) {
         trace!("Moving forward: {}", cols);
-        let num_cols = self.grid.num_cols();
+        let num_cols = self.num_cols();
         self.grid.cursor.point.col = min(self.grid.cursor.point.col + cols, num_cols - 1);
         self.grid.cursor.input_needs_wrap = false;
     }
@@ -1524,7 +1529,7 @@ impl<T: EventListener> Handler for Term<T> {
             return;
         }
 
-        while self.grid.cursor.point.col < self.grid.num_cols() && count != 0 {
+        while self.grid.cursor.point.col < self.num_cols() && count != 0 {
             count -= 1;
 
             let c = self.grid.cursor.charsets[self.active_charset].map('\t');
@@ -1534,7 +1539,7 @@ impl<T: EventListener> Handler for Term<T> {
             }
 
             loop {
-                if (self.grid.cursor.point.col + 1) == self.grid.num_cols() {
+                if (self.grid.cursor.point.col + 1) == self.num_cols() {
                     break;
                 }
 
@@ -1573,7 +1578,7 @@ impl<T: EventListener> Handler for Term<T> {
         let next = self.grid.cursor.point.line + 1;
         if next == self.scroll_region.end {
             self.scroll_up(Line(1));
-        } else if next < self.grid.num_lines() {
+        } else if next < self.num_lines() {
             self.grid.cursor.point.line += 1;
         }
     }
@@ -1653,7 +1658,7 @@ impl<T: EventListener> Handler for Term<T> {
     #[inline]
     fn delete_lines(&mut self, lines: Line) {
         let origin = self.grid.cursor.point.line;
-        let lines = min(self.lines() - origin, lines);
+        let lines = min(self.num_lines() - origin, lines);
 
         trace!("Deleting {} lines", lines);
 
@@ -1669,7 +1674,7 @@ impl<T: EventListener> Handler for Term<T> {
         trace!("Erasing chars: count={}, col={}", count, cursor.point.col);
 
         let start = cursor.point.col;
-        let end = min(start + count, self.grid.num_cols());
+        let end = min(start + count, self.num_cols());
 
         // Cleared cells have current background color set.
         let row = &mut self.grid[cursor.point.line];
@@ -1680,7 +1685,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn delete_chars(&mut self, count: Column) {
-        let cols = self.grid.num_cols();
+        let cols = self.num_cols();
         let cursor = self.grid.cursor;
 
         // Ensure deleting within terminal bounds.
@@ -1850,7 +1855,7 @@ impl<T: EventListener> Handler for Term<T> {
         trace!("Clearing screen: {:?}", mode);
         let template = self.grid.cursor.template;
 
-        let num_lines = self.grid.num_lines().0;
+        let num_lines = self.num_lines().0;
         let cursor_buffer_line = num_lines - self.grid.cursor.point.line.0 - 1;
 
         match mode {
@@ -1864,7 +1869,7 @@ impl<T: EventListener> Handler for Term<T> {
                 }
 
                 // Clear up to the current column in the current line.
-                let end = min(cursor.col + 1, self.grid.num_cols());
+                let end = min(cursor.col + 1, self.num_cols());
                 for cell in &mut self.grid[cursor.line][..end] {
                     cell.reset(&template);
                 }
@@ -1933,17 +1938,18 @@ impl<T: EventListener> Handler for Term<T> {
         self.cursor_style = None;
         self.grid.reset(Cell::default());
         self.inactive_grid.reset(Cell::default());
-        self.scroll_region = Line(0)..self.grid.num_lines();
-        self.tabs = TabStops::new(self.grid.num_cols());
+        self.scroll_region = Line(0)..self.num_lines();
+        self.tabs = TabStops::new(self.num_cols());
         self.title_stack = Vec::new();
         self.title = None;
         self.selection = None;
+        self.regex_search = None;
     }
 
     #[inline]
     fn reverse_index(&mut self) {
         trace!("Reversing index");
-
+        // If cursor is at the top.
         if self.grid.cursor.point.line == self.scroll_region.start {
             self.scroll_down(Line(1));
         } else {
@@ -2074,7 +2080,10 @@ impl<T: EventListener> Handler for Term<T> {
     }
 
     #[inline]
-    fn set_scrolling_region(&mut self, top: usize, bottom: usize) {
+    fn set_scrolling_region(&mut self, top: usize, bottom: Option<usize>) {
+        // Fallback to the last line as default.
+        let bottom = bottom.unwrap_or_else(|| self.num_lines().0);
+
         if top >= bottom {
             debug!("Invalid scrolling region: ({};{})", top, bottom);
             return;
@@ -2089,8 +2098,8 @@ impl<T: EventListener> Handler for Term<T> {
 
         trace!("Setting scrolling region: ({};{})", start, end);
 
-        self.scroll_region.start = min(start, self.grid.num_lines());
-        self.scroll_region.end = min(end, self.grid.num_lines());
+        self.scroll_region.start = min(start, self.num_lines());
+        self.scroll_region.end = min(end, self.num_lines());
         self.goto(Line(0), Column(0));
     }
 
@@ -2213,6 +2222,79 @@ impl Index<Column> for TabStops {
 impl IndexMut<Column> for TabStops {
     fn index_mut(&mut self, index: Column) -> &mut bool {
         self.tabs.index_mut(index.0)
+    }
+}
+
+/// Terminal test helpers.
+pub mod test {
+    use super::*;
+
+    use unicode_width::UnicodeWidthChar;
+
+    use crate::config::Config;
+    use crate::index::Column;
+
+    /// Construct a terminal from its content as string.
+    ///
+    /// A `\n` will break line and `\r\n` will break line without wrapping.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use alacritty_terminal::term::test::mock_term;
+    ///
+    /// // Create a terminal with the following cells:
+    /// //
+    /// // [h][e][l][l][o] <- WRAPLINE flag set
+    /// // [:][)][ ][ ][ ]
+    /// // [t][e][s][t][ ]
+    /// mock_term(
+    ///     "\
+    ///     hello\n:)\r\ntest",
+    /// );
+    /// ```
+    pub fn mock_term(content: &str) -> Term<()> {
+        let lines: Vec<&str> = content.split('\n').collect();
+        let num_cols = lines
+            .iter()
+            .map(|line| line.chars().filter(|c| *c != '\r').map(|c| c.width().unwrap()).sum())
+            .max()
+            .unwrap_or(0);
+
+        // Create terminal with the appropriate dimensions.
+        let size = SizeInfo {
+            width: num_cols as f32,
+            height: lines.len() as f32,
+            cell_width: 1.,
+            cell_height: 1.,
+            padding_x: 0.,
+            padding_y: 0.,
+            dpr: 1.,
+        };
+        let mut term = Term::new(&Config::<()>::default(), &size, ());
+
+        // Fill terminal with content.
+        for (line, text) in lines.iter().rev().enumerate() {
+            if !text.ends_with('\r') && line != 0 {
+                term.grid[line][Column(num_cols - 1)].flags.insert(Flags::WRAPLINE);
+            }
+
+            let mut index = 0;
+            for c in text.chars().take_while(|c| *c != '\r') {
+                term.grid[line][Column(index)].c = c;
+
+                // Handle fullwidth characters.
+                let width = c.width().unwrap();
+                if width == 2 {
+                    term.grid[line][Column(index)].flags.insert(Flags::WIDE_CHAR);
+                    term.grid[line][Column(index + 1)].flags.insert(Flags::WIDE_CHAR_SPACER);
+                }
+
+                index += width;
+            }
+        }
+
+        term
     }
 }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -965,7 +965,7 @@ impl<T> Term<T> {
             self.selection = None;
 
             // Recreate tabs list.
-            self.tabs.resize(self.num_cols());
+            self.tabs.resize(num_cols);
         } else if let Some(selection) = self.selection.take() {
             // Move the selection if only number of lines changed.
             let delta = if num_lines > old_lines {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -274,12 +274,13 @@ impl RenderableCell {
         // Lookup RGB values.
         let mut fg_rgb = Self::compute_fg_rgb(iter.config, iter.colors, cell.fg, cell.flags);
         let mut bg_rgb = Self::compute_bg_rgb(iter.colors, cell.bg);
-        let mut bg_alpha = Self::compute_bg_alpha(cell.bg);
 
-        if cell.inverse() {
+        let mut bg_alpha = if cell.inverse() {
             mem::swap(&mut fg_rgb, &mut bg_rgb);
-            bg_alpha = 1.0;
-        }
+            1.0
+        } else {
+            Self::compute_bg_alpha(cell.bg)
+        };
 
         if iter.is_selected(point) {
             let config_bg = iter.config.colors.selection.background();

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -679,7 +679,7 @@ pub struct Term<T> {
     tabs: TabStops,
 
     /// Mode flags.
-    pub mode: TermMode,
+    mode: TermMode,
 
     /// Scroll region.
     ///
@@ -990,6 +990,12 @@ impl<T> Term<T> {
         self.scroll_region = Line(0)..self.num_lines();
     }
 
+    /// Active terminal modes.
+    #[inline]
+    pub fn mode(&self) -> &TermMode {
+        &self.mode
+    }
+
     /// Swap primary and alternate screen buffer.
     pub fn swap_alt(&mut self) {
         if !self.mode.contains(TermMode::ALT_SCREEN) {
@@ -1107,6 +1113,13 @@ impl<T> Term<T> {
             self.cancel_search();
         }
 
+        self.dirty = true;
+    }
+
+    /// Start vi mode without moving the cursor.
+    #[inline]
+    pub fn set_vi_mode(&mut self) {
+        self.mode.insert(TermMode::VI);
         self.dirty = true;
     }
 

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -111,7 +111,7 @@ impl<T> Term<T> {
             .find(|regex_match| {
                 let match_point = Self::match_side(&regex_match, side);
 
-                // If the matche's point is beyond the origin, we're done.
+                // If the match's point is beyond the origin, we're done.
                 match_point.line > start.line
                     || match_point.line < origin.line
                     || (match_point.line == origin.line && match_point.col >= origin.col)
@@ -224,7 +224,7 @@ impl<T> Term<T> {
             let mut buf = [0; 4];
             let utf8_len = cell.c.encode_utf8(&mut buf).len();
 
-            // Pass char to DFA is individual bytes.
+            // Pass char to DFA as individual bytes.
             for i in 0..utf8_len {
                 // Inverse byte order when going left.
                 let byte = match direction {

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -148,7 +148,7 @@ impl<T> Term<T> {
             .find(|regex_match| {
                 let match_point = Self::match_side(&regex_match, side);
 
-                // If the matche's point is beyond the origin, we're done.
+                // If the match's point is beyond the origin, we're done.
                 match_point.line < start.line
                     || match_point.line > origin.line
                     || (match_point.line == origin.line && match_point.col <= origin.col)

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -97,7 +97,7 @@ impl<T> Term<T> {
         end = match max_lines {
             Some(max_lines) => {
                 let line = (start.line + total_lines - max_lines) % total_lines;
-                Point::new(line, self.num_cols() - 1)
+                Point::new(line, self.cols() - 1)
             },
             _ => end.sub_absolute(self, Boundary::Wrap, 1),
         };
@@ -203,7 +203,7 @@ impl<T> Term<T> {
         dfa: &impl DFA,
     ) -> Option<Point<usize>> {
         let last_line = self.total_lines() - 1;
-        let last_col = self.num_cols() - 1;
+        let last_col = self.cols() - 1;
 
         // Advance the iterator.
         let next = match direction {
@@ -363,7 +363,7 @@ impl<T> Term<T> {
         point.line = min(point.line, self.total_lines() - 1);
 
         let mut iter = self.grid.iter_from(point);
-        let last_col = self.num_cols() - Column(1);
+        let last_col = self.cols() - Column(1);
 
         let wide = Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER;
         while let Some(cell) = iter.prev() {
@@ -387,7 +387,7 @@ impl<T> Term<T> {
         point.line = min(point.line, self.total_lines() - 1);
 
         let mut iter = self.grid.iter_from(point);
-        let last_col = self.num_cols() - 1;
+        let last_col = self.cols() - 1;
 
         let wide = Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER;
         while let Some(cell) = iter.next() {
@@ -408,7 +408,7 @@ impl<T> Term<T> {
     /// Find the beginning of the current line across linewraps.
     pub fn line_search_left(&self, mut point: Point<usize>) -> Point<usize> {
         while point.line + 1 < self.total_lines()
-            && self.grid[point.line + 1][self.num_cols() - 1].flags.contains(Flags::WRAPLINE)
+            && self.grid[point.line + 1][self.cols() - 1].flags.contains(Flags::WRAPLINE)
         {
             point.line += 1;
         }
@@ -420,11 +420,11 @@ impl<T> Term<T> {
 
     /// Find the end of the current line across linewraps.
     pub fn line_search_right(&self, mut point: Point<usize>) -> Point<usize> {
-        while self.grid[point.line][self.num_cols() - 1].flags.contains(Flags::WRAPLINE) {
+        while self.grid[point.line][self.cols() - 1].flags.contains(Flags::WRAPLINE) {
             point.line -= 1;
         }
 
-        point.col = self.num_cols() - 1;
+        point.col = self.cols() - 1;
 
         point
     }

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -1,0 +1,801 @@
+use std::cmp::min;
+use std::mem;
+use std::ops::RangeInclusive;
+
+use regex_automata::{dense, DenseDFA, Error as RegexError, DFA};
+
+use crate::event::EventListener;
+use crate::grid::{BidirectionalIterator, Dimensions, GridIterator};
+use crate::index::{Boundary, Column, Direction, Point, Side};
+use crate::term::cell::{Cell, Flags};
+use crate::term::Term;
+
+/// Used to match equal brackets, when performing a bracket-pair selection.
+const BRACKET_PAIRS: [(char, char); 4] = [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
+
+pub type Match = RangeInclusive<Point<usize>>;
+
+/// Terminal regex search state.
+pub struct RegexSearch {
+    /// Locate end of match searching right.
+    right_fdfa: DenseDFA<Vec<usize>, usize>,
+    /// Locate start of match searching right.
+    right_rdfa: DenseDFA<Vec<usize>, usize>,
+
+    /// Locate start of match searching left.
+    left_fdfa: DenseDFA<Vec<usize>, usize>,
+    /// Locate end of match searching left.
+    left_rdfa: DenseDFA<Vec<usize>, usize>,
+}
+
+impl RegexSearch {
+    /// Build the forwards and backwards search DFAs.
+    pub fn new(search: &str) -> Result<RegexSearch, RegexError> {
+        // Check case info for smart case
+        let has_uppercase = search.chars().any(|c| c.is_uppercase());
+
+        // Create Regex DFAs for all search directions.
+        let mut builder = dense::Builder::new();
+        let builder = builder.case_insensitive(!has_uppercase);
+
+        let left_fdfa = builder.clone().reverse(true).build(search)?;
+        let left_rdfa = builder.clone().anchored(true).longest_match(true).build(search)?;
+
+        let right_fdfa = builder.clone().build(search)?;
+        let right_rdfa = builder.anchored(true).longest_match(true).reverse(true).build(search)?;
+
+        Ok(RegexSearch { right_fdfa, right_rdfa, left_fdfa, left_rdfa })
+    }
+}
+
+impl<T> Term<T> {
+    /// Enter terminal buffer search mode.
+    #[inline]
+    pub fn start_search(&mut self, search: &str)
+    where
+        T: EventListener,
+    {
+        self.regex_search = RegexSearch::new(search).ok();
+        self.dirty = true;
+    }
+
+    /// Cancel active terminal buffer search.
+    #[inline]
+    pub fn cancel_search(&mut self) {
+        self.regex_search = None;
+        self.dirty = true;
+    }
+
+    /// Get next search match in the specified direction.
+    pub fn search_next(
+        &self,
+        mut origin: Point<usize>,
+        direction: Direction,
+        side: Side,
+        max_lines: Option<usize>,
+    ) -> Option<Match>
+    where
+        T: EventListener,
+    {
+        origin = self.expand_wide(origin, direction);
+
+        match direction {
+            Direction::Right => self.next_match_right(origin, side, max_lines),
+            Direction::Left => self.next_match_left(origin, side, max_lines),
+        }
+    }
+
+    /// Find the next match to the right of the origin.
+    fn next_match_right(
+        &self,
+        origin: Point<usize>,
+        side: Side,
+        max_lines: Option<usize>,
+    ) -> Option<Match> {
+        // Skip origin itself to exclude it from the search results.
+        let origin = origin.add_absolute(self, Boundary::Wrap, 1);
+        let start = self.line_search_left(origin);
+        let mut end = start;
+
+        // Limit maximum number of lines searched.
+        let total_lines = self.total_lines();
+        end = match max_lines {
+            Some(max_lines) if max_lines + 1 < total_lines => {
+                let line = (start.line + total_lines - max_lines) % total_lines;
+                Point::new(line, self.num_cols() - 1)
+            },
+            _ => end.sub_absolute(self, Boundary::Wrap, 1),
+        };
+
+        let mut regex_iter = RegexIter::new(start, end, Direction::Right, &self).peekable();
+
+        // Check if there's any match at all.
+        let first_match = regex_iter.peek()?.clone();
+
+        let regex_match = regex_iter
+            .find(|regex_match| {
+                let match_point = Self::match_side(&regex_match, side);
+
+                // If the matche's point is beyond the origin, we're done.
+                match_point.line > start.line
+                    || match_point.line < origin.line
+                    || (match_point.line == origin.line && match_point.col >= origin.col)
+            })
+            .unwrap_or(first_match);
+
+        Some(regex_match)
+    }
+
+    /// Find the next match to the left of the origin.
+    fn next_match_left(
+        &self,
+        origin: Point<usize>,
+        side: Side,
+        max_lines: Option<usize>,
+    ) -> Option<Match> {
+        // Skip origin itself to exclude it from the search results.
+        let origin = origin.sub_absolute(self, Boundary::Wrap, 1);
+        let start = self.line_search_right(origin);
+        let mut end = start;
+
+        // Limit maximum number of lines searched.
+        let total_lines = self.total_lines();
+        end = match max_lines {
+            Some(max_lines) if max_lines + 1 < total_lines => {
+                Point::new((start.line + max_lines) % total_lines, Column(0))
+            },
+            _ => end.add_absolute(self, Boundary::Wrap, 1),
+        };
+
+        let mut regex_iter = RegexIter::new(start, end, Direction::Left, &self).peekable();
+
+        // Check if there's any match at all.
+        let first_match = regex_iter.peek()?.clone();
+
+        let regex_match = regex_iter
+            .find(|regex_match| {
+                let match_point = Self::match_side(&regex_match, side);
+
+                // If the matche's point is beyond the origin, we're done.
+                match_point.line < start.line
+                    || match_point.line > origin.line
+                    || (match_point.line == origin.line && match_point.col <= origin.col)
+            })
+            .unwrap_or(first_match);
+
+        Some(regex_match)
+    }
+
+    /// Get the side of a match.
+    fn match_side(regex_match: &Match, side: Side) -> Point<usize> {
+        match side {
+            Side::Right => *regex_match.end(),
+            Side::Left => *regex_match.start(),
+        }
+    }
+
+    /// Find the next regex match to the left of the origin point.
+    ///
+    /// The origin is always included in the regex.
+    pub fn regex_search_left(&self, start: Point<usize>, end: Point<usize>) -> Option<Match> {
+        let RegexSearch { left_fdfa: fdfa, left_rdfa: rdfa, .. } = self.regex_search.as_ref()?;
+
+        // Find start and end of match.
+        let match_start = self.regex_search(start, end, Direction::Left, &fdfa)?;
+        let match_end = self.regex_search(match_start, start, Direction::Right, &rdfa)?;
+
+        Some(match_start..=match_end)
+    }
+
+    /// Find the next regex match to the right of the origin point.
+    ///
+    /// The origin is always included in the regex.
+    pub fn regex_search_right(&self, start: Point<usize>, end: Point<usize>) -> Option<Match> {
+        let RegexSearch { right_fdfa: fdfa, right_rdfa: rdfa, .. } = self.regex_search.as_ref()?;
+
+        // Find start and end of match.
+        let match_end = self.regex_search(start, end, Direction::Right, &fdfa)?;
+        let match_start = self.regex_search(match_end, start, Direction::Left, &rdfa)?;
+
+        Some(match_start..=match_end)
+    }
+
+    /// Find the next regex match.
+    ///
+    /// This will always return the side of the first match which is farthest from the start point.
+    fn regex_search(
+        &self,
+        start: Point<usize>,
+        end: Point<usize>,
+        direction: Direction,
+        dfa: &impl DFA,
+    ) -> Option<Point<usize>> {
+        let last_line = self.total_lines() - 1;
+        let last_col = self.num_cols() - 1;
+
+        // Advance the iterator.
+        let next = match direction {
+            Direction::Right => GridIterator::next,
+            Direction::Left => GridIterator::prev,
+        };
+
+        let mut iter = self.grid.iter_from(start);
+        let mut state = dfa.start_state();
+        let mut regex_match = None;
+
+        let mut cell = *iter.cell();
+        self.skip_fullwidth(&mut iter, &mut cell, direction);
+        let mut point = iter.point();
+
+        loop {
+            // Convert char to array of bytes.
+            let mut buf = [0; 4];
+            let utf8_len = cell.c.encode_utf8(&mut buf).len();
+
+            // Pass char to DFA is individual bytes.
+            for i in 0..utf8_len {
+                // Inverse byte order when going left.
+                let byte = match direction {
+                    Direction::Right => buf[i],
+                    Direction::Left => buf[utf8_len - i - 1],
+                };
+
+                // Since we get the state from the DFA, it doesn't need to be checked.
+                state = unsafe { dfa.next_state_unchecked(state, byte) };
+            }
+
+            // Handle regex state changes.
+            if dfa.is_match_or_dead_state(state) {
+                if dfa.is_dead_state(state) {
+                    break;
+                } else {
+                    regex_match = Some(point);
+                }
+            }
+
+            // Stop once we've reached the target point.
+            if point == end {
+                break;
+            }
+
+            // Advance grid cell iterator.
+            let mut new_cell = match next(&mut iter) {
+                Some(&cell) => cell,
+                None => {
+                    // Wrap around to other end of the scrollback buffer.
+                    let start = Point::new(last_line - point.line, last_col - point.col);
+                    iter = self.grid.iter_from(start);
+                    *iter.cell()
+                },
+            };
+            self.skip_fullwidth(&mut iter, &mut new_cell, direction);
+            let last_point = mem::replace(&mut point, iter.point());
+            let last_cell = mem::replace(&mut cell, new_cell);
+
+            // Handle linebreaks.
+            if (last_point.col == last_col
+                && point.col == Column(0)
+                && !last_cell.flags.contains(Flags::WRAPLINE))
+                || (last_point.col == Column(0)
+                    && point.col == last_col
+                    && !cell.flags.contains(Flags::WRAPLINE))
+            {
+                match regex_match {
+                    Some(_) => break,
+                    None => state = dfa.start_state(),
+                }
+            }
+        }
+
+        regex_match
+    }
+
+    /// Advance the grid iterator over fullwidth characters.
+    fn skip_fullwidth(
+        &self,
+        iter: &mut GridIterator<'_, Cell>,
+        cell: &mut Cell,
+        direction: Direction,
+    ) {
+        match direction {
+            Direction::Right if cell.flags.contains(Flags::WIDE_CHAR) => {
+                iter.next();
+            },
+            Direction::Right if cell.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER) => {
+                if let Some(new_cell) = iter.next() {
+                    *cell = *new_cell;
+                }
+                iter.next();
+            },
+            Direction::Left if cell.flags.contains(Flags::WIDE_CHAR_SPACER) => {
+                if let Some(new_cell) = iter.prev() {
+                    *cell = *new_cell;
+                }
+
+                let prev = iter.point().sub_absolute(self, Boundary::Clamp, 1);
+                if self.grid[prev].flags.contains(Flags::LEADING_WIDE_CHAR_SPACER) {
+                    iter.prev();
+                }
+            },
+            _ => (),
+        }
+    }
+
+    /// Find next matching bracket.
+    pub fn bracket_search(&self, point: Point<usize>) -> Option<Point<usize>> {
+        let start_char = self.grid[point.line][point.col].c;
+
+        // Find the matching bracket we're looking for
+        let (forwards, end_char) = BRACKET_PAIRS.iter().find_map(|(open, close)| {
+            if open == &start_char {
+                Some((true, *close))
+            } else if close == &start_char {
+                Some((false, *open))
+            } else {
+                None
+            }
+        })?;
+
+        let mut iter = self.grid.iter_from(point);
+
+        // For every character match that equals the starting bracket, we
+        // ignore one bracket of the opposite type.
+        let mut skip_pairs = 0;
+
+        loop {
+            // Check the next cell
+            let cell = if forwards { iter.next() } else { iter.prev() };
+
+            // Break if there are no more cells
+            let c = match cell {
+                Some(cell) => cell.c,
+                None => break,
+            };
+
+            // Check if the bracket matches
+            if c == end_char && skip_pairs == 0 {
+                return Some(iter.point());
+            } else if c == start_char {
+                skip_pairs += 1;
+            } else if c == end_char {
+                skip_pairs -= 1;
+            }
+        }
+
+        None
+    }
+
+    /// Find left end of semantic block.
+    pub fn semantic_search_left(&self, mut point: Point<usize>) -> Point<usize> {
+        // Limit the starting point to the last line in the history
+        point.line = min(point.line, self.total_lines() - 1);
+
+        let mut iter = self.grid.iter_from(point);
+        let last_col = self.num_cols() - Column(1);
+
+        let wide = Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER;
+        while let Some(cell) = iter.prev() {
+            if !cell.flags.intersects(wide) && self.semantic_escape_chars.contains(cell.c) {
+                break;
+            }
+
+            if iter.point().col == last_col && !cell.flags.contains(Flags::WRAPLINE) {
+                break; // cut off if on new line or hit escape char
+            }
+
+            point = iter.point();
+        }
+
+        point
+    }
+
+    /// Find right end of semantic block.
+    pub fn semantic_search_right(&self, mut point: Point<usize>) -> Point<usize> {
+        // Limit the starting point to the last line in the history
+        point.line = min(point.line, self.total_lines() - 1);
+
+        let mut iter = self.grid.iter_from(point);
+        let last_col = self.num_cols() - 1;
+
+        let wide = Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER;
+        while let Some(cell) = iter.next() {
+            if !cell.flags.intersects(wide) && self.semantic_escape_chars.contains(cell.c) {
+                break;
+            }
+
+            point = iter.point();
+
+            if point.col == last_col && !cell.flags.contains(Flags::WRAPLINE) {
+                break; // cut off if on new line or hit escape char
+            }
+        }
+
+        point
+    }
+
+    /// Find the beginning of the current line across linewraps.
+    pub fn line_search_left(&self, mut point: Point<usize>) -> Point<usize> {
+        while point.line + 1 < self.total_lines()
+            && self.grid[point.line + 1][self.num_cols() - 1].flags.contains(Flags::WRAPLINE)
+        {
+            point.line += 1;
+        }
+
+        point.col = Column(0);
+
+        point
+    }
+
+    /// Find the end of the current line across linewraps.
+    pub fn line_search_right(&self, mut point: Point<usize>) -> Point<usize> {
+        while self.grid[point.line][self.num_cols() - 1].flags.contains(Flags::WRAPLINE) {
+            point.line -= 1;
+        }
+
+        point.col = self.num_cols() - 1;
+
+        point
+    }
+}
+
+pub struct RegexIter<'a, T> {
+    point: Point<usize>,
+    end: Point<usize>,
+    direction: Direction,
+    term: &'a Term<T>,
+    done: bool,
+}
+
+impl<'a, T> RegexIter<'a, T> {
+    pub fn new(
+        start: Point<usize>,
+        end: Point<usize>,
+        direction: Direction,
+        term: &'a Term<T>,
+    ) -> Self {
+        Self { point: start, done: false, end, direction, term }
+    }
+
+    /// Skip one cell, advancing the origin point to the next one.
+    fn skip(&mut self) {
+        self.point = self.term.expand_wide(self.point, self.direction);
+
+        self.point = match self.direction {
+            Direction::Right => self.point.add_absolute(self.term, Boundary::Wrap, 1),
+            Direction::Left => self.point.sub_absolute(self.term, Boundary::Wrap, 1),
+        };
+    }
+
+    /// Get the next match in the specified direction.
+    fn next_match(&self) -> Option<Match> {
+        match self.direction {
+            Direction::Right => self.term.regex_search_right(self.point, self.end),
+            Direction::Left => self.term.regex_search_left(self.point, self.end),
+        }
+    }
+}
+
+impl<'a, T> Iterator for RegexIter<'a, T> {
+    type Item = Match;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.point == self.end {
+            self.done = true;
+        } else if self.done {
+            return None;
+        }
+
+        let regex_match = self.next_match()?;
+
+        self.point = *regex_match.end();
+        self.skip();
+
+        Some(regex_match)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::index::Column;
+    use crate::term::test::mock_term;
+
+    #[test]
+    fn regex_right() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            testing66\r\n\
+            Alacritty\n\
+            123\r\n\
+            Alacritty\r\n\
+            123\
+        ");
+
+        // Check regex across wrapped and unwrapped lines.
+        term.regex_search = Some(RegexSearch::new("Ala.*123").unwrap());
+        let start = Point::new(3, Column(0));
+        let end = Point::new(0, Column(2));
+        let match_start = Point::new(3, Column(0));
+        let match_end = Point::new(2, Column(2));
+        assert_eq!(term.regex_search_right(start, end), Some(match_start..=match_end));
+    }
+
+    #[test]
+    fn regex_left() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            testing66\r\n\
+            Alacritty\n\
+            123\r\n\
+            Alacritty\r\n\
+            123\
+        ");
+
+        // Check regex across wrapped and unwrapped lines.
+        term.regex_search = Some(RegexSearch::new("Ala.*123").unwrap());
+        let start = Point::new(0, Column(2));
+        let end = Point::new(3, Column(0));
+        let match_start = Point::new(3, Column(0));
+        let match_end = Point::new(2, Column(2));
+        assert_eq!(term.regex_search_left(start, end), Some(match_start..=match_end));
+    }
+
+    #[test]
+    fn nested_regex() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            Ala -> Alacritty -> critty\r\n\
+            critty\
+        ");
+
+        // Greedy stopped at linebreak.
+        term.regex_search = Some(RegexSearch::new("Ala.*critty").unwrap());
+        let start = Point::new(1, Column(0));
+        let end = Point::new(1, Column(25));
+        assert_eq!(term.regex_search_right(start, end), Some(start..=end));
+
+        // Greedy stopped at dead state.
+        term.regex_search = Some(RegexSearch::new("Ala[^y]*critty").unwrap());
+        let start = Point::new(1, Column(0));
+        let end = Point::new(1, Column(15));
+        assert_eq!(term.regex_search_right(start, end), Some(start..=end));
+    }
+
+    #[test]
+    fn no_match_right() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            first line\n\
+            broken second\r\n\
+            third\
+        ");
+
+        term.regex_search = Some(RegexSearch::new("nothing").unwrap());
+        let start = Point::new(2, Column(0));
+        let end = Point::new(0, Column(4));
+        assert_eq!(term.regex_search_right(start, end), None);
+    }
+
+    #[test]
+    fn no_match_left() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            first line\n\
+            broken second\r\n\
+            third\
+        ");
+
+        term.regex_search = Some(RegexSearch::new("nothing").unwrap());
+        let start = Point::new(0, Column(4));
+        let end = Point::new(2, Column(0));
+        assert_eq!(term.regex_search_left(start, end), None);
+    }
+
+    #[test]
+    fn include_linebreak_left() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            testing123\r\n\
+            xxx\
+        ");
+
+        // Make sure the cell containing the linebreak is not skipped.
+        term.regex_search = Some(RegexSearch::new("te.*123").unwrap());
+        let start = Point::new(0, Column(0));
+        let end = Point::new(1, Column(0));
+        let match_start = Point::new(1, Column(0));
+        let match_end = Point::new(1, Column(9));
+        assert_eq!(term.regex_search_left(start, end), Some(match_start..=match_end));
+    }
+
+    #[test]
+    fn include_linebreak_right() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            xxx\r\n\
+            testing123\
+        ");
+
+        // Make sure the cell containing the linebreak is not skipped.
+        term.regex_search = Some(RegexSearch::new("te.*123").unwrap());
+        let start = Point::new(1, Column(2));
+        let end = Point::new(0, Column(9));
+        let match_start = Point::new(0, Column(0));
+        assert_eq!(term.regex_search_right(start, end), Some(match_start..=end));
+    }
+
+    #[test]
+    fn skip_dead_cell() {
+        let mut term = mock_term("alacritty");
+
+        // Make sure dead state cell is skipped when reversing.
+        term.regex_search = Some(RegexSearch::new("alacrit").unwrap());
+        let start = Point::new(0, Column(0));
+        let end = Point::new(0, Column(6));
+        assert_eq!(term.regex_search_right(start, end), Some(start..=end));
+    }
+
+    #[test]
+    fn reverse_search_dead_recovery() {
+        let mut term = mock_term("zooo lense");
+
+        // Make sure the reverse DFA operates the same as a forwards DFA.
+        term.regex_search = Some(RegexSearch::new("zoo").unwrap());
+        let start = Point::new(0, Column(9));
+        let end = Point::new(0, Column(0));
+        let match_start = Point::new(0, Column(0));
+        let match_end = Point::new(0, Column(2));
+        assert_eq!(term.regex_search_left(start, end), Some(match_start..=match_end));
+    }
+
+    #[test]
+    fn multibyte_unicode() {
+        let mut term = mock_term("testвосибing");
+
+        term.regex_search = Some(RegexSearch::new("te.*ing").unwrap());
+        let start = Point::new(0, Column(0));
+        let end = Point::new(0, Column(11));
+        assert_eq!(term.regex_search_right(start, end), Some(start..=end));
+
+        term.regex_search = Some(RegexSearch::new("te.*ing").unwrap());
+        let start = Point::new(0, Column(11));
+        let end = Point::new(0, Column(0));
+        assert_eq!(term.regex_search_left(start, end), Some(end..=start));
+    }
+
+    #[test]
+    fn fullwidth() {
+        let mut term = mock_term("a🦇x🦇");
+
+        term.regex_search = Some(RegexSearch::new("[^ ]*").unwrap());
+        let start = Point::new(0, Column(0));
+        let end = Point::new(0, Column(5));
+        assert_eq!(term.regex_search_right(start, end), Some(start..=end));
+
+        term.regex_search = Some(RegexSearch::new("[^ ]*").unwrap());
+        let start = Point::new(0, Column(5));
+        let end = Point::new(0, Column(0));
+        assert_eq!(term.regex_search_left(start, end), Some(end..=start));
+    }
+
+    #[test]
+    fn singlecell_fullwidth() {
+        let mut term = mock_term("🦇");
+
+        term.regex_search = Some(RegexSearch::new("🦇").unwrap());
+        let start = Point::new(0, Column(0));
+        let end = Point::new(0, Column(1));
+        assert_eq!(term.regex_search_right(start, end), Some(start..=end));
+
+        term.regex_search = Some(RegexSearch::new("🦇").unwrap());
+        let start = Point::new(0, Column(1));
+        let end = Point::new(0, Column(0));
+        assert_eq!(term.regex_search_left(start, end), Some(end..=start));
+    }
+
+    #[test]
+    fn wrapping() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            xxx\r\n\
+            xxx\
+        ");
+
+        term.regex_search = Some(RegexSearch::new("xxx").unwrap());
+        let start = Point::new(0, Column(2));
+        let end = Point::new(1, Column(2));
+        let match_start = Point::new(1, Column(0));
+        assert_eq!(term.regex_search_right(start, end), Some(match_start..=end));
+
+        term.regex_search = Some(RegexSearch::new("xxx").unwrap());
+        let start = Point::new(1, Column(0));
+        let end = Point::new(0, Column(0));
+        let match_end = Point::new(0, Column(2));
+        assert_eq!(term.regex_search_left(start, end), Some(end..=match_end));
+    }
+
+    #[test]
+    fn wrapping_into_fullwidth() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            🦇xx\r\n\
+            xx🦇\
+        ");
+
+        term.regex_search = Some(RegexSearch::new("🦇x").unwrap());
+        let start = Point::new(0, Column(0));
+        let end = Point::new(1, Column(3));
+        let match_start = Point::new(1, Column(0));
+        let match_end = Point::new(1, Column(2));
+        assert_eq!(term.regex_search_right(start, end), Some(match_start..=match_end));
+
+        term.regex_search = Some(RegexSearch::new("x🦇").unwrap());
+        let start = Point::new(1, Column(2));
+        let end = Point::new(0, Column(0));
+        let match_start = Point::new(0, Column(1));
+        let match_end = Point::new(0, Column(3));
+        assert_eq!(term.regex_search_left(start, end), Some(match_start..=match_end));
+    }
+
+    #[test]
+    fn leading_spacer() {
+        #[rustfmt::skip]
+        let mut term = mock_term("\
+            xxx \n\
+            🦇xx\
+        ");
+        term.grid[1][Column(3)].flags.insert(Flags::LEADING_WIDE_CHAR_SPACER);
+
+        term.regex_search = Some(RegexSearch::new("🦇x").unwrap());
+        let start = Point::new(1, Column(0));
+        let end = Point::new(0, Column(3));
+        let match_start = Point::new(1, Column(3));
+        let match_end = Point::new(0, Column(2));
+        assert_eq!(term.regex_search_right(start, end), Some(match_start..=match_end));
+
+        term.regex_search = Some(RegexSearch::new("🦇x").unwrap());
+        let start = Point::new(0, Column(3));
+        let end = Point::new(1, Column(0));
+        let match_start = Point::new(1, Column(3));
+        let match_end = Point::new(0, Column(2));
+        assert_eq!(term.regex_search_left(start, end), Some(match_start..=match_end));
+
+        term.regex_search = Some(RegexSearch::new("x🦇").unwrap());
+        let start = Point::new(1, Column(0));
+        let end = Point::new(0, Column(3));
+        let match_start = Point::new(1, Column(2));
+        let match_end = Point::new(0, Column(1));
+        assert_eq!(term.regex_search_right(start, end), Some(match_start..=match_end));
+
+        term.regex_search = Some(RegexSearch::new("x🦇").unwrap());
+        let start = Point::new(0, Column(3));
+        let end = Point::new(1, Column(0));
+        let match_start = Point::new(1, Column(2));
+        let match_end = Point::new(0, Column(1));
+        assert_eq!(term.regex_search_left(start, end), Some(match_start..=match_end));
+    }
+}
+
+#[cfg(all(test, feature = "bench"))]
+mod benches {
+    extern crate test;
+
+    use super::*;
+
+    use crate::term::test::mock_term;
+
+    #[bench]
+    fn regex_search(b: &mut test::Bencher) {
+        let input = format!("{:^10000}", "Alacritty");
+        let mut term = mock_term(&input);
+        term.regex_search = Some(RegexSearch::new("   Alacritty   ").unwrap());
+        let start = Point::new(0, Column(0));
+        let end = Point::new(0, Column(input.len() - 1));
+
+        b.iter(|| {
+            test::black_box(term.regex_search_right(start, end));
+            test::black_box(term.regex_search_left(end, start));
+        });
+    }
+}

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -66,8 +66,8 @@ impl ViModeCursor {
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn motion<T: EventListener>(mut self, term: &mut Term<T>, motion: ViMotion) -> Self {
         let display_offset = term.grid().display_offset();
-        let lines = term.grid().num_lines();
-        let cols = term.grid().num_cols();
+        let lines = term.grid().screen_lines();
+        let cols = term.grid().cols();
 
         let mut buffer_point = term.visible_to_buffer(self.point);
 
@@ -175,7 +175,7 @@ impl ViModeCursor {
         // Clamp movement to within visible region.
         let mut line = self.point.line.0 as isize;
         line -= overscroll;
-        line = max(0, min(term.grid().num_lines().0 as isize - 1, line));
+        line = max(0, min(term.grid().screen_lines().0 as isize - 1, line));
 
         // Find the first occupied cell after scrolling has been performed.
         let buffer_point = term.visible_to_buffer(self.point);
@@ -192,7 +192,7 @@ impl ViModeCursor {
 
 /// Find next end of line to move to.
 fn last<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
-    let cols = term.grid().num_cols();
+    let cols = term.grid().cols();
 
     // Expand across wide cells.
     point = term.expand_wide(point, Direction::Right);
@@ -218,7 +218,7 @@ fn last<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
 
 /// Find next non-empty cell to move to.
 fn first_occupied<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
-    let cols = term.grid().num_cols();
+    let cols = term.grid().cols();
 
     // Expand left across wide chars, since we're searching lines left to right.
     point = term.expand_wide(point, Direction::Left);
@@ -352,14 +352,14 @@ fn word<T: EventListener>(
 
 /// Find first non-empty cell in line.
 fn first_occupied_in_line<T>(term: &Term<T>, line: usize) -> Option<Point<usize>> {
-    (0..term.grid().num_cols().0)
+    (0..term.grid().cols().0)
         .map(|col| Point::new(line, Column(col)))
         .find(|&point| !is_space(term, point))
 }
 
 /// Find last non-empty cell in line.
 fn last_occupied_in_line<T>(term: &Term<T>, line: usize) -> Option<Point<usize>> {
-    (0..term.grid().num_cols().0)
+    (0..term.grid().cols().0)
         .map(|col| Point::new(line, Column(col)))
         .rfind(|&point| !is_space(term, point))
 }
@@ -387,7 +387,7 @@ fn is_wrap<T>(term: &Term<T>, point: Point<usize>) -> bool {
 /// Check if point is at screen boundary.
 fn is_boundary<T>(term: &Term<T>, point: Point<usize>, direction: Direction) -> bool {
     let total_lines = term.grid().total_lines();
-    let num_cols = term.grid().num_cols();
+    let num_cols = term.grid().cols();
     (point.line + 1 >= total_lines && point.col.0 == 0 && direction == Direction::Left)
         || (point.line == 0 && point.col + 1 >= num_cols && direction == Direction::Right)
 }

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -195,7 +195,7 @@ fn last<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
     let cols = term.grid().num_cols();
 
     // Expand across wide cells.
-    point = term.expand_wide(point, Direction::Left);
+    point = term.expand_wide(point, Direction::Right);
 
     // Find last non-empty cell in the current line.
     let occupied = last_occupied_in_line(term, point.line).unwrap_or_default();
@@ -221,7 +221,7 @@ fn first_occupied<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
     let cols = term.grid().num_cols();
 
     // Expand left across wide chars, since we're searching lines left to right.
-    point = term.expand_wide(point, Direction::Right);
+    point = term.expand_wide(point, Direction::Left);
 
     // Find first non-empty cell in current line.
     let occupied = first_occupied_in_line(term, point.line)

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -3,10 +3,10 @@ use std::cmp::{max, min};
 use serde::Deserialize;
 
 use crate::event::EventListener;
-use crate::grid::{GridCell, Scroll};
-use crate::index::{Column, Line, Point};
+use crate::grid::{Dimensions, GridCell};
+use crate::index::{Boundary, Column, Direction, Line, Point, Side};
 use crate::term::cell::Flags;
-use crate::term::{Search, Term};
+use crate::term::Term;
 
 /// Possible vi mode motion movements.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
@@ -73,16 +73,16 @@ impl ViModeCursor {
 
         match motion {
             ViMotion::Up => {
-                if buffer_point.line + 1 < term.grid().len() {
+                if buffer_point.line + 1 < term.grid().total_lines() {
                     buffer_point.line += 1;
                 }
             },
             ViMotion::Down => buffer_point.line = buffer_point.line.saturating_sub(1),
             ViMotion::Left => {
-                buffer_point = expand_wide(term, buffer_point, true);
+                buffer_point = term.expand_wide(buffer_point, Direction::Left);
                 let wrap_point = Point::new(buffer_point.line + 1, cols - 1);
                 if buffer_point.col.0 == 0
-                    && buffer_point.line + 1 < term.grid().len()
+                    && buffer_point.line + 1 < term.grid().total_lines()
                     && is_wrap(term, wrap_point)
                 {
                     buffer_point = wrap_point;
@@ -91,7 +91,7 @@ impl ViModeCursor {
                 }
             },
             ViMotion::Right => {
-                buffer_point = expand_wide(term, buffer_point, false);
+                buffer_point = term.expand_wide(buffer_point, Direction::Right);
                 if is_wrap(term, buffer_point) {
                     buffer_point = Point::new(buffer_point.line - 1, Column(0));
                 } else {
@@ -99,9 +99,9 @@ impl ViModeCursor {
                 }
             },
             ViMotion::First => {
-                buffer_point = expand_wide(term, buffer_point, true);
+                buffer_point = term.expand_wide(buffer_point, Direction::Left);
                 while buffer_point.col.0 == 0
-                    && buffer_point.line + 1 < term.grid().len()
+                    && buffer_point.line + 1 < term.grid().total_lines()
                     && is_wrap(term, Point::new(buffer_point.line + 1, cols - 1))
                 {
                     buffer_point.line += 1;
@@ -125,20 +125,36 @@ impl ViModeCursor {
                 let col = first_occupied_in_line(term, line).unwrap_or_default().col;
                 buffer_point = Point::new(line, col);
             },
-            ViMotion::SemanticLeft => buffer_point = semantic(term, buffer_point, true, true),
-            ViMotion::SemanticRight => buffer_point = semantic(term, buffer_point, false, true),
-            ViMotion::SemanticLeftEnd => buffer_point = semantic(term, buffer_point, true, false),
-            ViMotion::SemanticRightEnd => buffer_point = semantic(term, buffer_point, false, false),
-            ViMotion::WordLeft => buffer_point = word(term, buffer_point, true, true),
-            ViMotion::WordRight => buffer_point = word(term, buffer_point, false, true),
-            ViMotion::WordLeftEnd => buffer_point = word(term, buffer_point, true, false),
-            ViMotion::WordRightEnd => buffer_point = word(term, buffer_point, false, false),
+            ViMotion::SemanticLeft => {
+                buffer_point = semantic(term, buffer_point, Direction::Left, Side::Left);
+            },
+            ViMotion::SemanticRight => {
+                buffer_point = semantic(term, buffer_point, Direction::Right, Side::Left);
+            },
+            ViMotion::SemanticLeftEnd => {
+                buffer_point = semantic(term, buffer_point, Direction::Left, Side::Right);
+            },
+            ViMotion::SemanticRightEnd => {
+                buffer_point = semantic(term, buffer_point, Direction::Right, Side::Right);
+            },
+            ViMotion::WordLeft => {
+                buffer_point = word(term, buffer_point, Direction::Left, Side::Left);
+            },
+            ViMotion::WordRight => {
+                buffer_point = word(term, buffer_point, Direction::Right, Side::Left);
+            },
+            ViMotion::WordLeftEnd => {
+                buffer_point = word(term, buffer_point, Direction::Left, Side::Right);
+            },
+            ViMotion::WordRightEnd => {
+                buffer_point = word(term, buffer_point, Direction::Right, Side::Right);
+            },
             ViMotion::Bracket => {
                 buffer_point = term.bracket_search(buffer_point).unwrap_or(buffer_point);
             },
         }
 
-        scroll_to_point(term, buffer_point);
+        term.scroll_to_point(buffer_point);
         self.point = term.grid().clamp_buffer_to_visible(buffer_point);
 
         self
@@ -164,7 +180,7 @@ impl ViModeCursor {
         // Find the first occupied cell after scrolling has been performed.
         let buffer_point = term.visible_to_buffer(self.point);
         let mut target_line = buffer_point.line as isize + lines;
-        target_line = max(0, min(term.grid().len() as isize - 1, target_line));
+        target_line = max(0, min(term.grid().total_lines() as isize - 1, target_line));
         let col = first_occupied_in_line(term, target_line as usize).unwrap_or_default().col;
 
         // Move cursor.
@@ -174,27 +190,12 @@ impl ViModeCursor {
     }
 }
 
-/// Scroll display if point is outside of viewport.
-fn scroll_to_point<T: EventListener>(term: &mut Term<T>, point: Point<usize>) {
-    let display_offset = term.grid().display_offset();
-    let lines = term.grid().num_lines();
-
-    // Scroll once the top/bottom has been reached.
-    if point.line >= display_offset + lines.0 {
-        let lines = point.line.saturating_sub(display_offset + lines.0 - 1);
-        term.scroll_display(Scroll::Lines(lines as isize));
-    } else if point.line < display_offset {
-        let lines = display_offset.saturating_sub(point.line);
-        term.scroll_display(Scroll::Lines(-(lines as isize)));
-    };
-}
-
 /// Find next end of line to move to.
 fn last<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
     let cols = term.grid().num_cols();
 
     // Expand across wide cells.
-    point = expand_wide(term, point, false);
+    point = term.expand_wide(point, Direction::Left);
 
     // Find last non-empty cell in the current line.
     let occupied = last_occupied_in_line(term, point.line).unwrap_or_default();
@@ -220,7 +221,7 @@ fn first_occupied<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
     let cols = term.grid().num_cols();
 
     // Expand left across wide chars, since we're searching lines left to right.
-    point = expand_wide(term, point, true);
+    point = term.expand_wide(point, Direction::Right);
 
     // Find first non-empty cell in current line.
     let occupied = first_occupied_in_line(term, point.line)
@@ -231,7 +232,7 @@ fn first_occupied<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
         let mut occupied = None;
 
         // Search for non-empty cell in previous lines.
-        for line in (point.line + 1)..term.grid().len() {
+        for line in (point.line + 1)..term.grid().total_lines() {
             if !is_wrap(term, Point::new(line, cols - 1)) {
                 break;
             }
@@ -262,18 +263,18 @@ fn first_occupied<T>(term: &Term<T>, mut point: Point<usize>) -> Point<usize> {
 fn semantic<T: EventListener>(
     term: &mut Term<T>,
     mut point: Point<usize>,
-    left: bool,
-    start: bool,
+    direction: Direction,
+    side: Side,
 ) -> Point<usize> {
     // Expand semantically based on movement direction.
     let expand_semantic = |point: Point<usize>| {
         // Do not expand when currently on a semantic escape char.
         let cell = term.grid()[point.line][point.col];
         if term.semantic_escape_chars().contains(cell.c)
-            && !cell.flags.contains(Flags::WIDE_CHAR_SPACER)
+            && !cell.flags.intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
         {
             point
-        } else if left {
+        } else if direction == Direction::Left {
             term.semantic_search_left(point)
         } else {
             term.semantic_search_right(point)
@@ -281,27 +282,27 @@ fn semantic<T: EventListener>(
     };
 
     // Make sure we jump above wide chars.
-    point = expand_wide(term, point, left);
+    point = term.expand_wide(point, direction);
 
     // Move to word boundary.
-    if left != start && !is_boundary(term, point, left) {
+    if direction != side && !is_boundary(term, point, direction) {
         point = expand_semantic(point);
     }
 
     // Skip whitespace.
-    let mut next_point = advance(term, point, left);
-    while !is_boundary(term, point, left) && is_space(term, next_point) {
+    let mut next_point = advance(term, point, direction);
+    while !is_boundary(term, point, direction) && is_space(term, next_point) {
         point = next_point;
-        next_point = advance(term, point, left);
+        next_point = advance(term, point, direction);
     }
 
     // Assure minimum movement of one cell.
-    if !is_boundary(term, point, left) {
-        point = advance(term, point, left);
+    if !is_boundary(term, point, direction) {
+        point = advance(term, point, direction);
     }
 
     // Move to word boundary.
-    if left == start && !is_boundary(term, point, left) {
+    if direction == side && !is_boundary(term, point, direction) {
         point = expand_semantic(point);
     }
 
@@ -312,58 +313,38 @@ fn semantic<T: EventListener>(
 fn word<T: EventListener>(
     term: &mut Term<T>,
     mut point: Point<usize>,
-    left: bool,
-    start: bool,
+    direction: Direction,
+    side: Side,
 ) -> Point<usize> {
     // Make sure we jump above wide chars.
-    point = expand_wide(term, point, left);
+    point = term.expand_wide(point, direction);
 
-    if left == start {
+    if direction == side {
         // Skip whitespace until right before a word.
-        let mut next_point = advance(term, point, left);
-        while !is_boundary(term, point, left) && is_space(term, next_point) {
+        let mut next_point = advance(term, point, direction);
+        while !is_boundary(term, point, direction) && is_space(term, next_point) {
             point = next_point;
-            next_point = advance(term, point, left);
+            next_point = advance(term, point, direction);
         }
 
         // Skip non-whitespace until right inside word boundary.
-        let mut next_point = advance(term, point, left);
-        while !is_boundary(term, point, left) && !is_space(term, next_point) {
+        let mut next_point = advance(term, point, direction);
+        while !is_boundary(term, point, direction) && !is_space(term, next_point) {
             point = next_point;
-            next_point = advance(term, point, left);
+            next_point = advance(term, point, direction);
         }
     }
 
-    if left != start {
+    if direction != side {
         // Skip non-whitespace until just beyond word.
-        while !is_boundary(term, point, left) && !is_space(term, point) {
-            point = advance(term, point, left);
+        while !is_boundary(term, point, direction) && !is_space(term, point) {
+            point = advance(term, point, direction);
         }
 
         // Skip whitespace until right inside word boundary.
-        while !is_boundary(term, point, left) && is_space(term, point) {
-            point = advance(term, point, left);
+        while !is_boundary(term, point, direction) && is_space(term, point) {
+            point = advance(term, point, direction);
         }
-    }
-
-    point
-}
-
-/// Jump to the end of a wide cell.
-fn expand_wide<T, P>(term: &Term<T>, point: P, left: bool) -> Point<usize>
-where
-    P: Into<Point<usize>>,
-{
-    let mut point = point.into();
-    let cell = term.grid()[point.line][point.col];
-
-    if cell.flags.contains(Flags::WIDE_CHAR) && !left {
-        point.col += 1;
-    } else if cell.flags.contains(Flags::WIDE_CHAR_SPACER)
-        && term.grid()[point.line][point.col - 1].flags.contains(Flags::WIDE_CHAR)
-        && left
-    {
-        point.col -= 1;
     }
 
     point
@@ -384,18 +365,19 @@ fn last_occupied_in_line<T>(term: &Term<T>, line: usize) -> Option<Point<usize>>
 }
 
 /// Advance point based on direction.
-fn advance<T>(term: &Term<T>, point: Point<usize>, left: bool) -> Point<usize> {
-    if left {
-        point.sub_absolute(term.grid().num_cols(), 1)
+fn advance<T>(term: &Term<T>, point: Point<usize>, direction: Direction) -> Point<usize> {
+    if direction == Direction::Left {
+        point.sub_absolute(term, Boundary::Clamp, 1)
     } else {
-        point.add_absolute(term.grid().num_cols(), 1)
+        point.add_absolute(term, Boundary::Clamp, 1)
     }
 }
 
 /// Check if cell at point contains whitespace.
 fn is_space<T>(term: &Term<T>, point: Point<usize>) -> bool {
     let cell = term.grid()[point.line][point.col];
-    cell.c == ' ' || cell.c == '\t' && !cell.flags().contains(Flags::WIDE_CHAR_SPACER)
+    !cell.flags().intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+        && (cell.c == ' ' || cell.c == '\t')
 }
 
 fn is_wrap<T>(term: &Term<T>, point: Point<usize>) -> bool {
@@ -403,9 +385,11 @@ fn is_wrap<T>(term: &Term<T>, point: Point<usize>) -> bool {
 }
 
 /// Check if point is at screen boundary.
-fn is_boundary<T>(term: &Term<T>, point: Point<usize>, left: bool) -> bool {
-    (point.line == 0 && point.col + 1 >= term.grid().num_cols() && !left)
-        || (point.line + 1 >= term.grid().len() && point.col.0 == 0 && left)
+fn is_boundary<T>(term: &Term<T>, point: Point<usize>, direction: Direction) -> bool {
+    let total_lines = term.grid().total_lines();
+    let num_cols = term.grid().num_cols();
+    (point.line + 1 >= total_lines && point.col.0 == 0 && direction == Direction::Left)
+        || (point.line == 0 && point.col + 1 >= num_cols && direction == Direction::Right)
 }
 
 #[cfg(test)]

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -8,11 +8,10 @@ use std::path::Path;
 use alacritty_terminal::ansi;
 use alacritty_terminal::config::MockConfig;
 use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::{Dimensions, Grid};
 use alacritty_terminal::index::Column;
 use alacritty_terminal::term::cell::Cell;
-use alacritty_terminal::term::SizeInfo;
-use alacritty_terminal::Grid;
-use alacritty_terminal::Term;
+use alacritty_terminal::term::{SizeInfo, Term};
 
 macro_rules! ref_tests {
     ($($name:ident)*) => {
@@ -114,7 +113,7 @@ fn ref_test(dir: &Path) {
     term_grid.truncate();
 
     if grid != term_grid {
-        for i in 0..grid.len() {
+        for i in 0..grid.total_lines() {
             for j in 0..grid.num_cols().0 {
                 let cell = term_grid[i][Column(j)];
                 let original_cell = grid[i][Column(j)];

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -114,7 +114,7 @@ fn ref_test(dir: &Path) {
 
     if grid != term_grid {
         for i in 0..grid.total_lines() {
-            for j in 0..grid.num_cols().0 {
+            for j in 0..grid.cols().0 {
                 let cell = term_grid[i][Column(j)];
                 let original_cell = grid[i][Column(j)];
                 if original_cell != cell {


### PR DESCRIPTION
This adds initial support for regex scrollback buffer search. While
searching should already be fully functional, the match is currently
only logged to stdout and not displayed in Alacritty.

However the searching should already behave as intended.

Fixes #3672.
Fixes #1017.

There are a lot of edgecases with this PR that need to be tested, I went through all of them but I doubt I've tested all permutations. So here's a list with things that would be useful to test:
 - Search from vi mode starting in last line
 - Search from vi mode above last line
 - Search without vi mode
 - Forward search
 - Backwards search
 - Goto match next start/end, previous start/end
 - Resize during search
 - Message bar
 - Start search while scrolled up
 - Search without history
 - Search with history and normal cursor at bottom
 - Search with history and normal cursor not at bottom (ctrl+l)
 - Immediate search while typing with match < 1000 lines away
 - Delayed search while typing with match > 1000 lines away

There are a few features I've intentionally left out that we should likely add in the future. I'll create issues for them as soon as this PR is merged:
 - Moving the cursor inside the search bar
 - Anchored searches using ^ and $