### PR TITLE
Adds feature to select random colors on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The mouse bindings now support keyboard modifiers (shift/ctrl/alt/super)
 - Add support for the bright foreground color
 - Support for setting foreground, background colors in one escape sequence
+- Support for randomized color settings
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -23,6 +23,7 @@ parking_lot = "0.10.2"
 font = { path = "../font" }
 urlocator = "0.1.3"
 copypasta = { version = "0.7.0", default-features = false }
+rand = "0.7.3"
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -256,8 +256,8 @@ impl Options {
         match &config.random_colors {
             Some(colors) => {
                 info!("Available colors {:?}", colors);
-                config.colors = colors[rand::random::<usize>()%colors.len()].clone();
-            }
+                config.colors = colors[rand::random::<usize>() % colors.len()].clone();
+            },
             None => info!("No random colors found"),
         }
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -2,10 +2,12 @@ use std::cmp::max;
 use std::path::PathBuf;
 
 use clap::{crate_authors, crate_description, crate_name, crate_version, App, Arg};
-use log::{self, error, LevelFilter};
+use log::{self, error, info, LevelFilter};
 
 use alacritty_terminal::config::{Delta, Dimensions, Program, DEFAULT_NAME};
 use alacritty_terminal::index::{Column, Line};
+
+use rand;
 
 use crate::config::Config;
 
@@ -249,6 +251,14 @@ impl Options {
         match self.working_dir.or_else(|| config.working_directory.take()) {
             Some(ref wd) if !wd.is_dir() => error!("Unable to set working directory to {:?}", wd),
             wd => config.working_directory = wd,
+        }
+
+        match &config.random_colors {
+            Some(colors) => {
+                info!("Available colors {:?}", colors);
+                config.colors = colors[rand::random::<usize>()%colors.len()].clone();
+            }
+            None => info!("No random colors found"),
         }
 
         if let Some(lcr) = self.live_config_reload {

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -51,6 +51,9 @@ pub struct Config<T> {
     #[serde(default, deserialize_with = "failure_default")]
     pub colors: Colors,
 
+    #[serde(default, deserialize_with = "failure_default")]
+    pub random_colors: Option<Vec<Colors>>,
+
     /// Background opacity from 0.0 to 1.0.
     #[serde(default, deserialize_with = "failure_default")]
     background_opacity: Percentage,


### PR DESCRIPTION
Since Alacritty watches the `alacritty.yml` file it is not possible to
modify that file on-the-fly to produce randomized colors when starting
the terminal. Additionally, it just feels kind of hacky to do it like
that.

With this commit, we preserve existing behavior for people who have not added
the random_colors option, while enabling it for those who have.