### PR TITLE
Fix reflow of empty wrapped cursor line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression in font rendering on macOS
 - Scroll down escape (`CSI Ps T`) incorrectly pulling lines from history
 - Dim escape (`CSI 2 m`) support for truecolor text
+- Incorrectly deleted lines when increasing width with a prompt wrapped using spaces
 
 ## 0.4.3
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -187,11 +187,6 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
         Point { line: self.lines.0 + self.display_offset - point.line.0 - 1, col: point.col }
     }
 
-    /// Return the cursor position in buffer coordinates.
-    pub fn cursor_buffer_point(&self) -> Point<usize> {
-        Point { line: self.lines.0 - self.cursor.point.line.0 - 1, col: self.cursor.point.col }
-    }
-
     /// Update the size of the scrollback history.
     pub fn update_history(&mut self, history_size: usize) {
         let current_history_size = self.history_size();

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -67,9 +67,11 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
             self.scroll_up(&(Line(0)..self.lines), Line(required_scrolling), T::default());
 
             // Clamp cursors to the new viewport size.
-            self.saved_cursor.point.line = min(self.saved_cursor.point.line, target - 1);
             self.cursor.point.line = min(self.cursor.point.line, target - 1);
         }
+
+        // Clamp saved cursor, since only primary cursor is scrolled into viewport.
+        self.saved_cursor.point.line = min(self.saved_cursor.point.line, target - 1);
 
         self.raw.rotate((self.lines - target).0 as isize);
         self.raw.shrink_visible_lines(target);
@@ -136,7 +138,7 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
             last_row.append(&mut cells);
 
             let cursor_buffer_line = (self.lines - self.cursor.point.line - 1).0;
-            if row.is_empty() && i != cursor_buffer_line {
+            if row.is_empty() && (i != cursor_buffer_line || row.len() == 0) {
                 if i + reversed.len() < self.lines.0 {
                     // Add new line and move everything up if we can't pull from history.
                     self.saved_cursor.point.line.0 = self.saved_cursor.point.line.saturating_sub(1);
@@ -147,12 +149,12 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
                     self.display_offset = self.display_offset.saturating_sub(1);
 
                     // Rotate cursors down if content below them was pulled from history.
-                    if i <= cursor_buffer_line {
+                    if i < cursor_buffer_line {
                         self.cursor.point.line += 1;
                     }
 
                     let saved_buffer_line = (self.lines - self.saved_cursor.point.line - 1).0;
-                    if i <= saved_buffer_line {
+                    if i < saved_buffer_line {
                         self.saved_cursor.point.line += 1;
                     }
                 }

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -138,7 +138,7 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
             last_row.append(&mut cells);
 
             let cursor_buffer_line = (self.lines - self.cursor.point.line - 1).0;
-            if row.is_empty() && (i != cursor_buffer_line || row.len() == 0) {
+            if row.is_clear() && (i != cursor_buffer_line || row.len() == 0) {
                 if i + reversed.len() < self.lines.0 {
                     // Add new line and move everything up if we can't pull from history.
                     self.saved_cursor.point.line.0 = self.saved_cursor.point.line.saturating_sub(1);

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -139,13 +139,13 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
                 if i + reversed.len() < self.lines.0 {
                     // Move cursor lines up if the removed line is above them.
                     let cursor_buffer_line = (self.num_lines() - self.cursor.point.line - 1).0;
-                    if i > cursor_buffer_line {
-                        self.cursor.point.line.0 = self.cursor.point.line.saturating_sub(1);
+                    if i > cursor_buffer_line && self.cursor.point.line.0 != 0 {
+                        self.cursor.point.line -= 1;
                     }
 
                     let saved_buffer_line = (self.num_lines() - self.saved_cursor.point.line - 1).0;
-                    if i > saved_buffer_line {
-                        self.saved_cursor.point.line.0 = self.saved_cursor.point.line.saturating_sub(1);
+                    if i > saved_buffer_line && self.saved_cursor.point.line.0 != 0 {
+                        self.saved_cursor.point.line -= 1;
                     }
 
                     // Add a new line to the bottom, to fill the gap in the viewport.

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -137,9 +137,18 @@ impl<T: GridCell + Default + PartialEq + Copy> Grid<T> {
 
             if row.is_empty() {
                 if i + reversed.len() < self.lines.0 {
-                    // Add new line and move everything up if we can't pull from history.
-                    self.saved_cursor.point.line.0 = self.saved_cursor.point.line.saturating_sub(1);
-                    self.cursor.point.line.0 = self.cursor.point.line.saturating_sub(1);
+                    // Move cursor lines up if the removed line is above them.
+                    let cursor_buffer_line = (self.num_lines() - self.cursor.point.line - 1).0;
+                    if i > cursor_buffer_line {
+                        self.cursor.point.line.0 = self.cursor.point.line.saturating_sub(1);
+                    }
+
+                    let saved_buffer_line = (self.num_lines() - self.saved_cursor.point.line - 1).0;
+                    if i > saved_buffer_line {
+                        self.saved_cursor.point.line.0 = self.saved_cursor.point.line.saturating_sub(1);
+                    }
+
+                    // Add a new line to the bottom, to fill the gap in the viewport.
                     new_empty_lines += 1;
                 } else {
                     // Since we removed a line, rotate down the viewport.

--- a/alacritty_terminal/src/grid/row.rs
+++ b/alacritty_terminal/src/grid/row.rs
@@ -130,8 +130,9 @@ impl<T> Row<T> {
         self.inner = vec;
     }
 
+    /// Check if all cells in the row are empty.
     #[inline]
-    pub fn is_empty(&self) -> bool
+    pub fn is_clear(&self) -> bool
     where
         T: GridCell,
     {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1775,7 +1775,7 @@ impl<T: EventListener> Handler for Term<T> {
             },
         }
 
-        let cursor_buffer_line = self.grid.cursor_buffer_point().line;
+        let cursor_buffer_line = (self.grid.num_lines() - self.grid.cursor.point.line - 1).0;
         self.selection = self
             .selection
             .take()
@@ -1858,7 +1858,7 @@ impl<T: EventListener> Handler for Term<T> {
         let template = self.grid.cursor.template;
 
         let num_lines = self.grid.num_lines().0;
-        let cursor_buffer_line = self.grid.cursor_buffer_point().line;
+        let cursor_buffer_line = num_lines - self.grid.cursor.point.line.0 - 1;
 
         match mode {
             ansi::ClearMode::Above => {


### PR DESCRIPTION
This bug was caused by trying to grow the terminal while the cursor line
was wrapped but entirely empty. Resizing the terminal now accounts for
the position of the deleted line and moves the cursor up only when the
line deleted was above it.

The deletion of the line was caused by the shell redrawing itself
whenever the cursor is moved.

Fixes #3583.
