### PR TITLE
Render colored emojis' true colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize lag on launch under some X11 wms
 - Increased input latency due to vsync behavior on X11
 - Freeze when application is invisible on Wayland
+- Emoji colors blending with terminal background
 
 ## 0.4.2
 

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -418,7 +418,7 @@ struct InstanceData {
     bg_g: f32,
     bg_b: f32,
     bg_a: f32,
-    // boolean set to true if the glyph already is colored (typically RGBA emojis)
+    // Colored glyph indicator.
     colored: u8,
 }
 

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -472,7 +472,6 @@ impl Batch {
             self.tex = glyph.tex_id;
         }
 
-
         self.instances.push(InstanceData {
             col: cell.column.0 as f32,
             row: cell.line.0 as f32,
@@ -1520,7 +1519,8 @@ impl Atlas {
             gl::PixelStorei(gl::UNPACK_ALIGNMENT, 1);
             gl::GenTextures(1, &mut id);
             gl::BindTexture(gl::TEXTURE_2D, id);
-            // Use RGBA texture for both normal and emoji glyphs, since it has no performance impact.
+            // Use RGBA texture for both normal and emoji glyphs, since it has no performance
+            // impact.
             gl::TexImage2D(
                 gl::TEXTURE_2D,
                 0,

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -419,7 +419,7 @@ struct InstanceData {
     bg_b: f32,
     bg_a: f32,
     // boolean set to true if the glyph already is colored (typically RGBA emojis)
-    pre_colored: u8,
+    colored: u8,
 }
 
 #[derive(Debug)]
@@ -495,7 +495,7 @@ impl Batch {
             bg_g: f32::from(cell.bg.g),
             bg_b: f32::from(cell.bg.b),
             bg_a: cell.bg_alpha,
-            pre_colored: glyph.colored as u8,
+            colored: glyph.colored as u8,
         });
     }
 
@@ -639,7 +639,7 @@ impl QuadRenderer {
             );
             gl::EnableVertexAttribArray(4);
             gl::VertexAttribDivisor(4, 1);
-            // preColoredGlyph attribute
+            // coloredGlyph attribute
             gl::VertexAttribPointer(
                 5,
                 1,
@@ -1521,8 +1521,9 @@ impl Atlas {
             gl::GenTextures(1, &mut id);
             gl::BindTexture(gl::TEXTURE_2D, id);
             // We use an RGBA atlas that can handle colored glyphs.
-            // As they usually are outnumbered by regular text glyphs, this is slightly wasteful.
-            // Another way would be to have a separate atlas for RGBA and render in two passes.
+            // Most of the text glyphs don't need this alpha channel but it has a negligible impact in practice.
+            // For more details and comparative benchmarks with a dual atlas approach, see:
+            // https://github.com/alacritty/alacritty/pull/3665
             gl::TexImage2D(
                 gl::TEXTURE_2D,
                 0,

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -418,8 +418,8 @@ struct InstanceData {
     bg_g: f32,
     bg_b: f32,
     bg_a: f32,
-    // Colored glyph indicator.
-    colored: u8,
+    // Flag indicating that glyph uses multiple colors, like an Emoji.
+    multicolor: u8,
 }
 
 #[derive(Debug)]
@@ -495,7 +495,7 @@ impl Batch {
             bg_g: f32::from(cell.bg.g),
             bg_b: f32::from(cell.bg.b),
             bg_a: cell.bg_alpha,
-            colored: glyph.colored as u8,
+            multicolor: glyph.colored as u8,
         });
     }
 
@@ -639,7 +639,7 @@ impl QuadRenderer {
             );
             gl::EnableVertexAttribArray(4);
             gl::VertexAttribDivisor(4, 1);
-            // coloredGlyph attribute
+            // Multicolor flag.
             gl::VertexAttribPointer(
                 5,
                 1,
@@ -1520,10 +1520,7 @@ impl Atlas {
             gl::PixelStorei(gl::UNPACK_ALIGNMENT, 1);
             gl::GenTextures(1, &mut id);
             gl::BindTexture(gl::TEXTURE_2D, id);
-            // We use an RGBA atlas that can handle colored glyphs.
-            // Most of the text glyphs don't need this alpha channel but it has a negligible impact in practice.
-            // For more details and comparative benchmarks with a dual atlas approach, see:
-            // https://github.com/alacritty/alacritty/pull/3665
+            // Use RGBA texture for both normal and emoji glyphs, since it has no performance impact.
             gl::TexImage2D(
                 gl::TEXTURE_2D,
                 0,

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -488,8 +488,8 @@ impl Font {
             kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host,
         );
 
-        // Give the context an opaque, black background.
-        cg_context.set_rgb_fill_color(0.0, 0.0, 0.0, 1.0);
+        // Set background color for graphics context.
+        cg_context.set_rgb_fill_color(0.0, 0.0, 0.0, 0.0);
         let context_rect = CGRect::new(
             &CGPoint::new(0.0, 0.0),
             &CGSize::new(f64::from(rasterized_width), f64::from(rasterized_height)),

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -173,7 +173,7 @@ pub struct RasterizedGlyph {
 
 #[derive(Clone, Debug)]
 pub enum BitmapBuffer {
-    /// RGB pixels.
+    /// RGB alphamask.
     RGB(Vec<u8>),
 
     /// RGBA pixels with premultiplied alpha.

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -173,7 +173,10 @@ pub struct RasterizedGlyph {
 
 #[derive(Clone, Debug)]
 pub enum BitmapBuffer {
+    /// RGB pixels.
     RGB(Vec<u8>),
+
+    /// RGBA pixels with premultiplied alpha.
     RGBA(Vec<u8>),
 }
 

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -15,6 +15,7 @@
 in vec2 TexCoords;
 flat in vec3 fg;
 flat in vec4 bg;
+flat in int preColored;
 uniform int backgroundPass;
 
 layout(location = 0, index = 0) out vec4 color;
@@ -31,8 +32,14 @@ void main()
         alphaMask = vec4(1.0);
         color = vec4(bg.rgb, 1.0);
     } else {
-        vec3 textColor = texture(mask, TexCoords).rgb;
-        alphaMask = vec4(textColor, textColor.r);
-        color = vec4(fg, 1.0);
+        if (preColored != 0) {
+            vec4 c = texture(mask, TexCoords);
+            alphaMask = vec4(c.a);
+            color = c;
+        } else {
+            vec3 textColor = texture(mask, TexCoords).rgb;
+            alphaMask = vec4(textColor, textColor.r);
+            color = vec4(fg, 1.0);
+        }
     }
 }

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -36,7 +36,9 @@ void main()
             // Color glyphs (such as emojis).
             vec4 glyphColor = texture(mask, TexCoords);
             alphaMask = vec4(glyphColor.a);
-            color = vec4(glyphColor.rgb, 1.0);
+            // Blend with background color used in a pass.
+            vec3 blendedColor = glyphColor.rgb + bg.rgb * (1.0 -  glyphColor.a);
+            color = vec4(blendedColor, 1.0);
         } else {
             // Regular text glyphs.
             vec3 textColor = texture(mask, TexCoords).rgb;

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -37,11 +37,10 @@ void main()
             vec4 glyphColor = texture(mask, TexCoords);
             alphaMask = vec4(glyphColor.a);
 
-            // Handle premultiplied alpha.
-            //
-            // NOTE - we won't show garbage from division by zero on a screen,
-            // due to alpha being 0, so it's perfrectly fine to do so.
-            glyphColor.rgb = vec3(glyphColor.rgb / glyphColor.a);
+            // Revert alpha premultiplication.
+            if (glyphColor.a != 0) {
+                glyphColor.rgb = vec3(glyphColor.rgb / glyphColor.a);
+            }
 
             color = vec4(glyphColor.rgb, 1.0);
         } else {

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -15,7 +15,7 @@
 in vec2 TexCoords;
 flat in vec3 fg;
 flat in vec4 bg;
-flat in int preColored;
+flat in int colored;
 uniform int backgroundPass;
 
 layout(location = 0, index = 0) out vec4 color;
@@ -32,11 +32,13 @@ void main()
         alphaMask = vec4(1.0);
         color = vec4(bg.rgb, 1.0);
     } else {
-        if (preColored != 0) {
-            vec4 c = texture(mask, TexCoords);
-            alphaMask = vec4(c.a);
-            color = c;
+        if (colored != 0) {
+            // Color glyphs (such as emojis).
+            vec4 glyphColor = texture(mask, TexCoords);
+            alphaMask = vec4(glyphColor.a);
+            color = vec4(glyphColor.rgb, 1.0);
         } else {
+            // Regular text glyphs.
             vec3 textColor = texture(mask, TexCoords).rgb;
             alphaMask = vec4(textColor, textColor.r);
             color = vec4(fg, 1.0);

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -33,12 +33,17 @@ void main()
         color = vec4(bg.rgb, 1.0);
     } else {
         if (colored != 0) {
-            // Color glyphs (such as emojis).
+            // Color glyphs, like emojis.
             vec4 glyphColor = texture(mask, TexCoords);
             alphaMask = vec4(glyphColor.a);
-            // Blend with background color used in a pass.
-            vec3 blendedColor = glyphColor.rgb + bg.rgb * (1.0 -  glyphColor.a);
-            color = vec4(blendedColor, 1.0);
+
+            // Handle premultiplied alpha.
+            //
+            // NOTE - we won't show garbage from division by zero on a screen,
+            // due to alpha being 0, so it's perfrectly fine to do so.
+            glyphColor.rgb = vec3(glyphColor.rgb / glyphColor.a);
+
+            color = vec4(glyphColor.rgb, 1.0);
         } else {
             // Regular text glyphs.
             vec3 textColor = texture(mask, TexCoords).rgb;

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -27,9 +27,12 @@ layout (location = 3) in vec3 textColor;
 // Background color
 layout (location = 4) in vec4 backgroundColor;
 
+layout (location = 5) in int preColoredGlyph;
+
 out vec2 TexCoords;
 flat out vec3 fg;
 flat out vec4 bg;
+flat out int preColored;
 
 // Terminal properties
 uniform vec2 cellDim;
@@ -71,4 +74,5 @@ void main()
 
     bg = vec4(backgroundColor.rgb / 255.0, backgroundColor.a);
     fg = textColor / vec3(255.0, 255.0, 255.0);
+    preColored = preColoredGlyph;
 }

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -27,12 +27,13 @@ layout (location = 3) in vec3 textColor;
 // Background color
 layout (location = 4) in vec4 backgroundColor;
 
-layout (location = 5) in int preColoredGlyph;
+// Set to 1 if the glyph colors should be kept
+layout (location = 5) in int coloredGlyph;
 
 out vec2 TexCoords;
 flat out vec3 fg;
 flat out vec4 bg;
-flat out int preColored;
+flat out int colored;
 
 // Terminal properties
 uniform vec2 cellDim;
@@ -74,5 +75,5 @@ void main()
 
     bg = vec4(backgroundColor.rgb / 255.0, backgroundColor.a);
     fg = textColor / vec3(255.0, 255.0, 255.0);
-    preColored = preColoredGlyph;
+    colored = coloredGlyph;
 }

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -15,13 +15,13 @@
 // Cell properties.
 layout (location = 0) in vec2 gridCoords;
 
-// glyph properties.
+// Glyph properties.
 layout (location = 1) in vec4 glyph;
 
 // uv mapping.
 layout (location = 2) in vec4 uv;
 
-// text fg color.
+// Text fg color.
 layout (location = 3) in vec3 textColor;
 
 // Background color.

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #version 330 core
-// Cell properties
+// Cell properties.
 layout (location = 0) in vec2 gridCoords;
 
-// glyph properties
+// glyph properties.
 layout (location = 1) in vec4 glyph;
 
-// uv mapping
+// uv mapping.
 layout (location = 2) in vec4 uv;
 
-// text fg color
+// text fg color.
 layout (location = 3) in vec3 textColor;
 
-// Background color
+// Background color.
 layout (location = 4) in vec4 backgroundColor;
 
-// Set to 1 if the glyph colors should be kept
+// Set to 1 if the glyph colors should be kept.
 layout (location = 5) in int coloredGlyph;
 
 out vec2 TexCoords;


### PR DESCRIPTION
As they have an alpha channel, we can use it directly for blending
instead of applying the normal text fragment shader that blends it with
the text color and ends up mixing with background as well (particularly
bad on bright background).

Instead of branching on data in the shader, it and storing an alpha
channel for the complete Atlas, it might be wiser to have a separate
Atlas and rendering phase for these glyphs.

Fixes #1864.
