### PR TITLE
Treat Shift+Backspace as Backspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Low resolution window decoration icon on Windows
 - Mouse bindings for additional buttons need to be specified as a number not a string
 - Don't hide cursor on modifier press with `mouse.hide_when_typing` enabled
+- `Shift + Backspace` now sends `^?` instead of `^H`
 
 ### Fixed
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -306,6 +306,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         L,    ModifiersState::CTRL,  ~TermMode::VI; Action::Esc("\x0c".into());
         Tab,  ModifiersState::SHIFT, ~TermMode::VI; Action::Esc("\x1b[Z".into());
         Back, ModifiersState::ALT,   ~TermMode::VI; Action::Esc("\x1b\x7f".into());
+        Back, ModifiersState::SHIFT, ~TermMode::VI; Action::Esc("\x7f".into());
         Home,     ModifiersState::SHIFT, ~TermMode::ALT_SCREEN; Action::ScrollToTop;
         End,      ModifiersState::SHIFT, ~TermMode::ALT_SCREEN; Action::ScrollToBottom;
         PageUp,   ModifiersState::SHIFT, ~TermMode::ALT_SCREEN; Action::ScrollPageUp;


### PR DESCRIPTION
This is a fix for #3652.
I decided not to modify the config file since this is a sane default in my opinion.