### PR TITLE
Use embedded resource for window icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Block cursor is no longer inverted at the start/end of a selection
 - Preserve selection on non-LMB or mouse mode clicks
 - Wayland client side decorations are now based on config colorscheme
+- Low resolution window decoration icon on Windows
 
 ### Fixed
 - Tabstops not being reset with `reset`


### PR DESCRIPTION
Just a quick one to use `Icon::from_resource` to (on Windows) load the window icon from the resource embedded by the Windows manifest, rather than including it for a second time via `include_bytes`.

In my experience Windows does a slightly better job of scaling the window icon image in this case. It also leads to a binary size saving of 300KB (~6% of a release build as measured on my machine).

Before:

![before](https://user-images.githubusercontent.com/1939362/80275497-7825f480-86d9-11ea-8c4e-52869739dfff.PNG)

After:

![after](https://user-images.githubusercontent.com/1939362/80275498-7c521200-86d9-11ea-8ee3-f7640d93ad0d.PNG)

(It's subtle, but to me lines are in general a bit smoother in the "after" shot.)
