### PR TITLE
Clear selection on clear line/screen escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set IUTF8 termios flag for improved UTF8 input support
 - Dragging files into terminal now adds a space after each path
 - Default binding replacement conditions
+- Adjusted selection clearing granularity to more accurately match content
 
 ### Fixed
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -188,7 +188,7 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
     }
 
     /// Return the cursor position in buffer coordinates.
-    pub fn buffer_cursor_point(&self) -> Point<usize> {
+    pub fn cursor_buffer_point(&self) -> Point<usize> {
         Point { line: self.lines.0 - self.cursor.point.line.0 - 1, col: self.cursor.point.col }
     }
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -187,6 +187,11 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
         Point { line: self.lines.0 + self.display_offset - point.line.0 - 1, col: point.col }
     }
 
+    /// Return the cursor position in buffer coordinates.
+    pub fn buffer_cursor_point(&self) -> Point<usize> {
+        Point { line: self.lines.0 - self.cursor.point.line.0 - 1, col: self.cursor.point.col }
+    }
+
     /// Update the size of the scrollback history.
     pub fn update_history(&mut self, history_size: usize) {
         let current_history_size = self.history_size();

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -195,12 +195,12 @@ impl Selection {
 
     /// Check whether selection contains any point in a given range.
     pub fn intersects_range(&self, range: RangeInclusive<usize>) -> bool {
-        let (mut start, mut end) = (self.region.start, self.region.end);
-        if Self::points_need_swap(start.point, end.point) {
+        let mut start = self.region.start.point.line;
+        let mut end = self.region.end.point.line;
+
+        if Self::points_need_swap(self.region.start.point, self.region.end.point) {
             mem::swap(&mut start, &mut end);
         }
-
-        let (start, end) = (start.point.line, end.point.line);
 
         let (range_start, range_end) = range.into_inner();
 
@@ -233,7 +233,9 @@ impl Selection {
         let num_cols = grid.num_cols();
 
         // Order start above the end.
-        let (mut start, mut end) = (self.region.start, self.region.end);
+        let mut start = self.region.start;
+        let mut end = self.region.end;
+
         if Self::points_need_swap(start.point, end.point) {
             mem::swap(&mut start, &mut end);
         }

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -204,7 +204,7 @@ impl Selection {
 
         let (range_start, range_end) = range.into_inner();
 
-        range.start <= selection.start && range.end >= selection.end
+        range_start <= start && range_end >= end
     }
 
     /// Expand selection sides to include all cells.
@@ -658,5 +658,19 @@ mod tests {
             end: Point::new(6, Column(3)),
             is_block: true,
         });
+    }
+
+    #[test]
+    fn range_intersection() {
+        let mut selection =
+            Selection::new(SelectionType::Lines, Point::new(6, Column(1)), Side::Left);
+        selection.update(Point::new(3, Column(1)), Side::Right);
+
+        assert!(selection.intersects_range(4..=5));
+        assert!(selection.intersects_range(5..=7));
+        assert!(selection.intersects_range(2..=4));
+        assert!(selection.intersects_range(2..=7));
+        assert!(!selection.intersects_range(7..=8));
+        assert!(!selection.intersects_range(1..=2));
     }
 }

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -7,7 +7,7 @@
 
 use std::convert::TryFrom;
 use std::mem;
-use std::ops::Range;
+use std::ops::{Range, RangeInclusive};
 
 use crate::index::{Column, Line, Point, Side};
 use crate::term::{Search, Term};
@@ -191,6 +191,22 @@ impl Selection {
             },
             SelectionType::Semantic | SelectionType::Lines => false,
         }
+    }
+
+    /// Check whether selection contains any point in a given range.
+    pub fn intersects_range(&self, range: RangeInclusive<usize>) -> bool {
+        let (mut start, mut end) = (self.region.start, self.region.end);
+        if Self::points_need_swap(start.point, end.point) {
+            mem::swap(&mut start, &mut end);
+        }
+
+        let (start, end) = (start.point.line, end.point.line);
+
+        let (range_start, range_end) = range.into_inner();
+
+        (start >= range_end && end <= range_end)
+            || (start >= range_start && end <= range_start)
+            || (start >= range_start && start <= range_end)
     }
 
     /// Expand selection sides to include all cells.

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -204,9 +204,7 @@ impl Selection {
 
         let (range_start, range_end) = range.into_inner();
 
-        (start >= range_end && end <= range_end)
-            || (start >= range_start && end <= range_start)
-            || (start >= range_start && start <= range_end)
+        range.start <= selection.start && range.end >= selection.end
     }
 
     /// Expand selection sides to include all cells.

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1865,11 +1865,10 @@ impl<T: EventListener> Handler for Term<T> {
                     cell.reset(&template);
                 }
 
