### PR TITLE
use fs::read_to_string in tests instead of custom implementation.

### DIFF
--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use serde_json as json;
 
-use std::fs::File;
+use std::fs::{read_to_string, File};
 use std::io::{self, Read};
 use std::path::Path;
 
@@ -75,16 +75,6 @@ where
     res
 }
 
-fn read_string<P>(path: P) -> Result<String, ::std::io::Error>
-where
-    P: AsRef<Path>,
-{
-    let mut res = String::new();
-    File::open(path.as_ref()).and_then(|mut f| f.read_to_string(&mut res))?;
-
-    Ok(res)
-}
-
 #[derive(Deserialize, Default)]
 struct RefConfig {
     history_size: u32,
@@ -97,9 +87,9 @@ impl EventListener for Mock {
 
 fn ref_test(dir: &Path) {
     let recording = read_u8(dir.join("alacritty.recording"));
-    let serialized_size = read_string(dir.join("size.json")).unwrap();
-    let serialized_grid = read_string(dir.join("grid.json")).unwrap();
-    let serialized_cfg = read_string(dir.join("config.json")).unwrap();
+    let serialized_size = read_to_string(dir.join("size.json")).unwrap();
+    let serialized_grid = read_to_string(dir.join("grid.json")).unwrap();
+    let serialized_cfg = read_to_string(dir.join("config.json")).unwrap();
 
     let size: SizeInfo = json::from_str(&serialized_size).unwrap();
     let grid: Grid<Cell> = json::from_str(&serialized_grid).unwrap();


### PR DESCRIPTION
Should have run with --all-targets --all-features previously... :)