### PR TITLE
Add support for background blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default Command+N keybinding for SpawnNewInstance on macOS
 - Vi mode for copying text and opening links
 - `CopySelection` action which copies into selection buffer on Linux/BSD
+- Config option `background_blur` to enable background blur effect
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -288,6 +288,12 @@
 # The value `0.0` is completely transparent and `1.0` is opaque.
 #background_opacity: 1.0
 
+# Background blur
+#
+# Request transcluent parts of window's background to be blurred.
+# Currently this only affects KWin and X11.
+#background_blur: false
+
 #selection:
   #semantic_escape_chars: ",│`|:\"' ()[]{}<>\t"
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -300,6 +300,11 @@ impl Display {
             self.update_glyph_cache(config, font);
         }
 
+        // Update background blur state
+        if let Some(background_blur) = update_pending.background_blur {
+            self.window.set_background_blur(background_blur);
+        }
+
         let cell_width = self.size_info.cell_width;
         let cell_height = self.size_info.cell_height;
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -48,6 +48,7 @@ pub struct DisplayUpdate {
     pub dimensions: Option<PhysicalSize<u32>>,
     pub message_buffer: Option<()>,
     pub font: Option<Font>,
+    pub background_blur: Option<bool>,
 }
 
 impl DisplayUpdate {
@@ -540,6 +541,11 @@ impl<N: Notify + OnResize> Processor<N> {
 
                             let font = config.font.clone().with_size(*processor.ctx.font_size);
                             processor.ctx.display_update_pending.font = Some(font);
+                        }
+
+                        if processor.ctx.config.background_blur() != config.background_blur() {
+                            processor.ctx.display_update_pending.background_blur =
+                                Some(config.background_blur());
                         }
 
                         *processor.ctx.config = config;

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -69,6 +69,10 @@ pub struct Config<T> {
     #[serde(default, deserialize_with = "failure_default")]
     background_opacity: Alpha,
 
+    /// Background blur
+    #[serde(default, deserialize_with = "failure_default")]
+    background_blur: bool,
+
     /// Window configuration
     #[serde(default, deserialize_with = "failure_default")]
     pub window: WindowConfig,
@@ -146,6 +150,11 @@ impl<T> Config<T> {
     #[inline]
     pub fn draw_bold_text_with_bright_colors(&self) -> bool {
         self.draw_bold_text_with_bright_colors
+    }
+
+    #[inline]
+    pub fn background_blur(&self) -> bool {
+        self.background_blur
     }
 
     /// Should show render timer


### PR DESCRIPTION
Add new `background_blur` boolean configuration option for enabling background
blur effect.

This setting currently only has any effect when Alacritty is used with KWin and
X11 as the implementation relies on KWin's compositor for blurring.

This feature was requested in #972 

Considering the limited OS/WM support, I realize that you might not want to introduce this feature as-is. However, I still decide to open this PR as a sort of proof-of-concept implementation that works well enough for me. Maybe someone else will also find it useful.

![Screenshot_20200330_192224](https://user-images.githubusercontent.com/40366/77937214-b0920880-72bc-11ea-8dd1-3f5cdf1f476f.png)