-                let last_visible_line_index = num_lines - 1;
                 self.selection = self
                     .selection
                     .take()
-                    .filter(|s| !s.intersects_range(cursor_buffer_line..=last_visible_line_index));
+                    .filter(|s| !s.intersects_range(cursor_buffer_line..num_lines));
             },
             ansi::ClearMode::Below => {
                 let cursor = self.grid.cursor.point;
@@ -1882,7 +1881,7 @@ impl<T: EventListener> Handler for Term<T> {
                 }
 
                 self.selection =
-                    self.selection.take().filter(|s| !s.intersects_range(0..=cursor_buffer_line));
+                    self.selection.take().filter(|s| !s.intersects_range(..=cursor_buffer_line));
             },
             ansi::ClearMode::All => {
                 if self.mode.contains(TermMode::ALT_SCREEN) {
@@ -1892,20 +1891,12 @@ impl<T: EventListener> Handler for Term<T> {
                     self.grid.clear_viewport(template);
                 }
 
-                let last_visible_line_index = num_lines - 1;
-                self.selection = self
-                    .selection
-                    .take()
-                    .filter(|s| !s.intersects_range(0..=last_visible_line_index));
+                self.selection = self.selection.take().filter(|s| !s.intersects_range(..num_lines));
             },
             ansi::ClearMode::Saved if self.grid.history_size() > 0 => {
                 self.grid.clear_history();
 
-                let last_scrollback_line = self.grid.len() - 1;
-                self.selection = self
-                    .selection
-                    .take()
-                    .filter(|s| !s.intersects_range(num_lines..=last_scrollback_line));
+                self.selection = self.selection.take().filter(|s| !s.intersects_range(num_lines..));
             },
             // We have no history to clear.
             ansi::ClearMode::Saved => (),

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1896,15 +1896,16 @@ impl<T: EventListener> Handler for Term<T> {
             },
             ansi::ClearMode::Saved => {
                 let last_scrollback_line = self.grid.len() - 1;
+                if last_scrollback_line == last_line {
+                    return;
+                }
 
                 self.grid.clear_history();
 
-                if last_scrollback_line > last_line {
-                    self.selection = self
-                        .selection
-                        .take()
-                        .filter(|s| !s.intersects_range(last_line + 1..=last_scrollback_line));
-                }
+                self.selection = self
+                    .selection
+                    .take()
+                    .filter(|s| !s.intersects_range(last_line + 1..=last_scrollback_line));
             },
         }
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1894,19 +1894,16 @@ impl<T: EventListener> Handler for Term<T> {
                 self.selection =
                     self.selection.take().filter(|s| !s.intersects_range(0..=last_line));
             },
-            ansi::ClearMode::Saved => {
-                let last_scrollback_line = self.grid.len() - 1;
-                if last_scrollback_line == last_line {
-                    return;
-                }
-
+            ansi::ClearMode::Saved if self.grid.len() - 1 > last_line => {
                 self.grid.clear_history();
 
                 self.selection = self
                     .selection
                     .take()
-                    .filter(|s| !s.intersects_range(last_line + 1..=last_scrollback_line));
+                    .filter(|s| !s.intersects_range(last_line + 1..=self.grid.len() - 1));
             },
+            // We have no history to clear.
+            ansi::ClearMode::Saved => (),
         }
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1894,13 +1894,14 @@ impl<T: EventListener> Handler for Term<T> {
                 self.selection =
                     self.selection.take().filter(|s| !s.intersects_range(0..=last_line));
             },
-            ansi::ClearMode::Saved if self.grid.len() - 1 > last_line => {
+            ansi::ClearMode::Saved if self.grid.history_size() > 0 => {
                 self.grid.clear_history();
 
+                let last_scrollback_line = self.grid.len() - 1;
                 self.selection = self
                     .selection
                     .take()
-                    .filter(|s| !s.intersects_range(last_line + 1..=self.grid.len() - 1));
+                    .filter(|s| !s.intersects_range(last_line + 1..=last_scrollback_line));
             },
             // We have no history to clear.
             ansi::ClearMode::Saved => (),


### PR DESCRIPTION
Selection is now cleared if clear line or clear screen escape
sequences are clearing content behind it. In addition, selection
won't be cleared on resize if the amount of columns remain the same.