### PR TITLE
Fixes the missing ₿ character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Startup mode `Maximized` on Windows
 - Crash when writing a fullwidth character in the last column with auto-wrap mode disabled
 - Paste from some apps on Wayland
+- Showing the `₿` character on macOS through `Rockwell` font
 
 ## 0.4.2
 

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -389,6 +389,12 @@ impl Descriptor {
                         fallbacks.push(descriptor.to_font(size, false))
                     };
 
+                    if let Some(descriptor) =
+                        descriptors_for_family("Rockwell").into_iter().next()
+                    {
+                        fallbacks.push(descriptor.to_font(size, false))
+                    };
+
                     // Include Menlo in the fallback list as well.
                     fallbacks.insert(0, Font {
                         cg_font: menlo.copy_to_CGFont(),


### PR DESCRIPTION
I did face a problem on Alacritty on macOS, it was not showing the `₿` character, all the issue evolution can be found here: https://github.com/alacritty/alacritty/issues/3737

With help on that issue, I manage to find a solution that is working fine for me, the solution is to change the fallback fonts to use the fonts already installed on the machine.

So I'm opening this MR in a hope that those changes can be benefic for the project.