### PR TITLE
Add the feature to build and copy the binary via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust
+
+RUN apt-get update && \
+    apt-get install -y cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev python3
+
+WORKDIR /code
+
+ADD . .
+
+RUN RUSTFLAGS='-C link-arg=-s' cargo build --release
+

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ APP_DIR = $(RELEASE_DIR)/osx
 APP_BINARY = $(RELEASE_DIR)/$(TARGET)
 APP_BINARY_DIR  = $(APP_DIR)/$(APP_NAME)/Contents/MacOS
 
+PWD = $(pwd)
+
 DMG_NAME = Alacritty.dmg
 DMG_DIR = $(RELEASE_DIR)/osx
 
@@ -45,6 +47,10 @@ $(DMG_NAME): $(APP_NAME)
 
 install: $(DMG_NAME) ## Mount disk image
 	@open $(DMG_DIR)/$(DMG_NAME)
+
+docker:
+	docker build -t alacritty .
+	docker run -it -v $(PWD):/out alacritty cp release/alacritty /out/alacritty
 
 .PHONY: app binary clean dmg install $(TARGET)
 


### PR DESCRIPTION
This feature allows the user to compile the alacritty binary in release
mode, without having to install all the rust compiler.