### PR TITLE
Fix vi ScrollToBottom motion

### DIFF
--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -260,6 +260,9 @@ impl<T: EventListener> Execute<T> for Action {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
                 term.vi_mode_cursor.point.line = term.grid().num_lines() - 1;
+
+                // Move to beginning twice, to always jump across linewraps.
+                term.vi_motion(ViMotion::FirstOccupied);
                 term.vi_motion(ViMotion::FirstOccupied);
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),


### PR DESCRIPTION
This resolves an issue with the ScrollToBottom motion in vi mode where
it would jump between the first unoccupied across wrapped lines and the
first unoccupied in the current line.
