### PR TITLE
Fix CHANGELOG section for v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Tabstops not being reset with `reset`
 
-## 0.4.2-dev
+## 0.4.2
 
 ### Packaging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ The exact steps for an exemplary `1.2.3` release might look like this:
  11. A GitHub release is created for the `v1.2.3` tag
  12. The changelog since the last stable release (**not** RC)
         is added to the GitHub release description
- 13. The `-dev` is stripped from previous change log entries
+ 13. The `-dev` is stripped from previous changelog entries
 
 # Contact
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,6 @@ The exact steps for an exemplary `1.2.3` release might look like this:
  1. Initially, the version on the latest master is `1.2.3-dev`
  2. A new `v1.2.3` branch is created for the release
  3. On master, the version is bumped to `1.2.4-dev`
-        and the `-dev` is stripped from previous change log entries
  4. In the branch, the version is bumped to `1.2.3-rc1`
  5. The new commit in the branch is tagged as `v1.2.3-rc1`
  6. A GitHub release is created for the `v1.2.3-rc1` tag
@@ -126,6 +125,7 @@ The exact steps for an exemplary `1.2.3` release might look like this:
  11. A GitHub release is created for the `v1.2.3` tag
  12. The changelog since the last stable release (**not** RC)
         is added to the GitHub release description
+ 13. The `-dev` is stripped from previous change log entries
 
 # Contact
 


### PR DESCRIPTION
During bump to v0.5.0-dev it was forgotten to strip 'dev' suffix from
v0.4.2.

Also changes contributing to make `-dev` update after release.