### PR TITLE
Convert Shell.program from Cow to String

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -41,7 +41,7 @@ pub struct Options {
     pub class: Option<String>,
     pub embed: Option<String>,
     pub log_level: LevelFilter,
-    pub command: Option<Shell<'static>>,
+    pub command: Option<Shell>,
     pub hold: bool,
     pub working_dir: Option<PathBuf>,
     pub config: Option<PathBuf>,
@@ -245,7 +245,7 @@ impl Options {
             // Arg::min_values(1) is set.
             let command = String::from(args.next().unwrap());
             let args = args.map(String::from).collect();
-            options.command = Some(Shell::new_with_args(command, args));
+            options.command = Some(Shell::new_with_args(&command, args));
         }
 
         if matches.is_present("hold") {

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -245,7 +245,7 @@ impl Options {
             // Arg::min_values(1) is set.
             let command = String::from(args.next().unwrap());
             let args = args.map(String::from).collect();
-            options.command = Some(Shell::new_with_args(&command, args));
+            options.command = Some(Shell::new_with_args(command, args));
         }
 
         if matches.is_present("hold") {

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -49,8 +49,8 @@ pub struct Options {
 }
 
 impl Default for Options {
-    fn default() -> Options {
-        Options {
+    fn default() -> Self {
+        Self {
             live_config_reload: None,
             print_events: false,
             ref_test: false,
@@ -78,7 +78,7 @@ impl Options {
             version = format!("{} ({})", version, commit_hash);
         }
 
-        let mut options = Options::default();
+        let mut options = Self::default();
 
         let matches = App::new(crate_name!())
             .version(version.as_str())

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -266,12 +266,12 @@ pub struct Shell {
 }
 
 impl Shell {
-    pub fn new(program: &str) -> Self {
-        Self { program: program.into(), args: Vec::new() }
+    pub const fn new(program: String) -> Self {
+        Self { program, args: Vec::new() }
     }
 
-    pub fn new_with_args(program: &str, args: Vec<String>) -> Self {
-        Self { program: program.into(), args }
+    pub const fn new_with_args(program: String, args: Vec<String>) -> Self {
+        Self { program, args }
     }
 }
 

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -143,7 +143,7 @@ pub struct Config<T> {
 
 impl<T> Config<T> {
     #[inline]
-    pub fn draw_bold_text_with_bright_colors(&self) -> bool {
+    pub const fn draw_bold_text_with_bright_colors(&self) -> bool {
         self.draw_bold_text_with_bright_colors
     }
 
@@ -155,7 +155,7 @@ impl<T> Config<T> {
 
     /// Live config reload
     #[inline]
-    pub fn live_config_reload(&self) -> bool {
+    pub const fn live_config_reload(&self) -> bool {
         self.live_config_reload.0
     }
 
@@ -165,13 +165,13 @@ impl<T> Config<T> {
     }
 
     #[inline]
-    pub fn dynamic_title(&self) -> bool {
+    pub const fn dynamic_title(&self) -> bool {
         self.dynamic_title.0
     }
 
     /// Cursor foreground color.
     #[inline]
-    pub fn cursor_text_color(&self) -> Option<Rgb> {
+    pub const fn cursor_text_color(&self) -> Option<Rgb> {
         self.colors.cursor.text
     }
 
@@ -183,13 +183,13 @@ impl<T> Config<T> {
 
     /// Vi mode cursor foreground color.
     #[inline]
-    pub fn vi_mode_cursor_text_color(&self) -> Option<Rgb> {
+    pub const fn vi_mode_cursor_text_color(&self) -> Option<Rgb> {
         self.colors.vi_mode_cursor.text
     }
 
     /// Vi mode cursor background color.
     #[inline]
-    pub fn vi_mode_cursor_cursor_color(&self) -> Option<Rgb> {
+    pub const fn vi_mode_cursor_cursor_color(&self) -> Option<Rgb> {
         self.colors.vi_mode_cursor.cursor
     }
 
@@ -200,7 +200,7 @@ impl<T> Config<T> {
 
     /// Send escape sequences using the alt key
     #[inline]
-    pub fn alt_send_esc(&self) -> bool {
+    pub const fn alt_send_esc(&self) -> bool {
         self.alt_send_esc.0
     }
 
@@ -211,7 +211,7 @@ impl<T> Config<T> {
     }
 
     #[inline]
-    pub fn background_opacity(&self) -> f32 {
+    pub const fn background_opacity(&self) -> f32 {
         self.background_opacity.0
     }
 }
@@ -236,7 +236,7 @@ struct EscapeChars(String);
 
 impl Default for EscapeChars {
     fn default() -> Self {
-        EscapeChars(String::from(",│`|:\"' ()[]{}<>\t"))
+        Self(String::from(",│`|:\"' ()[]{}<>\t"))
     }
 }
 
@@ -252,7 +252,7 @@ pub struct Cursor {
 }
 
 impl Cursor {
-    pub fn unfocused_hollow(self) -> bool {
+    pub const fn unfocused_hollow(self) -> bool {
         self.unfocused_hollow.0
     }
 }
@@ -293,7 +293,7 @@ pub struct Alpha(f32);
 
 impl Alpha {
     pub fn new(value: f32) -> Self {
-        Alpha(if value < 0.0 {
+        Self(if value < 0.0 {
             0.0
         } else if value > 1.0 {
             1.0
@@ -305,7 +305,7 @@ impl Alpha {
 
 impl Default for Alpha {
     fn default() -> Self {
-        Alpha(1.0)
+        Self(1.0)
     }
 }
 
@@ -314,7 +314,7 @@ impl<'a> Deserialize<'a> for Alpha {
     where
         D: Deserializer<'a>,
     {
-        Ok(Alpha::new(f32::deserialize(deserializer)?))
+        Ok(Self::new(f32::deserialize(deserializer)?))
     }
 }
 
@@ -323,7 +323,7 @@ struct DefaultTrueBool(bool);
 
 impl Default for DefaultTrueBool {
     fn default() -> Self {
-        DefaultTrueBool(true)
+        Self(true)
     }
 }
 

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::path::PathBuf;
@@ -77,8 +76,8 @@ pub struct Config<T> {
     pub selection: Selection,
 
     /// Path to a shell program to run on startup
-    #[serde(default, deserialize_with = "from_string_or_deserialize")]
-    pub shell: Option<Shell<'static>>,
+    #[serde(default, deserialize_with = "failure_default")]
+    pub shell: Option<Shell>,
 
     /// Path where config was loaded from
     #[serde(default, deserialize_with = "failure_default")]
@@ -259,32 +258,20 @@ impl Cursor {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-pub struct Shell<'a> {
-    pub program: Cow<'a, str>,
+pub struct Shell {
+    pub program: String,
 
     #[serde(default, deserialize_with = "failure_default")]
     pub args: Vec<String>,
 }
 
-impl<'a> Shell<'a> {
-    pub fn new<S>(program: S) -> Shell<'a>
-    where
-        S: Into<Cow<'a, str>>,
-    {
-        Shell { program: program.into(), args: Vec::new() }
+impl Shell {
+    pub fn new(program: &str) -> Self {
+        Self { program: program.into(), args: Vec::new() }
     }
 
-    pub fn new_with_args<S>(program: S, args: Vec<String>) -> Shell<'a>
-    where
-        S: Into<Cow<'a, str>>,
-    {
-        Shell { program: program.into(), args }
-    }
-}
-
-impl FromString for Option<Shell<'_>> {
-    fn from(input: String) -> Self {
-        Some(Shell::new(input))
+    pub fn new_with_args(program: &str, args: Vec<String>) -> Self {
+        Self { program: program.into(), args }
     }
 }
 

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -152,9 +152,9 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, window_id: Option<usize>) -> 
         let shell_name = pw.shell.rsplit('/').next().unwrap();
         let argv = vec![String::from("-c"), format!("exec -a -{} {}", shell_name, pw.shell)];
 
-        Shell::new_with_args("/bin/bash", argv)
+        Shell::new_with_args(String::from("/bin/bash"), argv)
     } else {
-        Shell::new(pw.shell)
+        Shell::new(String::from(pw.shell))
     };
     let shell = config.shell.as_ref().unwrap_or(&default_shell);
 

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -303,7 +303,7 @@ impl OnResize for Pty {
 }
 
 fn cmdline<C>(config: &Config<C>) -> String {
-    let default_shell = Shell::new("powershell");
+    let default_shell = Shell::new(String::from("powershell"));
     let shell = config.shell.as_ref().unwrap_or(&default_shell);
 
     once(shell.program.as_ref())


### PR DESCRIPTION
In the interest of easing future efforts to simplify and decouple the config facilities, I think that this use of Cow can be changed to a String with no discernible performance impact. I've tested it as best I can, but I'd really welcome a second look at the small amount of serde related code I've touched here.