### PR TITLE
Fix dropping of multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Shift + Backspace` now sends `^?` instead of `^H`
 - Default color scheme is now `Tomorrow Night` with the bright colors of `Tomorrow Night Bright`
 - Set IUTF8 termios flag for improved UTF8 input support
+- Dragging multiple files into terminal now adds a space after each file
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Shift + Backspace` now sends `^?` instead of `^H`
 - Default color scheme is now `Tomorrow Night` with the bright colors of `Tomorrow Night Bright`
 - Set IUTF8 termios flag for improved UTF8 input support
-- Dragging multiple files into terminal now adds a space after each file
+- Dragging files into terminal now adds a space after each path
 
 ### Fixed
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -630,7 +630,7 @@ impl<N: Notify + OnResize> Processor<N> {
                     },
                     WindowEvent::DroppedFile(path) => {
                         let path: String = path.to_string_lossy().into();
-                        processor.ctx.write_to_pty((path +  " ").into_bytes());
+                        processor.ctx.write_to_pty((path + " ").into_bytes());
                     },
                     WindowEvent::CursorLeft { .. } => {
                         processor.ctx.mouse.inside_grid = false;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -629,9 +629,8 @@ impl<N: Notify + OnResize> Processor<N> {
                         }
                     },
                     WindowEvent::DroppedFile(path) => {
-                        const PATH_SEPARATOR: &str = " ";
                         let path: String = path.to_string_lossy().into();
-                        processor.ctx.write_to_pty((path + PATH_SEPARATOR).into_bytes());
+                        processor.ctx.write_to_pty((path +  " ").into_bytes());
                     },
                     WindowEvent::CursorLeft { .. } => {
                         processor.ctx.mouse.inside_grid = false;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -629,8 +629,9 @@ impl<N: Notify + OnResize> Processor<N> {
                         }
                     },
                     WindowEvent::DroppedFile(path) => {
+                        const PATH_SEPARATOR: &str = " ";
                         let path: String = path.to_string_lossy().into();
-                        processor.ctx.write_to_pty(path.into_bytes());
+                        processor.ctx.write_to_pty((path + PATH_SEPARATOR).into_bytes());
                     },
                     WindowEvent::CursorLeft { .. } => {
                         processor.ctx.mouse.inside_grid = false;


### PR DESCRIPTION
This pull request is a fix for the problem occurring in #3767 where dragging multiple files into the terminal doesn't automatically separate the file names. This just appends a space to the string being written to the pty.

Apologies if the code style isn't write this is my first contribution to a Rust project.
