### PR TITLE
Implement dynamic copying suggested in #1919

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -99,6 +99,9 @@ pub enum Action {
     /// Paste contents of system clipboard.
     Paste,
 
+    /// Copy selection and clear it, or forward the keybinding to the program if there is no selection.
+    CopyDynamic,
+
     /// Store current selection into clipboard.
     Copy,
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -139,6 +139,15 @@ impl<T: EventListener> Execute<T> for Action {
             Action::Copy => ctx.copy_selection(ClipboardType::Clipboard),
             #[cfg(not(any(target_os = "macos", windows)))]
             Action::CopySelection => ctx.copy_selection(ClipboardType::Selection),
+            Action::CopyDynamic => {
+                if ctx.selection_is_empty() {
+                    *ctx.suppress_chars() = false;
+                } else {
+                    ctx.copy_selection(ClipboardType::Clipboard);
+                    ctx.clear_selection();
+                    *ctx.suppress_chars() = true;
+                }
+            },
             Action::Paste => {
                 let text = ctx.clipboard_mut().load(ClipboardType::Clipboard);
                 paste(ctx, &text);
@@ -778,7 +787,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
     /// for its action to be executed.
     fn process_key_bindings(&mut self, input: KeyboardInput) {
         let mods = *self.ctx.modifiers();
-        let mut suppress_chars = None;
+        let mut suppress_chars = true;
 
         for i in 0..self.ctx.config().ui_config.key_bindings.len() {
             let binding = &self.ctx.config().ui_config.key_bindings[i];
@@ -794,13 +803,14 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
                 let binding = binding.clone();
                 binding.execute(&mut self.ctx);
 
-                // Don't suppress when there has been a `ReceiveChar` action.
-                *suppress_chars.get_or_insert(true) &= binding.action != Action::ReceiveChar;
+                // Don't suppress when there has been a `ReceiveChar` action
+                // or ctx.suppress_chars() was set.
+                suppress_chars |= binding.action != Action::ReceiveChar && *self.ctx.suppress_chars();
             }
         }
 
         // Don't suppress char if no bindings were triggered.
-        *self.ctx.suppress_chars() = suppress_chars.unwrap_or(false);
+        *self.ctx.suppress_chars() = suppress_chars;
     }
 
     /// Attempt to find a binding and execute its action.


### PR DESCRIPTION
Hi,

This PR adds the new Action::CopyDynamic that can be bound to
CTRL+C (for example) which will behave in the following way:

If there is no selection the key press will not be suppressed (and the
application will get the interrupt).

Otherwise, if there is a selection, the selection will be copied
and cleared such that a second press of CTRL+C will interrupt the
program.

Relevant configuration:

```
key_bindings:
  - { key: V,        mods: Control, action: Paste            } # Optional
  - { key: C,        mods: Control, action: CopyDynamic      }
```

The implementation is really hacky right now, so this is a draft for now.
I wanted to check with the community if this is a desired feature, so now anyone can test it out.
If this feature is desired I can clean up the implementation, document the feature and add it to the CHANGELOG.md.

Kind regards,
ambiso
