### PR TITLE
Perform glClear() on-screen on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Startup mode `Maximized` on Windows
 - Crash when writing a fullwidth character in the last column with auto-wrap mode disabled
 - Paste from some apps on Wayland
+- Incorrect window dimensions when clearing on X11
 
 ## 0.4.2
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -221,28 +221,32 @@ impl Display {
         // Update OpenGL projection.
         renderer.resize(&size_info);
 
-        // Clear screen.
-        let background_color = config.colors.primary.background;
-        renderer.with_api(&config, &size_info, |api| {
-            api.clear(background_color);
-        });
-
         // Set subpixel anti-aliasing.
         #[cfg(target_os = "macos")]
         set_font_smoothing(config.font.use_thin_strokes());
 
+        // Clear off-screen on Windows and MacOS.
+        //
+        // These systems do not suffer from issue #3061,
+        // so we can safely clear here as normal.
+        // NOTE: We put this line behind a conditional
+        // to avoid clearing twice on other systems.
+        #[cfg(any(target_os = "macos", windows))]
+        Self::clear_screen(config, &mut renderer, &size_info);
+
         #[cfg(not(any(target_os = "macos", windows)))]
         let is_x11 = event_loop.is_x11();
 
+        // Clear off-screen on Unix (non-X11).
+        //
+        // Wayland does not suffer from issue #3061,
+        // so we can safely clear here as normal.
+        // NOTE: We put this line behind a conditional and
+        // an `if` to avoid clearing twice on other systems.
         #[cfg(not(any(target_os = "macos", windows)))]
         {
-            // On Wayland we can safely ignore this call, since the window isn't visible until you
-            // actually draw something into it and commit those changes.
-            if is_x11 {
-                window.swap_buffers();
-                renderer.with_api(&config, &size_info, |api| {
-                    api.finish();
-                });
+            if !is_x11 {
+                Self::clear_screen(config, &mut renderer, &size_info);
             }
         }
 
@@ -279,6 +283,29 @@ impl Display {
             #[cfg(not(any(target_os = "macos", windows)))]
             wayland_event_queue,
         })
+    }
+
+    // Clear function we use during `Display` creation.
+    fn clear_screen(config: &Config, renderer: &mut QuadRenderer, size_info: &SizeInfo) {
+        // We factor out screen clearing to avoid duplication.
+        let background_color = config.colors.primary.background;
+        renderer.with_api(&config, &size_info, |api| {
+            api.clear(background_color);
+        });
+    }
+
+    // Clear function we use after `Display` creation (for X11).
+    #[cfg(not(any(target_os = "macos", windows)))]
+    pub fn clear_x11(&mut self, config: &Config) {
+        // Clear the screen as normal.
+        Self::clear_screen(config, &mut self.renderer, &self.size_info);
+        // Swap buffers.
+        //
+        // On Wayland we can safely ignore this call, since the window isn't visible until you
+        // actually draw something into it and commit those changes.
+        self.window.swap_buffers();
+        // NOTE: From what I understand, the window here is already shown,
+        // so there's no need to block here anymore with `api.finish()`.
     }
 
     fn new_glyph_cache(

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -268,12 +268,14 @@ impl Display {
         });
 
         #[cfg(not(any(target_os = "macos", windows)))]
-        if self.is_x11 {
-            // On Wayland we can safely ignore this call, since the window isn't visible until you
-            // actually draw something into it and commit those changes.
-            self.window.swap_buffers();
-            // NOTE: From what I understand, the window here is already shown,
-            // so there's no need to block anymore with `api.finish()`.
+        {
+            if self.is_x11 {
+                // On Wayland we can safely ignore this call, since the window isn't visible until you
+                // actually draw something into it and commit those changes.
+                self.window.swap_buffers();
+                // NOTE: From what I understand, the window here is already shown,
+                // so there's no need to block anymore with `api.finish()`.
+            }
         }
     }
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -419,6 +419,20 @@ impl<N: Notify + OnResize> Processor<N> {
     where
         T: EventListener,
     {
+
+        // Clear on-screen on Unix (X11).
+        //
+        // We only perform clearing here to avoid
+        // clearing at incorrect window dimensions.
+        // NOTE: We put this line behind a conditional and
+        // an `if` to avoid clearing twice on other systems.
+        #[cfg(not(any(target_os = "macos", windows)))]
+        {
+            if event_loop.is_x11() {
+                self.display.clear_x11(&self.config);
+            }
+        }
+
         event_loop.run_return(|event, event_loop, control_flow| {
             if self.config.debug.print_events {
                 info!("glutin event: {:?}", event);


### PR DESCRIPTION
This is my attempt #⁠2 at getting a fix for #3061 merged into upstream. 😅

The way we fix it is still the same. So I've chosen to reuse the title. But there's a few differences on how we do things now.

I don't think it's worth your time me explaining what I changed since then. The only things that should stand out now is that:

1) We now call `api.clear()` much later in the process (only in X11).

The reason for doing this is still as the title implies. Though, the decision to do it this way was based on a suggestion by @kchibisov in the previous thread. It was suggested that calling things nearer to `run_return` might help make the previous fix work better. And in fact, it actually does, with some tweaking. So I'm submitting it here now for further review.

2) We now do `api.clear()` behind ifs and conditionals.

The reason for doing this is to retain our previous behavior in other systems (MacOS, Windows, Unix with Wayland) where this bug doesn't exist. I'm not sure if there are better ways to do this yet. If so, please tell me.

[This was something I actually also did in my previous PR, but I failed to explain why. Hope that clears it up now why there are new ifs and conditionals everywhere]

I've done my best to comment on every change I made, but there's probably a few things I still left here and there. If so, kindly please tell me how I could improve on that. Thank you for your time.

\[[master](https://i.imgur.com/dspmolA.mp4)\]
\[[patched](https://i.imgur.com/lBQZkh8.mp4)\]