### PR TITLE
Remove winpty reference from INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -220,7 +220,6 @@ cargo build --release
 ```
 
 If all goes well, this should place a binary at `target/release/alacritty`.
-On Windows this directory should also contain the `winpty-agent.exe`.
 
 #### Desktop Entry
 


### PR DESCRIPTION
Windows instructions in `INSTALL.md` still refers to WinPTY which is no longer automatically built. This patch removes the reference.
