### PR TITLE
Make cursor thicknesses individually configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default Command+N keybinding for SpawnNewInstance on macOS
 - Vi mode for copying text and opening links
 - `CopySelection` action which copies into selection buffer on Linux/BSD
-- Option `cursor.thickness` to set terminal cursor thickness
+- Options `cursor.thickness.{beam, underline, hollow}` to set terminal cursor thickness
 - Font fallback on Windows
 - Support for Fontconfig embolden and matrix options
 

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -26,13 +26,13 @@ pub fn get_cursor_glyph(
     offset_x: i8,
     offset_y: i8,
     is_wide: bool,
-    cursor_thickness: f64,
+    beam_thickness: f64,
+    underline_thickness: f64,
+    hollow_thickness: f64,
 ) -> RasterizedGlyph {
     // Calculate the cell metrics.
     let height = metrics.line_height as i32 + i32::from(offset_y);
     let mut width = metrics.average_advance as i32 + i32::from(offset_x);
-
-    let line_width = cmp::max((cursor_thickness * f64::from(width)).round() as i32, 1);
 
     // Double the cursor width if it's above a double-width glyph.
     if is_wide {
@@ -40,12 +40,21 @@ pub fn get_cursor_glyph(
     }
 
     match cursor {
-        CursorStyle::HollowBlock => get_box_cursor_glyph(height, width, line_width),
-        CursorStyle::Underline => get_underline_cursor_glyph(width, line_width),
-        CursorStyle::Beam => get_beam_cursor_glyph(height, line_width),
+        CursorStyle::HollowBlock => {
+            get_box_cursor_glyph(height, width, get_line_width(hollow_thickness, width))
+        },
+        CursorStyle::Underline => {
+            get_underline_cursor_glyph(width, get_line_width(underline_thickness, width))
+        },
+        CursorStyle::Beam => get_beam_cursor_glyph(height, get_line_width(beam_thickness, width)),
         CursorStyle::Block => get_block_cursor_glyph(height, width),
         CursorStyle::Hidden => RasterizedGlyph::default(),
     }
+}
+
+#[inline]
+pub fn get_line_width(thickness: f64, width: i32) -> i32 {
+    cmp::max((thickness * f64::from(width)).round() as i32, 1)
 }
 
 /// Return a custom underline cursor character.

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -31,9 +31,9 @@ use parking_lot::MutexGuard;
 #[cfg(not(any(target_os = "macos", windows)))]
 use wayland_client::{Display as WaylandDisplay, EventQueue};
 
-use font::{self, Rasterize};
 #[cfg(target_os = "macos")]
 use font::set_font_smoothing;
+use font::{self, Rasterize};
 
 use alacritty_terminal::config::{Font, StartupMode};
 use alacritty_terminal::event::{Event, OnResize};

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -22,9 +22,9 @@ use glutin::platform::unix::EventLoopWindowTargetExtUnix;
 use log::{debug, info, warn};
 use serde_json as json;
 
-use font::{self, Size};
 #[cfg(target_os = "macos")]
 use font::set_font_smoothing;
+use font::{self, Size};
 
 use alacritty_terminal::clipboard::ClipboardType;
 use alacritty_terminal::config::Font;
@@ -705,8 +705,14 @@ impl<N: Notify + OnResize> Processor<N> {
         processor.ctx.terminal.update_config(&config);
 
         // Reload cursor if we've changed its thickness.
-        if (processor.ctx.config.cursor.thickness() - config.cursor.thickness()).abs()
-            > std::f64::EPSILON
+        if ((processor.ctx.config.cursor.thickness.beam()
+            + processor.ctx.config.cursor.thickness.underline()
+            + processor.ctx.config.cursor.thickness.hollow())
+            - (config.cursor.thickness.beam()
+                + config.cursor.thickness.underline()
+                + config.cursor.thickness.hollow()))
+        .abs()
+            > f64::EPSILON
         {
             processor.ctx.display_update_pending.cursor = true;
         }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1038,7 +1038,9 @@ impl<'a, C> RenderApi<'a, C> {
                         self.config.font.offset.x,
                         self.config.font.offset.y,
                         cursor_key.is_wide,
-                        self.config.cursor.thickness(),
+                        self.config.cursor.thickness.beam(),
+                        self.config.cursor.thickness.underline(),
+                        self.config.cursor.thickness.hollow(),
                     ))
                 });
                 self.add_render_item(cell, glyph);

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -249,21 +249,43 @@ pub struct Cursor {
     pub style: CursorStyle,
     #[serde(deserialize_with = "option_explicit_none")]
     pub vi_mode_style: Option<CursorStyle>,
-    #[serde(deserialize_with = "deserialize_cursor_thickness")]
-    thickness: Percentage,
+    #[serde(deserialize_with = "failure_default")]
+    pub thickness: Thickness,
     #[serde(deserialize_with = "failure_default")]
     unfocused_hollow: DefaultTrueBool,
+}
+
+#[derive(Deserialize, Copy, Clone, Debug, PartialEq)]
+pub struct Thickness {
+    #[serde(deserialize_with = "deserialize_cursor_thickness")]
+    beam: Percentage,
+    #[serde(deserialize_with = "deserialize_cursor_thickness")]
+    underline: Percentage,
+    #[serde(deserialize_with = "deserialize_cursor_thickness")]
+    hollow: Percentage,
+}
+
+impl Thickness {
+    #[inline]
+    pub fn beam(self) -> f64 {
+        self.beam.0 as f64
+    }
+
+    #[inline]
+    pub fn underline(self) -> f64 {
+        self.underline.0 as f64
+    }
+
+    #[inline]
+    pub fn hollow(self) -> f64 {
+        self.hollow.0 as f64
+    }
 }
 
 impl Cursor {
     #[inline]
     pub fn unfocused_hollow(self) -> bool {
         self.unfocused_hollow.0
-    }
-
-    #[inline]
-    pub fn thickness(self) -> f64 {
-        self.thickness.0 as f64
     }
 }
 
