### PR TITLE
Improve documentation for macos install with brew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve documentation for macos install with brew
 - Block cursor is no longer inverted at the start/end of a selection
 - Preserve selection on non-LMB or mouse mode clicks
 - Wayland client side decorations are now based on config colorscheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve documentation for macos install with brew
 - Block cursor is no longer inverted at the start/end of a selection
 - Preserve selection on non-LMB or mouse mode clicks
 - Wayland client side decorations are now based on config colorscheme

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ brew cask install alacritty
 Once the cask is installed, it is recommended to setup the
 [manual page](INSTALL.md#manual-page),
 [shell completions](INSTALL.md#shell-completions), and
-[terminfo definitions](INSTALL.md#terminfo). The auxiliary files necessary for
-your version can be found on the
-[GitHub releases page](https://github.com/alacritty/alacritty/releases).
+[terminfo definitions](INSTALL.md#terminfo). These instructions need to be
+followed from within the Alacritty source for your version, which can be found
+on the [GitHub releases page](https://github.com/alacritty/alacritty/releases).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ pkg install alacritty
 brew cask install alacritty
 ```
 
-After installation with brew, it is highly recommended that you clone
-alacritty source code with `git clone
-https://github.com/alacritty/alacritty.git` and setup the [manual
-page](INSTALL.md#manual-page), [shell
-completions](INSTALL.md#shell-completions), and [terminfo
-definitions](INSTALL.md#terminfo).
+Once the cask is installed, it is recommended to setup the
+[manual page](INSTALL.md#manual-page),
+[shell completions](INSTALL.md#shell-completions), and
+[terminfo definitions](INSTALL.md#terminfo). The auxiliary files necessary for
+your version can be found on the
+[GitHub releases page](https://github.com/alacritty/alacritty/releases).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ pkg install alacritty
 brew cask install alacritty
 ```
 
-After installation with brew, it is highly reocommended that you clone
+After installation with brew, it is highly recommended that you clone
 alacritty source code with `git clone
 https://github.com/alacritty/alacritty.git` and setup the [manual
 page](INSTALL.md#manual-page), [shell

--- a/README.md
+++ b/README.md
@@ -131,8 +131,12 @@ pkg install alacritty
 brew cask install alacritty
 ```
 
-Once the cask is installed, it is recommended to setup the [manual page](INSTALL.md#manual-page),
-[shell completions](INSTALL.md#shell-completions), and [terminfo definitions](INSTALL.md#terminfo).
+After installation with brew, it is highly reocommended that you clone
+alacritty source code with `git clone
+https://github.com/alacritty/alacritty.git` and setup the [manual
+page](INSTALL.md#manual-page), [shell
+completions](INSTALL.md#shell-completions), and [terminfo
+definitions](INSTALL.md#terminfo).
 
 ### Windows
 


### PR DESCRIPTION
There is possible confusion with users who don't read entire INSTALL.md file linked to when installing with macos install with brew. This adds an instruction to clone the alacritty repo before trying to install the manual.