### PR TITLE
Fix live right-click expansion

### DIFF
--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -361,12 +361,14 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         self.ctx.window_mut().set_mouse_cursor(mouse_state.into());
 
         let last_term_line = self.ctx.terminal().grid().num_lines() - 1;
-        if lmb_pressed && (self.ctx.modifiers().shift() || !self.ctx.mouse_mode()) {
+        if (lmb_pressed || self.ctx.mouse().right_button_state == ElementState::Pressed)
+            && (self.ctx.modifiers().shift() || !self.ctx.mouse_mode())
+        {
             // Treat motion over message bar like motion over the last line.
             let line = min(point.line, last_term_line);
 
             // Move vi mode cursor to mouse cursor position.
-            if self.ctx.terminal().mode().contains(TermMode::VI) {
+            if self.ctx.terminal().mode().contains(TermMode::VI) && lmb_pressed {
                 self.ctx.terminal_mut().vi_mode_cursor.point = point;
             }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -368,7 +368,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             let line = min(point.line, last_term_line);
 
             // Move vi mode cursor to mouse cursor position.
-            if self.ctx.terminal().mode().contains(TermMode::VI) && lmb_pressed {
+            if self.ctx.terminal().mode().contains(TermMode::VI) {
                 self.ctx.terminal_mut().vi_mode_cursor.point = point;
             }
 
@@ -560,6 +560,11 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
         selection.ty = selection_type;
         self.ctx.update_selection(point, cell_side);
+
+        // Move vi mode cursor to mouse click position.
+        if self.ctx.terminal().mode().contains(TermMode::VI) {
+            self.ctx.terminal_mut().vi_mode_cursor.point = point;
+        }
     }
 
     /// Handle left click selection and vi mode cursor movement.
@@ -591,9 +596,8 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             ClickState::None => (),
         };
 
-        // Move vi mode cursor to mouse position.
+        // Move vi mode cursor to mouse click position.
         if self.ctx.terminal().mode().contains(TermMode::VI) {
-            // Update Vi mode cursor position on click.
             self.ctx.terminal_mut().vi_mode_cursor.point = point;
         }
     }


### PR DESCRIPTION
While the commit 43c0ad6ea9d2467ccf867a310c4f1e30f5b627c6 introduced
right click as a way to expand the active selection, it did not allow
for holding right click to continuously do so.

This commit remedies that problem by allowing live expansion with while
holding the right mouse button.