@@ -272,8 +294,18 @@ impl Default for Cursor {
         Self {
             style: Default::default(),
             vi_mode_style: Default::default(),
-            thickness: Percentage::new(DEFAULT_CURSOR_THICKNESS),
+            thickness: Default::default(),
             unfocused_hollow: Default::default(),
+        }
+    }
+}
+
+impl Default for Thickness {
+    fn default() -> Self {
+        Self {
+            beam: Percentage::new(DEFAULT_CURSOR_THICKNESS),
+            underline: Percentage::new(DEFAULT_CURSOR_THICKNESS),
+            hollow: Percentage::new(DEFAULT_CURSOR_THICKNESS),
         }
     }
 }

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -281,7 +281,6 @@ pub struct Font {
 
 unsafe impl Send for Font {}
 
-
 /// Set subpixel anti-aliasing on macOS.
 ///
 /// Sub-pixel anti-aliasing has been disabled since macOS Mojave by default. This function allows
@@ -294,7 +293,7 @@ pub fn set_font_smoothing(enable: bool) {
     unsafe {
         // Check that we're running at least Mojave (10.14.0+).
         if !NSProcessInfo::processInfo(nil).isOperatingSystemAtLeastVersion(min_macos_version) {
-            return
+            return;
         }
 
         let key = NSString::alloc(nil).init_str("CGFontRenderingFontSmoothingDisabled");


### PR DESCRIPTION
This makes each of the cursor types' thicknesses individually configurable; a thicker beam is nice for cursor visibility in vim, but the same isn't true for the underline (a thicker underline looks a bit strange in other programs). Three configuration variables are exposed: `cursor.thickness.{beam,underline,hollow}`. This PR includes miscellaneous formatting changes made by `cargo fmt`, apparently needed for CI to pass (I can revert the ones not affecting files relevant to these changes, if that's needed).