### PR TITLE
Use compile_error! instead of panic! in build.rs

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(any(feature = "x11", feature = "wayland", target_os = "macos", windows)))]
+compile_error!(r#"at least one of the "x11"/"wayland" features must be enabled"#);
+
 use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
 
 use std::env;
@@ -22,10 +25,6 @@ use std::path::Path;
 use embed_resource;
 
 fn main() {
-    if cfg!(not(any(feature = "x11", feature = "wayland", target_os = "macos", windows))) {
-        panic!("at least one of the \"x11\"/\"wayland\" features must be enabled");
-    }
-
     let hash = rustc_tools_util::get_commit_hash().unwrap_or_default();
     println!("cargo:rustc-env=GIT_HASH={}", hash);
 


### PR DESCRIPTION
The compile_error! failure is way more readable and noticeable than
panic!.
