### PR TITLE
Automatically expands tab selection to nearest tab border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tabstops not being reset with `reset`
 - Selection not cleared when switching between main and alt grid
 - Fallback to `LC_CTYPE=UTF-8` on macOS without valid system locale
+- Expands selection, including a partial tab, to the nearest tab border
 
 ## 0.4.2
 


### PR DESCRIPTION
Fixes: https://github.com/alacritty/alacritty/issues/2764

Things to do:
- [x] Add `CHANGELOG.md` entry
- [x] Expand visual selection
- [x] Expand clipboard selection

Potential issues:
 - Changing tab width retroactively affects printed lines with an non-contained `\t`, e.g.: 
```
$ echo '12345678\t'
$ tabs 1,40,50
```

![alactab4](https://user-images.githubusercontent.com/255721/80615750-59f52700-8a40-11ea-8f38-99fdca21bf3d.gif)
