### PR TITLE
Fix font regression on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Paste from some apps on Wayland
 - Slow startup with Nvidia binary drivers on some X11 systems
 - Display not scrolling when printing new lines while scrolled in history
+- Regression in font rendering on macOS
 
 ## 0.4.3
 

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -486,7 +486,6 @@ impl Font {
             self.glyph_index(character).ok_or_else(|| Error::MissingGlyph(character))?;
 
         let bounds = self.bounding_rect_for_glyph(Default::default(), glyph_index);
-        let is_colored = self.is_colored();
 
         let rasterized_left = bounds.origin.x.floor() as i32;
         let rasterized_width =
@@ -515,6 +514,8 @@ impl Font {
             &CGColorSpace::create_device_rgb(),
             kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host,
         );
+
+        let is_colored = self.is_colored();
 
         // Set background color for graphics context.
         let bg_a = if is_colored { 0.0 } else { 1.0 };

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -486,6 +486,7 @@ impl Font {
             self.glyph_index(character).ok_or_else(|| Error::MissingGlyph(character))?;
 
         let bounds = self.bounding_rect_for_glyph(Default::default(), glyph_index);
+        let is_colored = self.is_colored();
 
         let rasterized_left = bounds.origin.x.floor() as i32;
         let rasterized_width =
@@ -516,7 +517,9 @@ impl Font {
         );
 
         // Set background color for graphics context.
-        cg_context.set_rgb_fill_color(0.0, 0.0, 0.0, 0.0);
+        let bg_a = if is_colored { 0.0 } else { 1.0 };
+        cg_context.set_rgb_fill_color(0.0, 0.0, 0.0, bg_a);
+
         let context_rect = CGRect::new(
             &CGPoint::new(0.0, 0.0),
             &CGSize::new(f64::from(rasterized_width), f64::from(rasterized_height)),
@@ -550,7 +553,7 @@ impl Font {
 
         let rasterized_pixels = cg_context.data().to_vec();
 
-        let buf = if self.is_colored() {
+        let buf = if is_colored {
             BitmapBuffer::RGBA(byte_order::extract_rgba(&rasterized_pixels))
         } else {
             BitmapBuffer::RGB(byte_order::extract_rgb(&rasterized_pixels))


### PR DESCRIPTION
The `0.0` alpha background works great for emoji, but normal text does not render well on macOS. Instead, use `1.0` for non-pre-colored glyphs.

Fixes #3809
