### PR TITLE
Fix various mouse mode + vi mode interactions

### DIFF
--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -364,7 +364,8 @@ impl Display {
         let size_info = self.size_info;
 
         let selection = !terminal.selection().as_ref().map(Selection::is_empty).unwrap_or(true);
-        let mouse_mode = terminal.mode().intersects(TermMode::MOUSE_MODE);
+        let mouse_mode = terminal.mode().intersects(TermMode::MOUSE_MODE)
+            && !terminal.mode().contains(TermMode::VI);
 
         let vi_mode_cursor = if terminal.mode().contains(TermMode::VI) {
             Some(terminal.vi_mode_cursor)

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use glutin::dpi::PhysicalSize;
-use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, MouseButton, WindowEvent};
+use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, WindowEvent};
 use glutin::event_loop::{ControlFlow, EventLoop, EventLoopProxy, EventLoopWindowTarget};
 use glutin::platform::desktop::EventLoopExtDesktop;
 use log::{debug, info, warn};
@@ -316,7 +316,6 @@ pub struct Mouse {
     pub cell_side: Side,
     pub lines_scrolled: f32,
     pub block_url_launcher: bool,
-    pub last_button: MouseButton,
     pub inside_grid: bool,
 }
 
@@ -336,7 +335,6 @@ impl Default for Mouse {
             cell_side: Side::Left,
             lines_scrolled: 0.,
             block_url_launcher: false,
-            last_button: MouseButton::Other(0),
             inside_grid: false,
         }
     }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -292,7 +292,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ClickState {
     None,
     Click,

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -469,15 +469,15 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             };
 
             self.mouse_report(code, ElementState::Pressed);
-            return;
-        }
-
-        // Do nothing when using buttons other than LMB
-        if button != MouseButton::Left {
+        } else if button == MouseButton::Left {
+            self.handle_lmb_click();
+        } else {
+            // Do nothing when using buttons other than LMB
             self.ctx.mouse_mut().click_state = ClickState::None;
-            return;
         }
+    }
 
+    fn handle_lmb_click(&mut self) {
         // Calculate time since the last click to handle double/triple clicks in normal mode
         let now = Instant::now();
         let elapsed = now - self.ctx.mouse().last_click_timestamp;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -470,14 +470,15 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
             self.mouse_report(code, ElementState::Pressed);
         } else if button == MouseButton::Left {
-            self.handle_lmb_click();
+            self.on_left_click();
         } else {
             // Do nothing when using buttons other than LMB
             self.ctx.mouse_mut().click_state = ClickState::None;
         }
     }
 
-    fn handle_lmb_click(&mut self) {
+    /// Handle left click selection and vi mode cursor movement.
+    fn on_left_click(&mut self) {
         // Calculate time since the last click to handle double/triple clicks in normal mode
         let now = Instant::now();
         let elapsed = now - self.ctx.mouse().last_click_timestamp;


### PR DESCRIPTION
This commit fixes some issues introduced by
1a8cd172e520e493bacc9c6a2ae6f80de086eaa3:

 1. Vi cursor not moving properly on double/triple click
 2. URL not launching via mouse click in vi mode + mouse mode
 3. Ability to select in mouse mode with double/triple click regardless
    of shift modifier

