### PR TITLE
Add support for reporting window size in pixels and characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Escapes for double underlines (`CSI 4 : 2 m`) and underline reset (`CSI 4 : 0 m`)
 - Configuration file option for sourcing other files (`import`)
 - CLI parameter `--option`/`-o` to override any configuration field
-- Escape sequences to report window size in pixels and area size in characters
+- Escape sequences to report text area size in pixels (`CSI 14 t`) and in characters (`CSI 18 t`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Escapes for double underlines (`CSI 4 : 2 m`) and underline reset (`CSI 4 : 0 m`)
 - Configuration file option for sourcing other files (`import`)
 - CLI parameter `--option`/`-o` to override any configuration field
+- Escape sequences to report window size in pixels and area size in characters
 
 ### Changed
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -427,7 +427,7 @@ impl Display {
         pty_resize_handle.on_resize(&pty_size);
 
         // Resize terminal.
-        terminal.resize(&pty_size);
+        terminal.resize(pty_size);
 
         // Resize renderer.
         let physical = PhysicalSize::new(self.size_info.width as u32, self.size_info.height as u32);

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1295,7 +1295,7 @@ mod tests {
 
                 let mut clipboard = Clipboard::new_nop();
 
-                let mut terminal = Term::new(&cfg, &size, MockEventProxy);
+                let mut terminal = Term::new(&cfg, size, MockEventProxy);
 
                 let mut mouse = Mouse::default();
                 mouse.click_state = $initial_state;

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -145,7 +145,7 @@ fn run(
     // This object contains all of the state about what's being displayed. It's
     // wrapped in a clonable mutex since both the I/O loop and display need to
     // access it.
-    let terminal = Term::new(&config, &display.size_info, event_proxy.clone());
+    let terminal = Term::new(&config, display.size_info, event_proxy.clone());
     let terminal = Arc::new(FairMutex::new(terminal));
 
     // Create the PTY.

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -316,6 +316,12 @@ pub trait Handler {
 
     /// Pop the last title from the stack.
     fn pop_title(&mut self) {}
+
+    /// Report window size in pixels.
+    fn window_size_pixels<W: io::Write>(&mut self, _: &mut W) {}
+
+    /// Report area size in characters.
+    fn area_size_chars<W: io::Write>(&mut self, _: &mut W) {}
 }
 
 /// Describes shape of cursor.
@@ -1080,6 +1086,8 @@ where
             ('s', None) => handler.save_cursor_position(),
             ('T', None) => handler.scroll_down(Line(next_param_or(1) as usize)),
             ('t', None) => match next_param_or(1) as usize {
+                14 => handler.window_size_pixels(writer),
+                18 => handler.area_size_chars(writer),
                 22 => handler.push_title(),
                 23 => handler.pop_title(),
                 _ => unhandled!(),

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -317,11 +317,11 @@ pub trait Handler {
     /// Pop the last title from the stack.
     fn pop_title(&mut self) {}
 
-    /// Report window size in pixels.
-    fn window_size_pixels<W: io::Write>(&mut self, _: &mut W) {}
+    /// Report text area size in pixels.
+    fn text_area_size_pixels<W: io::Write>(&mut self, _: &mut W) {}
 
-    /// Report area size in characters.
-    fn area_size_chars<W: io::Write>(&mut self, _: &mut W) {}
+    /// Report text area size in characters.
+    fn text_area_size_chars<W: io::Write>(&mut self, _: &mut W) {}
 }
 
 /// Describes shape of cursor.
@@ -1086,8 +1086,8 @@ where
             ('s', None) => handler.save_cursor_position(),
             ('T', None) => handler.scroll_down(Line(next_param_or(1) as usize)),
             ('t', None) => match next_param_or(1) as usize {
-                14 => handler.window_size_pixels(writer),
-                18 => handler.area_size_chars(writer),
+                14 => handler.text_area_size_pixels(writer),
+                18 => handler.text_area_size_chars(writer),
                 22 => handler.push_title(),
                 23 => handler.pop_title(),
                 _ => unhandled!(),

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -418,7 +418,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        Term::new(&MockConfig::default(), &size, Mock)
+        Term::new(&MockConfig::default(), size, Mock)
     }
 
     /// Test case of single cell selection.

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2774,43 +2774,6 @@ mod tests {
         assert_eq!(version_number("1.2.3-dev"), 1_02_03);
         assert_eq!(version_number("999.99.99"), 9_99_99_99);
     }
-
-    #[test]
-    fn report_size_in_pixels_and_chars() {
-        let size = SizeInfo {
-            width: 21.0,
-            height: 51.0,
-            cell_width: 3.0,
-            cell_height: 3.0,
-            padding_x: 0.0,
-            padding_y: 0.0,
-            dpr: 1.0,
-        };
-
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
-        let mut processor = ansi::Processor::default();
-
-        macro_rules! run_sequence {
-            ($input:expr, $output:expr) => {
-                let mut writer = Vec::new();
-                for &i in &$input[..] {
-                    processor.advance(&mut term, i, &mut writer);
-                }
-
-                assert_eq!(&$output[..], &writer[..]);
-            };
-        }
-
-        run_sequence!(b"\x1b[14t", b"\x1b[4;51;21t");
-        run_sequence!(b"\x1b[18t", b"\x1b[8;17;7t");
-
-        // Resize
-        let size = SizeInfo { width: 210.0, height: 510.0, ..size };
-        term.resize(&size);
-
-        run_sequence!(b"\x1b[14t", b"\x1b[4;510;210t");
-        run_sequence!(b"\x1b[18t", b"\x1b[8;170;70t");
-    }
 }
 
 #[cfg(all(test, feature = "bench"))]

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -969,6 +969,8 @@ impl<T> Term<T> {
 
     /// Resize terminal to new dimensions.
     pub fn resize(&mut self, size: SizeInfo) {
+        self.size = size;
+
         let old_cols = self.cols();
         let old_lines = self.screen_lines();
         let num_cols = max(size.cols(), Column(MIN_SIZE));
@@ -1002,8 +1004,6 @@ impl<T> Term<T> {
 
         self.grid.resize(!is_alt, num_lines, num_cols);
         self.inactive_grid.resize(is_alt, num_lines, num_cols);
-
-        self.size = size;
 
         // Clamp vi cursor to viewport.
         self.vi_mode_cursor.point.col = min(self.vi_mode_cursor.point.col, num_cols - 1);

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -746,7 +746,7 @@ pub struct Term<T> {
     /// Current forward and backward buffer search regexes.
     regex_search: Option<RegexSearch>,
 
-    /// Terminal size info.
+    /// Information about window dimensions.
     size: SizeInfo,
 }
 
@@ -761,7 +761,7 @@ impl<T> Term<T> {
         self.dirty = true;
     }
 
-    pub fn new<C>(config: &Config<C>, size: &SizeInfo, event_proxy: T) -> Term<T> {
+    pub fn new<C>(config: &Config<C>, size: SizeInfo, event_proxy: T) -> Term<T> {
         let num_cols = size.cols();
         let num_lines = size.lines();
 
@@ -798,7 +798,7 @@ impl<T> Term<T> {
             title_stack: Vec::new(),
             selection: None,
             regex_search: None,
-            size: *size,
+            size,
         }
     }
 
@@ -968,7 +968,7 @@ impl<T> Term<T> {
     }
 
     /// Resize terminal to new dimensions.
-    pub fn resize(&mut self, size: &SizeInfo) {
+    pub fn resize(&mut self, size: SizeInfo) {
         let old_cols = self.cols();
         let old_lines = self.screen_lines();
         let num_cols = max(size.cols(), Column(MIN_SIZE));
@@ -1003,15 +1003,14 @@ impl<T> Term<T> {
         self.grid.resize(!is_alt, num_lines, num_cols);
         self.inactive_grid.resize(is_alt, num_lines, num_cols);
 
+        self.size = size;
+
         // Clamp vi cursor to viewport.
         self.vi_mode_cursor.point.col = min(self.vi_mode_cursor.point.col, num_cols - 1);
         self.vi_mode_cursor.point.line = min(self.vi_mode_cursor.point.line, num_lines - 1);
 
         // Reset scrolling region.
         self.scroll_region = Line(0)..self.screen_lines();
-
-        // Save term size.
-        self.size = *size;
     }
 
     /// Active terminal modes.
@@ -2229,14 +2228,14 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn text_area_size_pixels<W: io::Write>(&mut self, writer: &mut W) {
-        let width = self.size.cell_width * self.grid.cols().0 as f32;
-        let height = self.size.cell_height * self.grid.screen_lines().0 as f32;
+        let width = self.size.cell_width * self.cols().0 as f32;
+        let height = self.size.cell_height * self.screen_lines().0 as f32;
         let _ = write!(writer, "\x1b[4;{};{}t", height, width);
     }
 
     #[inline]
     fn text_area_size_chars<W: io::Write>(&mut self, writer: &mut W) {
-        let _ = write!(writer, "\x1b[8;{};{}t", self.grid.screen_lines(), self.grid.cols());
+        let _ = write!(writer, "\x1b[8;{};{}t", self.screen_lines(), self.cols());
     }
 }
 
@@ -2361,7 +2360,7 @@ pub mod test {
             padding_y: 0.,
             dpr: 1.,
         };
-        let mut term = Term::new(&Config::<()>::default(), &size, ());
+        let mut term = Term::new(&Config::<()>::default(), size, ());
 
         // Fill terminal with content.
         for (line, text) in lines.iter().rev().enumerate() {
@@ -2418,7 +2417,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
         let mut grid: Grid<Cell> = Grid::new(Line(3), Column(5), 0, Cell::default());
         for i in 0..5 {
             for j in 0..2 {
@@ -2474,7 +2473,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
         let mut grid: Grid<Cell> = Grid::new(Line(1), Column(5), 0, Cell::default());
         for i in 0..5 {
             grid[Line(0)][Column(i)].c = 'a';
@@ -2503,7 +2502,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
         let mut grid: Grid<Cell> = Grid::new(Line(3), Column(3), 0, Cell::default());
         for l in 0..3 {
             if l != 1 {
@@ -2548,7 +2547,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
         let cursor = Point::new(Line(0), Column(0));
         term.configure_charset(CharsetIndex::G0, StandardCharset::SpecialCharacterAndLineDrawing);
         term.input('a');
@@ -2567,7 +2566,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
 
         // Add one line of scrollback.
         term.grid.scroll_up(&(Line(0)..Line(1)), Line(1), Cell::default());
@@ -2597,7 +2596,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2608,7 +2607,7 @@ mod tests {
 
         // Increase visible lines.
         size.height = 30.;
-        term.resize(&size);
+        term.resize(size);
 
         assert_eq!(term.history_size(), 0);
         assert_eq!(term.grid.cursor.point, Point::new(Line(19), Column(0)));
@@ -2625,7 +2624,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2639,7 +2638,7 @@ mod tests {
 
         // Increase visible lines.
         size.height = 30.;
-        term.resize(&size);
+        term.resize(size);
 
         // Leave alt screen.
         term.unset_mode(ansi::Mode::SwapScreenAndSetRestoreCursor);
@@ -2659,7 +2658,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2670,7 +2669,7 @@ mod tests {
 
         // Increase visible lines.
         size.height = 5.;
-        term.resize(&size);
+        term.resize(size);
 
         assert_eq!(term.history_size(), 15);
         assert_eq!(term.grid.cursor.point, Point::new(Line(4), Column(0)));
@@ -2687,7 +2686,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
 
         // Create 10 lines of scrollback.
         for _ in 0..19 {
@@ -2701,7 +2700,7 @@ mod tests {
 
         // Increase visible lines.
         size.height = 5.;
-        term.resize(&size);
+        term.resize(size);
 
         // Leave alt screen.
         term.unset_mode(ansi::Mode::SwapScreenAndSetRestoreCursor);
@@ -2721,7 +2720,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        let mut term = Term::new(&MockConfig::default(), &size, Mock);
+        let mut term = Term::new(&MockConfig::default(), size, Mock);
 
         // Title None by default.
         assert_eq!(term.title, None);

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -746,11 +746,8 @@ pub struct Term<T> {
     /// Current forward and backward buffer search regexes.
     regex_search: Option<RegexSearch>,
 
-    /// Width of individual cell.
-    cell_width: f32,
-
-    /// Height of individual cell.
-    cell_height: f32,
+    /// Terminal size info.
+    size: SizeInfo,
 }
 
 impl<T> Term<T> {
@@ -801,8 +798,7 @@ impl<T> Term<T> {
             title_stack: Vec::new(),
             selection: None,
             regex_search: None,
-            cell_width: size.cell_width,
-            cell_height: size.cell_height,
+            size: *size,
         }
     }
 
@@ -1014,9 +1010,8 @@ impl<T> Term<T> {
         // Reset scrolling region.
         self.scroll_region = Line(0)..self.screen_lines();
 
-        // Save cell size
-        self.cell_width = size.cell_width;
-        self.cell_height = size.cell_height;
+        // Save term size.
+        self.size = *size;
     }
 
     /// Active terminal modes.
@@ -2234,8 +2229,8 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn text_area_size_pixels<W: io::Write>(&mut self, writer: &mut W) {
-        let width = self.cell_width * self.grid.cols().0 as f32;
-        let height = self.cell_height * self.grid.screen_lines().0 as f32;
+        let width = self.size.cell_width * self.grid.cols().0 as f32;
+        let height = self.size.cell_height * self.grid.screen_lines().0 as f32;
         let _ = write!(writer, "\x1b[4;{};{}t", height, width);
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2233,14 +2233,14 @@ impl<T: EventListener> Handler for Term<T> {
     }
 
     #[inline]
-    fn window_size_pixels<W: io::Write>(&mut self, writer: &mut W) {
+    fn text_area_size_pixels<W: io::Write>(&mut self, writer: &mut W) {
         let width = self.cell_width * self.grid.cols().0 as f32;
         let height = self.cell_height * self.grid.screen_lines().0 as f32;
         let _ = write!(writer, "\x1b[4;{};{}t", height, width);
     }
 
     #[inline]
-    fn area_size_chars<W: io::Write>(&mut self, writer: &mut W) {
+    fn text_area_size_chars<W: io::Write>(&mut self, writer: &mut W) {
         let _ = write!(writer, "\x1b[8;{};{}t", self.grid.screen_lines(), self.grid.cols());
     }
 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2228,8 +2228,8 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn text_area_size_pixels<W: io::Write>(&mut self, writer: &mut W) {
-        let width = self.size.cell_width * self.cols().0 as f32;
-        let height = self.size.cell_height * self.screen_lines().0 as f32;
+        let width = self.size.cell_width as usize * self.cols().0;
+        let height = self.size.cell_height as usize * self.screen_lines().0;
         let _ = write!(writer, "\x1b[4;{};{}t", height, width);
     }
 

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -416,7 +416,7 @@ mod tests {
             padding_y: 0.0,
             dpr: 1.0,
         };
-        Term::new(&MockConfig::default(), &size, Mock)
+        Term::new(&MockConfig::default(), size, Mock)
     }
 
     #[test]

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -102,7 +102,7 @@ fn ref_test(dir: &Path) {
     let mut config = MockConfig::default();
     config.scrolling.set_history(ref_config.history_size);
 
-    let mut terminal = Term::new(&config, &size, Mock);
+    let mut terminal = Term::new(&config, size, Mock);
     let mut parser = ansi::Processor::new();
 
     for byte in recording {


### PR DESCRIPTION
This patch adds the following sequences:

* `CSI 14 t`, to report the window size in pixels.
* `CSI 18 t`, to report the area size in characters.

These sequences are described in [dtterm(5)](https://www.freebsd.org/cgi/man.cgi?query=dtterm&sektion=5&manpath=FreeBSD+12.1-RELEASE+and+Ports).

