### PR TITLE
Call glFinish right after swap_buffers on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tabstops not being reset with `reset`
 - Selection not cleared when switching between main and alt grid
 - Fallback to `LC_CTYPE=UTF-8` on macOS without valid system locale
+- Resize lag on launch under some X11 wms
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selection not cleared when switching between main and alt grid
 - Fallback to `LC_CTYPE=UTF-8` on macOS without valid system locale
 - Resize lag on launch under some X11 wms
+- Increased input latency due to vsync behavior on X11
 
 ## 0.4.2
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -513,9 +513,9 @@ impl Display {
         #[cfg(not(any(target_os = "macos", windows)))]
         {
             if self.is_x11 {
-                // It was find out that on X11 swap_buffers doesn't block with vsync on most
-                // systems, so the block will be on the next gl command (glClear on the next event
-                // loop tick for us), which introduces a permament one frame of delay
+                // On X11 `swap_buffers` does not block for vsync. However the next OpenGl command
+                // will block to synchronize (this is `glClear` in Alacritty), which causes a
+                // permanent one frame delay.
                 self.renderer.with_api(&config, &size_info, |api| {
                     api.finish();
                 });

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -923,6 +923,12 @@ impl<'a, C> RenderApi<'a, C> {
         }
     }
 
+    pub fn finish(&self) {
+        unsafe {
+            gl::Finish();
+        }
+    }
+
     fn render_batch(&mut self) {
         unsafe {
             gl::BufferSubData(


### PR DESCRIPTION
It was find out that on X11 swap_buffers doesn't block with vsync on most
systems, so the block will be on the next gl command (glClear on the next
event loop tick for us), which introduces a permament one frame of delay

Fixes #3061.
