### PR TITLE
Perform glClear() on-screen on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix escapes prematurely terminated by terminators in unicode glyphs
 - Incorrect location when clicking inside an unfocused window on macOS
 - Startup mode `Maximized` on Windows
+- Coloring at incorrect sizes when calling glClear() on X11
 
 ## 0.4.2
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -219,25 +219,27 @@ impl Display {
         // Update OpenGL projection.
         renderer.resize(&size_info);
 
-        // Clear screen.
-        let background_color = config.colors.primary.background;
-        renderer.with_api(&config, &size_info, |api| {
-            api.clear(background_color);
-        });
-
         #[cfg(not(any(target_os = "macos", windows)))]
         let is_x11 = event_loop.is_x11();
 
         #[cfg(not(any(target_os = "macos", windows)))]
         {
-            // On Wayland we can safely ignore this call, since the window isn't visible until you
-            // actually draw something into it and commit those changes.
-            if is_x11 {
-                window.swap_buffers();
+            // Clear screen on Wayland.
+            if !is_x11 {
+                let background_color = config.colors.primary.background;
                 renderer.with_api(&config, &size_info, |api| {
-                    api.finish();
+                    api.clear(background_color);
                 });
             }
+        }
+
+        #[cfg(any(target_os = "macos", windows))]
+        {
+            // Clear screen on Windows and MacOS.
+            let background_color = config.colors.primary.background;
+            renderer.with_api(&config, &size_info, |api| {
+                api.clear(background_color);
+            });
         }
 
         window.set_visible(true);

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -203,14 +203,14 @@ impl Window {
                 if let Some(parent_window_id) = config.window.embed {
                     x_embed_window(windowed_context.window(), parent_window_id);
                 }
-                // Perform glClear() on-screen to avoid drawing color over on the window
-                // at incorrect sizes.
+                // Perform glClear() on-screen to avoid drawing color over the window
+                // at an incorrect size.
+                // We make GL calls here directly, instead of going through QuadRenderer,
+                // to avoid having to initialize SizeInfo.
                 windowed_context.window().set_visible(true);
                 gl_clear(config.colors.primary.background, config.background_opacity());
-                // We make these GL calls here directly, instead of going through QuadRenderer,
-                // to avoid having to initialize SizeInfo. Also, swap buffers to avoid glitches.
+                // Swap buffers to commit glClear() color into the screen.
                 windowed_context.swap_buffers().expect("swap buffers");
-                gl_finish();
             } else {
                 // Apply client side decorations theme.
                 let theme = AlacrittyWaylandTheme::new(&config.colors);
@@ -493,14 +493,6 @@ unsafe extern "C" fn xembed_error_handler(_: *mut XDisplay, _: *mut XErrorEvent)
 
 #[inline]
 #[cfg(not(any(target_os = "macos", windows)))]
-fn gl_finish() {
-    unsafe {
-        gl::Finish();
-    }
-}
-
-#[inline]
-#[cfg(not(any(target_os = "macos", windows)))]
 fn gl_clear(color: Rgb, alpha: f32) {
     unsafe {
         gl::ClearColor(
@@ -510,5 +502,7 @@ fn gl_clear(color: Rgb, alpha: f32) {
             alpha,
         );
         gl::Clear(gl::COLOR_BUFFER_BIT);
+        // Block until glClear() finishes.
+        gl::Finish();
     }
 }

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -500,6 +500,7 @@ fn gl_finish() {
 }
 
 #[inline]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn gl_clear(color: Rgb, alpha: f32) {
     unsafe {
         gl::ClearColor(

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -502,7 +502,5 @@ fn gl_clear(color: Rgb, alpha: f32) {
             alpha,
         );
         gl::Clear(gl::COLOR_BUFFER_BIT);
-        // Block until glClear() finishes.
-        gl::Finish();
     }
 }


### PR DESCRIPTION
Fixes #3061.

On X11, `glClear()` relies on dimensions from the WM to know what portions of the screen it should color on.

These dimensions may be different for when the window is shown, and when the window is hidden. But the former tends to be more reliable (this is especially the case on tiling WMs which remap windows after they are shown).

So we only call `glClear()` when the window is on-screen.

This PR makes Alacritty call `set_visible()` earlier during init on X11 (the same behavior prior to 0815774cbfb9d1421b8077d5d9d641faf5f818c1), because this seems to be the only way I can get the window to init at the correct dimensions.

Other than that, it also makes Alacritty call `glClear()` earlier on X11 (right after `set_visible()`). This is to avoid having the window from being shown with an uninitialized surface (what 0815774cbfb9d1421b8077d5d9d641faf5f818c1 fixes) during init.
