### PR TITLE
Remove env_logger depedency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimum Rust version has been bumped to 1.41.0
 - Prebuilt Linux binaries have been removed
 
+### Removed
+
+- Environment variable `RUST_LOG` for selecting the log level
+
 ### Added
 
 - Default Command+N keybinding for SpawnNewInstance on macOS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "embed-resource 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "font 0.1.0",
  "gl_generator 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -13,7 +13,6 @@ alacritty_terminal = { path = "../alacritty_terminal", default-features = false 
 clap = "2"
 log = "0.4"
 time = "0.1.40"
-env_logger = "0.7.1"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -42,17 +42,11 @@ pub fn initialize(
 ) -> Result<Option<PathBuf>, log::SetLoggerError> {
     log::set_max_level(options.log_level);
 
-    // Use env_logger if RUST_LOG environment variable is defined. Otherwise,
-    // use the alacritty-only logger.
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::try_init()?;
-        Ok(None)
-    } else {
-        let logger = Logger::new(event_proxy);
-        let path = logger.file_path();
-        log::set_boxed_logger(Box::new(logger))?;
-        Ok(path)
-    }
+    let logger = Logger::new(event_proxy);
+    let path = logger.file_path();
+    log::set_boxed_logger(Box::new(logger))?;
+
+    Ok(path)
 }
 
 pub struct Logger {


### PR DESCRIPTION
The env logger has been broken for over a year and is not used by anyone
as far as I know. This removes this option entirely in favor of
Alacritty's built-in logger level selection flags.