### PR TITLE
Escape Windows shell command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set IUTF8 termios flag for improved UTF8 input support
 - Dragging files into terminal now adds a space after each path
 - Default binding replacement conditions
+- Escape Windows shell command line arguments
 
 ### Fixed
 

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -226,24 +226,25 @@ fn cmdline<C>(config: &Config<C>) -> String {
 /// between those delimiters are input to or output from the function.
 ///
 /// ```rust
-/// assert_eq!(quote_argument(r#"a b c"#), r#""a b c""#)
-/// assert_eq!(quote_argument(r#"a"bc"#), r#""a\"bc""#)
-/// assert_eq!(quote_argument(r#"a\"bc"#), r#""a\\\"bc""#)
-/// assert_eq!(quote_argument(r#"a\\"bc"#), r#""a\\\\\"bc""#)
-/// assert_eq!(quote_argument(r#"\abc""#), r#""\abc\""#)
-/// assert_eq!(quote_argument(r#"a\\bc""#), r#""a\\bc\""#)
-/// assert_eq!(quote_argument(r#"a\b"c"#), r#""a\b\"c""#)
-/// assert_eq!(quote_argument(r#""abc\"#), r#""\"abc\\""#)
+/// # use alacritty_terminal::tty::windows::quote_argument;
+/// assert_eq!(quote_argument(r#"a b c"#), r#""a b c""#);
+/// assert_eq!(quote_argument(r#"a"bc"#), r#""a\"bc""#);
+/// assert_eq!(quote_argument(r#"a\"bc"#), r#""a\\\"bc""#);
+/// assert_eq!(quote_argument(r#"a\\"bc"#), r#""a\\\\\"bc""#);
+/// assert_eq!(quote_argument(r#"\abc""#), r#""\abc\""#);
+/// assert_eq!(quote_argument(r#"a\\bc""#), r#""a\\bc\""#);
+/// assert_eq!(quote_argument(r#"a\b"c"#), r#""a\b\"c""#);
+/// assert_eq!(quote_argument(r#""abc\"#), r#""\"abc\\""#);
 ///
 /// // Simple enough, left unescaped.
-/// assert_eq!(quote_argument(r#"abc"#), r#"abc"#)
-/// assert_eq!(quote_argument(r#"\abc"#), r#"\abc"#)
-/// assert_eq!(quote_argument(r#"a\\bc"#), r#"a\\bc"#)
-/// assert_eq!(quote_argument(r#"abc\"#), r#"abc\"#)
+/// assert_eq!(quote_argument(r#"abc"#), r#"abc"#);
+/// assert_eq!(quote_argument(r#"\abc"#), r#"\abc"#);
+/// assert_eq!(quote_argument(r#"a\\bc"#), r#"a\\bc"#);
+/// assert_eq!(quote_argument(r#"abc\"#), r#"abc\"#);
 /// ```
 fn quote_argument(arg: &str) -> String {
     // If this argument is simple enough, get out of Dodge.
-    if arg.is_empty() && !arg.contains('"') && !args.chars().any(char::is_whitespace) {
+    if arg.is_empty() && !arg.contains('"') && !arg.chars().any(char::is_whitespace) {
         return arg.to_owned();
     }
 
@@ -262,8 +263,8 @@ fn quote_argument(arg: &str) -> String {
         } else if c == '"' {
             // If we have a backslash run, it was actually preceding a quote, so action is
             // required. We need to double the run, plus add an extra backslash to actually escape
-            // the quote.
-            for _ in 0..(backslash_count + 1) {
+            // the quote (hence the inclusive bound).
+            for _ in 0..=backslash_count {
                 output.push('\\');
             }
             // And now we're not in a run anymore.

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -193,28 +193,36 @@ fn cmdline<C>(config: &Config<C>) -> String {
         .join(" ")
 }
 
-// Quote an argument for a Windows command line. The full rules are described in the link below,
-// but the basic idea is that we need to add quotes around the argument, and escape any quotes
-// inside the argument.
-//
-// https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=vs-2019
-//
-// The escaping rules are a bit insane. Each quote must be escaped with a leading backslash.
-// Backslashes must *only* be escaped if they are in a run of backslashes preceding a quote. In
-// that case, each backslash in the run must be escaped with its own backslash. All other
-// backslashes must *not* be escaped and will be interpreted literally.
-//
-// Examples:
-//
-//   * abc -> "abc"
-//   * a b c -> "a b c"
-//   * a"bc -> "a\"bc"
-//   * a\"bc -> "a\\\"bc"
-//   * a\\"bc -> "a\\\\\"bc"
-//   * \abc -> "\abc"
-//   * a\\bc -> "a\\bc"
-//   * a\b"c -> "a\b\"c"
-//   * abc\ -> "abc\\"
+/// Quote an argument for a Windows command line.
+///
+/// The full rules are described [in this article][parsing-args] in terms of parsing rather than
+/// quoting, but the basic idea is that we need to add quotes around the argument and escape any
+/// quotes inside the argument.
+///
+/// [parsing-args]:
+/// https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments
+///
+/// The escaping rules are a bit insane. Each quote must be escaped with a leading backslash.
+/// Backslashes must *only* be escaped if they are in a run of backslashes preceding a quote. In
+/// that case, each backslash in the run must be escaped with its own backslash. All other
+/// backslashes must *not* be escaped and will be interpreted literally.
+///
+/// # Examples
+///
+/// Note in the following examples that `r#"..."#` defines a raw string, so only the characters
+/// between those delimiters are input to or output from the function.
+///
+/// ```rust
+/// assert_eq!(quote_argument(r#"abc"#), r#""abc""#)
+/// assert_eq!(quote_argument(r#"a b c"#), r#""a b c""#)
+/// assert_eq!(quote_argument(r#"a"bc"#), r#""a\"bc""#)
+/// assert_eq!(quote_argument(r#"a\"bc"#), r#""a\\\"bc""#)
+/// assert_eq!(quote_argument(r#"a\\"bc"#), r#""a\\\\\"bc""#)
+/// assert_eq!(quote_argument(r#"\abc"#), r#""\abc""#)
+/// assert_eq!(quote_argument(r#"a\\bc"#), r#""a\\bc""#)
+/// assert_eq!(quote_argument(r#"a\b"c"#), r#""a\b\"c""#)
+/// assert_eq!(quote_argument(r#"abc\"#), r#""abc\\""#)
+/// ```
 fn quote_argument(arg: &str) -> String {
     // Allocate the output string, which will require *at least* as much space as the input.
     let mut output = String::with_capacity(arg.len());

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -225,7 +225,7 @@ fn quote_argument(arg: &str) -> String {
     // Push the opening quote.
     output.push('"');
 
-    for (i, c) in arg.chars().enumerate() {
+    for c in arg.chars() {
         if c == '\\' {
             backslash_count += 1;
         } else if c == '"' {

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -188,6 +188,8 @@ fn cmdline<C>(config: &Config<C>) -> String {
 
     once(shell.program().as_ref())
         .chain(shell.args().iter().map(|a| a.as_ref()))
+        .map(|arg| arg.replace("\"", "\\\""))
+        .map(|arg| format!("\"{}\"", arg))
         .collect::<Vec<_>>()
         .join(" ")
 }


### PR DESCRIPTION
Change the Windows command line argument handling to escape arguments according to [the rules in this article][parsing-args]. (Note the article is written in terms of parsing, but we're interested in escaping.)

[parsing-args]: https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments

The escaping rules are a bit insane. Each quote must be escaped with a leading backslash. Backslashes must *only* be escaped if they are in a run of backslashes preceding a quote. In that case, each backslash in the run must be escaped with its own backslash. All other backslashes must *not* be escaped and will be interpreted literally.

## Concerns

As mentioned [in this comment][concerns], it's not clear that escaping like this is *always* the correct thing to do. It depends on the shell program, and is not something we can know. I've marked this pull request WIP until we settle that.

I have added a check so that arguments are only escaped when they are required to be. This should make it safer to pass arguments to programs using &ldquo;odd&rdquo; parsing rules (e.g., `cmd.exe`), as long as those arguments are simple.

[concerns]: https://github.com/alacritty/alacritty/issues/3552#issuecomment-610710931

Fixes #3552