### PR TITLE
Override default bindings when notmodes intersect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default color scheme is now `Tomorrow Night` with the bright colors of `Tomorrow Night Bright`
 - Set IUTF8 termios flag for improved UTF8 input support
 - Dragging files into terminal now adds a space after each path
+- Default binding replacement conditions
 
 ### Fixed
 


### PR DESCRIPTION
Make notmodes follow modes in terms of override behavior, so
default binding won't be pruned if and only if its modes intersect
with new binding notmodes and vise-versa.

Fixes #3476
