### PR TITLE
Adding use_xrdb to config and support for xrdb on colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "vte 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winpty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xrdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2133,6 +2134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11"
+version = "2.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "x11-clipboard"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xrdb"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11 2.18.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "yaml-rust"
@@ -2432,10 +2452,12 @@ dependencies = [
 "checksum winpty-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8a179a59760dc51d30b5e6eaf1bd6da88461f72f2616e962ddebef7e413210"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum x11 2.18.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
 "checksum x11-clipboard 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e5e937afd03b64b7be4f959cc044e09260a47241b71e56933f37db097bf7859d"
 "checksum x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"
 "checksum xcb 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62056f63138b39116f82a540c983cc11f1c90cd70b3d492a70c25eaa50bd22a6"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
+"checksum xrdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cc2dd91a21c92e87678e22f95956a03bfd314ce3232f39dbedd49dddb50f0c6d"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum zip 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6df134e83b8f0f8153a094c7b0fd79dfebe437f1d76e7715afa18ed95ebe2fd7"

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -172,6 +172,8 @@
 
 # Colors (Tomorrow Night Bright)
 #colors:
+  # Use xrdb colors (Linux/BSD only):
+  # use_xrdb: false
   # Default colors
   #primary:
   #  background: '#000000'

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -29,6 +29,7 @@ copypasta = { version = "0.6.3", default-features = false }
 [target.'cfg(unix)'.dependencies]
 nix = "0.16.1"
 signal-hook = { version = "0.1", features = ["mio-support"] }
+xrdb = "0.1.1"
 
 [target.'cfg(windows)'.dependencies]
 winpty = "0.2.0"

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -7,6 +7,9 @@ use crate::term::color::Rgb;
 #[serde(default)]
 #[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Colors {
+    /// Use xrdb Values
+    #[serde(deserialize_with = "failure_default")]
+    pub use_xrdb: bool,
     #[serde(deserialize_with = "failure_default")]
     pub primary: PrimaryColors,
     #[serde(deserialize_with = "failure_default")]

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::ansi;
 use crate::config::{Colors, LOG_TARGET_CONFIG};
-extern crate xrdb;
+
+#[cfg(unix)]
+use xrdb;
 
 pub const COUNT: usize = 269;
 
@@ -151,6 +153,10 @@ impl<'a> From<&'a Colors> for List {
 
 impl List {
     fn xrdb_colors(&mut self, colors: &Colors) -> bool {
+        // If not on unix, return without trying to read xrdb
+        #[cfg(not(unix))]
+        return false;
+
         // If xrdb is defined
         if colors.use_xrdb {
             // Get xrdb colors


### PR DESCRIPTION
Fixes #1771 **Load colors from Xresources.**

## Proposed Changes
  - **alacritty.yml**: Adds a new config option on colors: `use_xrdb: bool`
  - **alacritty_terminal/Cargo.toml**: Adds the external (and very new) crate [xrdb](https://crates.io/crates/xrdb) 
  - **alacritty_terminal/src/config/colors.rs**: Adds new field for deserialize `use_xrdb`
  - **alacritty_terminal/src/term/color.rs**: Adds a new private function
    `xrdb_colors -> bool` that will check for the `use_xrdb` option and try to
    load colors using the xrdb lib. If any of the previous is false or fails, it
    returns false, which leads to previus normal flow on fill_named. Otherwise
    it adds the expected xrdb to NamedColor.

## New dependencies?
Yes, [xrdb](https://crates.io/crates/xrdb).

### Warning:
- I am still starting to learn Rust
- This is my first serious PR ever ;)
