### PR TITLE
Add a keybinding to open OSX Emoji & Symbols picker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Default Command+N keybinding for SpawnNewInstance on macOS
+- Add keybinding to open "Emoji & Symbols" input dialog on macOS
 - Vi mode for copying text and opening links
 - `CopySelection` action which copies into selection buffer on Linux/BSD
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ version = "0.5.0-dev"
 dependencies = [
  "alacritty_terminal 0.5.0-dev",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "embed-resource 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,6 +31,7 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -503,6 +503,7 @@
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space
+#   - ShowEmojiAndSymbols: Display the "Emoji & Symbols" modal dialog
 #
 #   (Linux/BSD only):
 #   - CopySelection: Copies into selection buffer
@@ -616,21 +617,22 @@
   #- { key: Return,   mods: Alt,           action: ToggleFullscreen }
 
   # (macOS only)
-  #- { key: K,      mods: Command, mode: ~Vi, chars: "\x0c"            }
-  #- { key: Key0,   mods: Command,            action: ResetFontSize    }
-  #- { key: Equals, mods: Command,            action: IncreaseFontSize }
-  #- { key: Add,    mods: Command,            action: IncreaseFontSize }
-  #- { key: Minus,  mods: Command,            action: DecreaseFontSize }
-  #- { key: K,      mods: Command,            action: ClearHistory     }
-  #- { key: V,      mods: Command,            action: Paste            }
-  #- { key: C,      mods: Command,            action: Copy             }
-  #- { key: C,      mods: Command, mode: Vi,  action: ClearSelection   }
-  #- { key: H,      mods: Command,            action: Hide             }
-  #- { key: M,      mods: Command,            action: Minimize         }
-  #- { key: Q,      mods: Command,            action: Quit             }
-  #- { key: W,      mods: Command,            action: Quit             }
-  #- { key: N,      mods: Command,            action: SpawnNewInstance }
-  #- { key: F,      mods: Command|Control,    action: ToggleFullscreen }
+  #- { key: K,      mods: Command, mode: ~Vi, chars: "\x0c"               }
+  #- { key: Key0,   mods: Command,            action: ResetFontSize       }
+  #- { key: Equals, mods: Command,            action: IncreaseFontSize    }
+  #- { key: Add,    mods: Command,            action: IncreaseFontSize    }
+  #- { key: Minus,  mods: Command,            action: DecreaseFontSize    }
+  #- { key: Space,  mods: Command|Control,    action: ShowEmojiAndSymbols }
+  #- { key: K,      mods: Command,            action: ClearHistory        }
+  #- { key: V,      mods: Command,            action: Paste               }
+  #- { key: C,      mods: Command,            action: Copy                }
+  #- { key: C,      mods: Command, mode: Vi,  action: ClearSelection      }
+  #- { key: H,      mods: Command,            action: Hide                }
+  #- { key: M,      mods: Command,            action: Minimize            }
+  #- { key: Q,      mods: Command,            action: Quit                }
+  #- { key: W,      mods: Command,            action: Quit                }
+  #- { key: N,      mods: Command,            action: SpawnNewInstance    }
+  #- { key: F,      mods: Command|Control,    action: ToggleFullscreen    }
 
 #debug:
   # Display the time it takes to redraw each frame.

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -39,6 +39,10 @@ image = { version = "0.22.3", default-features = false, features = ["ico"] }
 [target.'cfg(any(target_os = "macos", windows))'.dependencies]
 dirs = "2.0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2.7"
+cocoa = "0.19.1"
+
 [target.'cfg(not(any(target_os="windows", target_os="macos")))'.dependencies]
 x11-dl = "2"
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -176,6 +176,10 @@ pub enum Action {
     #[cfg(target_os = "macos")]
     ToggleSimpleFullscreen,
 
+    /// Show the Emoji & Symbols window on macos.
+    #[cfg(target_os = "macos")]
+    ShowEmojiAndSymbols,
+
     /// Clear active selection.
     ClearSelection,
 
@@ -512,6 +516,7 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         Add,    ModifiersState::LOGO; Action::IncreaseFontSize;
         Minus,  ModifiersState::LOGO; Action::DecreaseFontSize;
         Insert, ModifiersState::SHIFT, ~TermMode::VI; Action::Esc("\x1b[2;2~".into());
+        Space,  ModifiersState::LOGO | ModifiersState::CTRL; Action::ShowEmojiAndSymbols;
         K, ModifiersState::LOGO, ~TermMode::VI; Action::Esc("\x0c".into());
         V, ModifiersState::LOGO, ~TermMode::VI; Action::Paste;
         N, ModifiersState::LOGO; Action::SpawnNewInstance;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -176,6 +176,8 @@ impl<T: EventListener> Execute<T> for Action {
             #[cfg(target_os = "macos")]
             Action::ToggleSimpleFullscreen => ctx.window_mut().toggle_simple_fullscreen(),
             #[cfg(target_os = "macos")]
+            Action::ShowEmojiAndSymbols => ctx.window().show_emoji_and_symbols(),
+            #[cfg(target_os = "macos")]
             Action::Hide => ctx.event_loop().hide_application(),
             #[cfg(not(target_os = "macos"))]
             Action::Hide => ctx.window().set_visible(false),

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -23,6 +23,10 @@
 #![windows_subsystem = "windows"]
 
 #[cfg(target_os = "macos")]
+#[macro_use]
+extern crate objc;
+
+#[cfg(target_os = "macos")]
 use std::env;
 use std::error::Error;
 use std::fs;

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -41,6 +41,9 @@ use alacritty_terminal::term::{SizeInfo, Term};
 use crate::config::Config;
 use crate::gl;
 
+#[cfg(target_os = "macos")]
+use cocoa::{appkit::NSApp, base::nil};
+
 // It's required to be in this directory due to the `windows.rc` file
 #[cfg(not(target_os = "macos"))]
 static WINDOW_ICON: &[u8] = include_bytes!("../../extra/windows/alacritty.ico");
@@ -354,6 +357,15 @@ impl Window {
         }
 
         self.window().set_simple_fullscreen(simple_fullscreen);
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn show_emoji_and_symbols(&self) {
+        unsafe {
+            let app = NSApp();
+            assert_ne!(app, nil);
+            let () = msg_send![app, orderFrontCharacterPalette: nil];
+        }
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]


### PR DESCRIPTION
This implements a call to OSX's [`orderfrontcharacterpalette()`](https://developer.apple.com/documentation/appkit/nsapplication/1428455-orderfrontcharacterpalette?language=objc) which is the aptly named function to display the standard on-screen keyboard for choosing emoji and of characters.

Similar functionality exists in an undocumented and [unexported function](https://github.com/rust-windowing/winit/blob/master/src/platform_impl/macos/util/mod.rs#L121-L124
) in the `winit` crate. A cleaner solution is to plumb this command through the crates dependencies and avoid the additional explicit dependencies on Objective-C macros in this crate.

Fixes #1895
