### PR TITLE
Fix crash when writing wide char in last column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix escapes prematurely terminated by terminators in unicode glyphs
 - Incorrect location when clicking inside an unfocused window on macOS
 - Startup mode `Maximized` on Windows
+- Crash when trying to write a fullwidth character in the last column
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix escapes prematurely terminated by terminators in unicode glyphs
 - Incorrect location when clicking inside an unfocused window on macOS
 - Startup mode `Maximized` on Windows
-- Crash when trying to write a fullwidth character in the last column
+- Crash when writing a fullwidth character in the last column with auto-wrap mode disabled
 
 ## 0.4.2
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1462,10 +1462,16 @@ impl<T: EventListener> Handler for Term<T> {
         if width == 1 {
             self.write_at_cursor(c);
         } else {
-            // Insert extra placeholder before wide char if glyph doesn't fit in this row anymore.
             if self.cursor.point.col + 1 >= num_cols {
-                self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
-                self.wrapline();
+                if self.mode.contains(TermMode::LINE_WRAP) {
+                    // Insert placeholder before wide char if glyph does not fit in this row.
+                    self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
+                    self.wrapline();
+                } else {
+                    // Prevent out of bounds crash when linewrapping is disabled.
+                    self.input_needs_wrap = true;
+                    return;
+                }
             }
 
             // Write full width glyph to current cursor cell.


### PR DESCRIPTION
This resolves an issue where trying to write a fullwidth character in
the last column would crash Alacritty, if linewrapping was disabled.

Instead of assuming that the linewrap put after the linewrapping spacer
was successful, the character writing is now skipped completely when
trying to put a wide character in the last column.
