### PR TITLE
Add deprecation warning for WINIT_HIDPI_FACTOR

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -217,6 +217,13 @@ fn print_deprecation_warnings(config: &Config) {
              the config"
         );
     }
+
+    if config.env.contains_key("WINIT_HIDPI_FACTOR") {
+        warn!(
+            target: LOG_TARGET_CONFIG,
+            "WINIT_HIDPI_FACTOR has been renamed to WINIT_X11_SCALE_FACTOR"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I spent an hour wondering why `WINIT_HIDPI_FACTOR` no longer had any effect with new versions of Alacritty (my bad for not going through CHANGELOG.md). I figured it would be helpful to warn users using the environment variable that it has been renamed to `WINIT_X11_SCALE_FACTOR`.