### PR TITLE
Implement cursor blinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Wide characters sometimes being cut off
 - Preserve vi mode across terminal `reset`
+### Added
+
+- New `cursor.style.blinking` option to set the default blinking state
+- Support for cursor blinking escapes (`CSI ? 12 h`, `CSI ? 12 l` and `CSI Ps SP q`)
 
 ## 0.6.0
 
@@ -38,8 +42,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for single line terminals dimensions
 - Right clicking on Wayland's client side decorations will show application menu
 - Escape sequences to enable and disable window urgency hints (`CSI ? 1042 h`, `CSI ? 1042 l`)
-- Blinking cursor configuration
-- Support for cursor blinking escapes (`CSI ? 12 h`, `CSI ? 12 l` and `CSI Ps SP q`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Wide characters sometimes being cut off
 - Preserve vi mode across terminal `reset`
+
 ### Added
 
 - New `cursor.style.blinking` option to set the default blinking state
+- New `cursor.blink_interval` option to configure the blinking frequency
 - Support for cursor blinking escapes (`CSI ? 12 h`, `CSI ? 12 l` and `CSI Ps SP q`)
 
 ## 0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for single line terminals dimensions
 - Right clicking on Wayland's client side decorations will show application menu
 - Escape sequences to enable and disable window urgency hints (`CSI ? 1042 h`, `CSI ? 1042 l`)
+- Blinking cursor configuration
+- Support for cursor blinking escapes (`CSI ? 12 h`, `CSI ? 12 l` and `CSI Ps SP q`)
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -359,7 +359,7 @@
   #vi_mode_style: None
 
   # Cursor blinking interval in milliseconds. Using `0` will disable blinking.
-  #blink_rate: 750
+  #blink_rate: 666
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -359,7 +359,7 @@
   #vi_mode_style: None
 
   # Cursor blinking interval in milliseconds. Using `0` will disable blinking.
-  #blink_rate: 666
+  #blink_rate: 500
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -358,8 +358,8 @@
   # See `cursor.style` for available options.
   #vi_mode_style: None
 
-  # Cursor blinking interval in milliseconds. Using `0` will disable blinking.
-  #blink_rate: 500
+  # Cursor blinking interval in milliseconds.
+  #blink_interval: 500
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -339,22 +339,22 @@
 #cursor:
   # Cursor style
   #style:
-      # Cursor shape
-      #
-      # Values for `shape`:
-      #   - ▇ Block
-      #   - _ Underline
-      #   - | Beam
-      #shape: Block
+    # Cursor shape
+    #
+    # Values for `shape`:
+    #   - ▇ Block
+    #   - _ Underline
+    #   - | Beam
+    #shape: Block
 
-      # Cursor blinking state
-      #
-      # Values for `blinking`:
-      #   - Never: Prevent the cursor from ever blinking
-      #   - Off: Disable blinking by default
-      #   - On: Enable blinking by default
-      #   - Always: Force the cursor to always blink
-      #blinking: Off
+    # Cursor blinking state
+    #
+    # Values for `blinking`:
+    #   - Never: Prevent the cursor from ever blinking
+    #   - Off: Disable blinking by default
+    #   - On: Enable blinking by default
+    #   - Always: Force the cursor to always blink
+    #blinking: Off
 
   # Vi mode cursor style
   #

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -338,12 +338,17 @@
 
 #cursor:
   # Cursor style
-  #
-  # Values for `style`:
-  #   - ▇ Block
-  #   - _ Underline
-  #   - | Beam
-  #style: Block
+  #style:
+      # The shape of the cursor
+      #
+      # Values for `shape`:
+      #   - ▇ Block
+      #   - _ Underline
+      #   - | Beam
+      #shape: Block
+
+      # Whether the cursor should blink by default or not.
+      #blinking: false
 
   # Vi mode cursor style
   #
@@ -352,6 +357,11 @@
   #
   # See `cursor.style` for available options.
   #vi_mode_style: None
+
+  # Cursor blinking interval
+  #
+  # Rate in milliseconds used for cursor blinking when a blinking cursor style is active. A `blink_rate` of `0` will completely disable cursor blinking.
+  #blink_rate: 500
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -339,7 +339,7 @@
 #cursor:
   # Cursor style
   #style:
-      # The shape of the cursor
+      # Cursor shape
       #
       # Values for `shape`:
       #   - ▇ Block
@@ -347,7 +347,7 @@
       #   - | Beam
       #shape: Block
 
-      # Whether the cursor should blink by default or not.
+      # Default cursor blinking state.
       #blinking: false
 
   # Vi mode cursor style
@@ -358,10 +358,8 @@
   # See `cursor.style` for available options.
   #vi_mode_style: None
 
-  # Cursor blinking interval
-  #
-  # Rate in milliseconds used for cursor blinking when a blinking cursor style is active. A `blink_rate` of `0` will completely disable cursor blinking.
-  #blink_rate: 500
+  # Cursor blinking interval in milliseconds. Using `0` will disable blinking.
+  #blink_rate: 750
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -347,8 +347,14 @@
       #   - | Beam
       #shape: Block
 
-      # Default cursor blinking state.
-      #blinking: false
+      # Cursor blinking state
+      #
+      # Values for `blinking`:
+      #   - Never: Prevent the cursor from ever blinking
+      #   - Off: Disable blinking by default
+      #   - On: Enable blinking by default
+      #   - Always: Force the cursor to always blink
+      #blinking: Off
 
   # Vi mode cursor style
   #
@@ -359,7 +365,7 @@
   #vi_mode_style: None
 
   # Cursor blinking interval in milliseconds.
-  #blink_interval: 500
+  #blink_interval: 750
 
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -2,7 +2,7 @@
 
 use crossfont::{BitmapBuffer, Metrics, RasterizedGlyph};
 
-use alacritty_terminal::ansi::CursorStyle;
+use alacritty_terminal::ansi::{CursorShape, CursorStyle};
 
 pub fn get_cursor_glyph(
     cursor: CursorStyle,
@@ -25,12 +25,12 @@ pub fn get_cursor_glyph(
         width *= 2;
     }
 
-    match cursor {
-        CursorStyle::HollowBlock => get_box_cursor_glyph(height, width, line_width),
-        CursorStyle::Underline => get_underline_cursor_glyph(width, line_width),
-        CursorStyle::Beam => get_beam_cursor_glyph(height, line_width),
-        CursorStyle::Block => get_block_cursor_glyph(height, width),
-        CursorStyle::Hidden => RasterizedGlyph::default(),
+    match cursor.shape {
+        CursorShape::HollowBlock => get_box_cursor_glyph(height, width, line_width),
+        CursorShape::Underline => get_underline_cursor_glyph(width, line_width),
+        CursorShape::Beam => get_beam_cursor_glyph(height, line_width),
+        CursorShape::Block => get_block_cursor_glyph(height, width),
+        CursorShape::Hidden => RasterizedGlyph::default(),
     }
 }
 

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -2,10 +2,10 @@
 
 use crossfont::{BitmapBuffer, Metrics, RasterizedGlyph};
 
-use alacritty_terminal::ansi::{CursorShape, CursorStyle};
+use alacritty_terminal::ansi::CursorShape;
 
 pub fn get_cursor_glyph(
-    cursor: CursorStyle,
+    cursor: CursorShape,
     metrics: Metrics,
     offset_x: i8,
     offset_y: i8,
@@ -25,7 +25,7 @@ pub fn get_cursor_glyph(
         width *= 2;
     }
 
-    match cursor.shape {
+    match cursor {
         CursorShape::HollowBlock => get_box_cursor_glyph(height, width, line_width),
         CursorShape::Underline => get_underline_cursor_glyph(width, line_width),
         CursorShape::Beam => get_beam_cursor_glyph(height, line_width),

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -160,6 +160,9 @@ pub struct Display {
     #[cfg(not(any(target_os = "macos", windows)))]
     pub is_x11: bool,
 
+    /// UI cursor visibility for blinking.
+    pub cursor_hidden: bool,
+
     renderer: QuadRenderer,
     glyph_cache: GlyphCache,
     meter: Meter,
@@ -300,6 +303,7 @@ impl Display {
             is_x11,
             #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
             wayland_event_queue,
+            cursor_hidden: false,
         })
     }
 
@@ -436,14 +440,13 @@ impl Display {
         mouse: &Mouse,
         mods: ModifiersState,
         search_state: &SearchState,
-        cursor_hidden: bool,
     ) {
         // Convert search match from viewport to absolute indexing.
         let search_active = search_state.regex().is_some();
         let viewport_match = search_state
             .focused_match()
             .and_then(|focused_match| terminal.grid().clamp_buffer_range_to_visible(focused_match));
-        let cursor_hidden = cursor_hidden || search_state.regex().is_some();
+        let cursor_hidden = self.cursor_hidden || search_state.regex().is_some();
 
         let grid_cells = terminal.renderable_cells(config, !cursor_hidden).collect::<Vec<_>>();
         let visual_bell_intensity = terminal.visual_bell.intensity();

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -436,14 +436,16 @@ impl Display {
         mouse: &Mouse,
         mods: ModifiersState,
         search_state: &SearchState,
+        cursor_hidden: bool,
     ) {
         // Convert search match from viewport to absolute indexing.
         let search_active = search_state.regex().is_some();
         let viewport_match = search_state
             .focused_match()
             .and_then(|focused_match| terminal.grid().clamp_buffer_range_to_visible(focused_match));
+        let cursor_hidden = cursor_hidden || search_state.regex().is_some();
 
-        let grid_cells = terminal.renderable_cells(config, !search_active).collect::<Vec<_>>();
+        let grid_cells = terminal.renderable_cells(config, !cursor_hidden).collect::<Vec<_>>();
         let visual_bell_intensity = terminal.visual_bell.intensity();
         let background_color = terminal.background_color();
         let cursor_point = terminal.grid().cursor.point;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1081,7 +1081,10 @@ impl<N: Notify + OnResize> Processor<N> {
                                 // Reenable blinking cursor based on current mode.
                                 let config = &processor.ctx.config;
                                 let cursor_style = if terminal.mode().contains(TermMode::VI) {
-                                    config.cursor.vi_mode_style().unwrap_or_else(|| config.cursor.style())
+                                    config
+                                        .cursor
+                                        .vi_mode_style()
+                                        .unwrap_or_else(|| config.cursor.style())
                                 } else {
                                     config.cursor.style()
                                 };

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -506,7 +506,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[inline]
     fn on_typing_start(&mut self) {
         // Disable cursor blinking.
-        let blink_interval = self.config.cursor.blink_interval;
+        let blink_interval = self.config.cursor.blink_interval();
         if let Some(timer) = self.scheduler.get_mut(TimerId::BlinkCursor) {
             timer.deadline = Instant::now() + Duration::from_millis(blink_interval);
             *self.cursor_hidden = false;
@@ -709,7 +709,7 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
         if blinking && self.terminal.is_focused {
             self.scheduler.schedule(
                 GlutinEvent::UserEvent(Event::BlinkCursor),
-                Duration::from_millis(self.config.cursor.blink_interval),
+                Duration::from_millis(self.config.cursor.blink_interval()),
                 true,
                 TimerId::BlinkCursor,
             )

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1081,10 +1081,8 @@ impl<N: Notify + OnResize> Processor<N> {
                                 // Reenable blinking cursor based on current mode.
                                 let config = &processor.ctx.config;
                                 let cursor_style = if terminal.mode().contains(TermMode::VI) {
-                                    config
-                                        .cursor
-                                        .vi_mode_style()
-                                        .unwrap_or_else(|| config.cursor.style())
+                                    let style = config.cursor.style();
+                                    config.cursor.vi_mode_style().unwrap_or(style)
                                 } else {
                                     config.cursor.style()
                                 };

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -515,7 +515,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         if blinking && self.terminal.is_focused {
             self.scheduler.schedule(
                 GlutinEvent::UserEvent(Event::BlinkCursor),
-                Duration::from_millis(self.config.cursor.blink_rate),
+                Duration::from_millis(self.config.cursor.blink_interval),
                 true,
                 TimerId::BlinkCursor,
             )
@@ -534,9 +534,9 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[inline]
     fn enable_input_mode(&mut self) {
         // Disable cursor blinking.
-        let cursor_blink_rate = self.config.cursor.blink_rate;
+        let blink_interval = self.config.cursor.blink_interval;
         if let Some(timer) = self.scheduler.get_mut(TimerId::BlinkCursor) {
-            timer.deadline = Instant::now() + Duration::from_millis(cursor_blink_rate);
+            timer.deadline = Instant::now() + Duration::from_millis(blink_interval);
             *self.cursor_hidden = false;
             self.terminal.dirty = true;
         }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -768,7 +768,6 @@ pub struct Processor<N> {
     event_queue: Vec<GlutinEvent<'static, Event>>,
     search_state: SearchState,
     cli_options: CLIOptions,
-    cursor_hidden: bool,
 }
 
 impl<N: Notify + OnResize> Processor<N> {
@@ -801,7 +800,6 @@ impl<N: Notify + OnResize> Processor<N> {
             clipboard,
             search_state: SearchState::new(),
             cli_options,
-            cursor_hidden: false,
         }
     }
 
@@ -911,7 +909,7 @@ impl<N: Notify + OnResize> Processor<N> {
                 scheduler: &mut scheduler,
                 search_state: &mut self.search_state,
                 cli_options: &self.cli_options,
-                cursor_hidden: &mut self.cursor_hidden,
+                cursor_hidden: &mut self.display.cursor_hidden,
                 event_loop,
             };
             let mut processor = input::Processor::new(context, &self.display.highlighted_url);
@@ -950,7 +948,6 @@ impl<N: Notify + OnResize> Processor<N> {
                     &self.mouse,
                     self.modifiers,
                     &self.search_state,
-                    self.cursor_hidden,
                 );
             }
         });

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1089,9 +1089,8 @@ impl<N: Notify + OnResize> Processor<N> {
                     },
                     WindowEvent::Focused(is_focused) => {
                         if window_id == processor.ctx.window.window_id() {
-                            let terminal = &mut processor.ctx.terminal;
-                            terminal.is_focused = is_focused;
-                            terminal.dirty = true;
+                            processor.ctx.terminal.is_focused = is_focused;
+                            processor.ctx.terminal.dirty = true;
 
                             if is_focused {
                                 processor.ctx.window.set_urgent(false);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -500,8 +500,16 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     /// Update the cursor blinking state.
     #[inline]
     fn update_cursor_blinking(&mut self) {
-        let blinking = self.terminal.cursor_style().blinking;
+        // Get config cursor style.
+        let mut cursor_style = self.config.cursor.style;
+        if self.terminal.mode().contains(TermMode::VI) {
+            cursor_style = self.config.cursor.vi_mode_style.unwrap_or(cursor_style);
+        };
 
+        // Check terminal cursor style.
+        let blinking = cursor_style.blinking(self.terminal.cursor_style().blinking);
+
+        // Update cursor blinking state.
         if !blinking || self.config.cursor.blink_rate == 0 || !self.terminal.is_focused {
             self.scheduler.unschedule(TimerId::BlinkCursor);
             *self.cursor_hidden = false;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -525,14 +525,14 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
     }
 
-    /// Enable input mode.
+    /// Handle keyboard typing start.
     ///
-    /// Putting the user in input mode will temporarily disable some features like terminal cursor
-    /// blinking or the mouse cursor.
+    /// This will temporarily disable some features like terminal cursor blinking or the mouse
+    /// cursor.
     ///
-    /// This mode will disable itself automatically.
+    /// All features are re-enabled again automatically.
     #[inline]
-    fn enable_input_mode(&mut self) {
+    fn on_typing_start(&mut self) {
         // Disable cursor blinking.
         let blink_interval = self.config.cursor.blink_interval;
         if let Some(timer) = self.scheduler.get_mut(TimerId::BlinkCursor) {
@@ -858,7 +858,7 @@ impl<N: Notify + OnResize> Processor<N> {
 
         // Start the initial cursor blinking timer.
         if self.config.cursor.style().blinking {
-            self.event_queue.push(Event::TerminalEvent(TerminalEvent::CursorBlinking(true)).into());
+            self.event_queue.push(Event::TerminalEvent(TerminalEvent::CursorBlinkingChange(true)).into());
         }
 
         event_loop.run_return(|event, event_loop, control_flow| {
@@ -1045,7 +1045,7 @@ impl<N: Notify + OnResize> Processor<N> {
                     },
                     TerminalEvent::MouseCursorDirty => processor.reset_mouse_cursor(),
                     TerminalEvent::Exit => (),
-                    TerminalEvent::CursorBlinking(_) => processor.ctx.update_cursor_blinking(),
+                    TerminalEvent::CursorBlinkingChange(_) => processor.ctx.update_cursor_blinking(),
                 },
             },
             GlutinEvent::RedrawRequested(_) => processor.ctx.terminal.dirty = true,

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -103,7 +103,6 @@ pub trait ActionContext<T: EventListener> {
     fn advance_search_origin(&mut self, direction: Direction);
     fn search_direction(&self) -> Direction;
     fn search_active(&self) -> bool;
-    fn update_cursor_blinking(&mut self);
     fn on_typing_start(&mut self);
 }
 
@@ -165,10 +164,7 @@ impl<T: EventListener> Execute<T> for Action {
                 start_daemon(program, args);
             },
             Action::ClearSelection => ctx.clear_selection(),
-            Action::ToggleViMode => {
-                ctx.terminal_mut().toggle_vi_mode();
-                ctx.update_cursor_blinking();
-            },
+            Action::ToggleViMode => ctx.terminal_mut().toggle_vi_mode(),
             Action::ViMotion(motion) => {
                 ctx.on_typing_start();
                 ctx.terminal_mut().vi_motion(motion)
@@ -1270,10 +1266,6 @@ mod tests {
         }
 
         fn on_typing_start(&mut self) {
-            unimplemented!();
-        }
-
-        fn update_cursor_blinking(&mut self) {
             unimplemented!();
         }
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -103,7 +103,7 @@ pub trait ActionContext<T: EventListener> {
     fn advance_search_origin(&mut self, direction: Direction);
     fn search_direction(&self) -> Direction;
     fn search_active(&self) -> bool;
-    fn update_cursor_blinking(&mut self, blinking: bool);
+    fn update_cursor_blinking(&mut self);
     fn show_cursor(&mut self);
 }
 
@@ -168,11 +168,8 @@ impl<T: EventListener> Execute<T> for Action {
             },
             Action::ClearSelection => ctx.clear_selection(),
             Action::ToggleViMode => {
-                let config = ctx.config();
-                let style = config.cursor.vi_mode_style().unwrap_or_else(|| config.cursor.style());
-                ctx.update_cursor_blinking(style.blinking);
-
                 ctx.terminal_mut().toggle_vi_mode();
+                ctx.update_cursor_blinking();
             },
             Action::ViMotion(motion) => {
                 if ctx.config().ui_config.mouse.hide_when_typing {

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1287,7 +1287,7 @@ mod tests {
             unimplemented!();
         }
 
-        fn update_cursor_blinking(&mut self, _blinking: bool) {
+        fn update_cursor_blinking(&mut self) {
             unimplemented!();
         }
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -104,7 +104,7 @@ pub trait ActionContext<T: EventListener> {
     fn search_direction(&self) -> Direction;
     fn search_active(&self) -> bool;
     fn update_cursor_blinking(&mut self);
-    fn show_cursor(&mut self);
+    fn enable_input_mode(&mut self);
 }
 
 trait Execute<T: EventListener> {
@@ -140,9 +140,7 @@ impl<T: EventListener> Execute<T> for Action {
     fn execute<A: ActionContext<T>>(&self, ctx: &mut A) {
         match *self {
             Action::Esc(ref s) => {
-                if ctx.config().ui_config.mouse.hide_when_typing {
-                    ctx.window_mut().set_mouse_visible(false);
-                }
+                ctx.enable_input_mode();
 
                 ctx.clear_selection();
                 ctx.scroll(Scroll::Bottom);
@@ -172,10 +170,7 @@ impl<T: EventListener> Execute<T> for Action {
                 ctx.update_cursor_blinking();
             },
             Action::ViMotion(motion) => {
-                if ctx.config().ui_config.mouse.hide_when_typing {
-                    ctx.window_mut().set_mouse_visible(false);
-                }
-
+                ctx.enable_input_mode();
                 ctx.terminal_mut().vi_motion(motion)
             },
             Action::ViAction(ViAction::ToggleNormalSelection) => {
@@ -875,6 +870,13 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         self.ctx.window_mut().set_mouse_cursor(mouse_state.into());
     }
 
+    /// Reset mouse cursor based on modifier and terminal state.
+    #[inline]
+    pub fn reset_mouse_cursor(&mut self) {
+        let mouse_state = self.mouse_state();
+        self.ctx.window_mut().set_mouse_cursor(mouse_state.into());
+    }
+
     /// Process a received character.
     pub fn received_char(&mut self, c: char) {
         let suppress_chars = *self.ctx.suppress_chars();
@@ -895,16 +897,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             return;
         }
 
-        // Disable cursor blinking while the user is typing.
-        let cursor_blink_rate = self.ctx.config().cursor.blink_rate;
-        if let Some(timer) = self.ctx.scheduler_mut().get_mut(TimerId::BlinkCursor) {
-            timer.deadline = Instant::now() + Duration::from_millis(cursor_blink_rate);
-            self.ctx.show_cursor();
-        }
-
-        if self.ctx.config().ui_config.mouse.hide_when_typing {
-            self.ctx.window_mut().set_mouse_visible(false);
-        }
+        self.ctx.enable_input_mode();
 
         self.ctx.scroll(Scroll::Bottom);
         self.ctx.clear_selection();
@@ -927,13 +920,6 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         self.ctx.write_to_pty(bytes);
 
         *self.ctx.received_count() += 1;
-    }
-
-    /// Reset mouse cursor based on modifier and terminal state.
-    #[inline]
-    pub fn reset_mouse_cursor(&mut self) {
-        let mouse_state = self.mouse_state();
-        self.ctx.window_mut().set_mouse_cursor(mouse_state.into());
     }
 
     /// Attempt to find a binding and execute its action.
@@ -1283,7 +1269,7 @@ mod tests {
             unimplemented!();
         }
 
-        fn show_cursor(&mut self) {
+        fn enable_input_mode(&mut self) {
             unimplemented!();
         }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -104,7 +104,7 @@ pub trait ActionContext<T: EventListener> {
     fn search_direction(&self) -> Direction;
     fn search_active(&self) -> bool;
     fn update_cursor_blinking(&mut self);
-    fn enable_input_mode(&mut self);
+    fn on_typing_start(&mut self);
 }
 
 trait Execute<T: EventListener> {
@@ -140,7 +140,7 @@ impl<T: EventListener> Execute<T> for Action {
     fn execute<A: ActionContext<T>>(&self, ctx: &mut A) {
         match *self {
             Action::Esc(ref s) => {
-                ctx.enable_input_mode();
+                ctx.on_typing_start();
 
                 ctx.clear_selection();
                 ctx.scroll(Scroll::Bottom);
@@ -170,7 +170,7 @@ impl<T: EventListener> Execute<T> for Action {
                 ctx.update_cursor_blinking();
             },
             Action::ViMotion(motion) => {
-                ctx.enable_input_mode();
+                ctx.on_typing_start();
                 ctx.terminal_mut().vi_motion(motion)
             },
             Action::ViAction(ViAction::ToggleNormalSelection) => {
@@ -897,7 +897,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             return;
         }
 
-        self.ctx.enable_input_mode();
+        self.ctx.on_typing_start();
 
         self.ctx.scroll(Scroll::Bottom);
         self.ctx.clear_selection();
@@ -1269,7 +1269,7 @@ mod tests {
             unimplemented!();
         }
 
-        fn enable_input_mode(&mut self) {
+        fn on_typing_start(&mut self) {
             unimplemented!();
         }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1285,6 +1285,14 @@ mod tests {
         fn scheduler_mut(&mut self) -> &mut Scheduler {
             unimplemented!();
         }
+
+        fn show_cursor(&mut self) {
+            unimplemented!();
+        }
+
+        fn update_cursor_blinking(&mut self, _blinking: bool) {
+            unimplemented!();
+        }
     }
 
     macro_rules! test_clickstate {

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1010,7 +1010,7 @@ impl<'a> RenderApi<'a> {
                 let metrics = glyph_cache.metrics;
                 let glyph = glyph_cache.cursor_cache.entry(cursor_key).or_insert_with(|| {
                     self.load_glyph(&cursor::get_cursor_glyph(
-                        cursor_key.style,
+                        cursor_key.shape,
                         metrics,
                         self.config.font.offset.x,
                         self.config.font.offset.y,

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -14,6 +14,7 @@ type Event = GlutinEvent<'static, AlacrittyEvent>;
 pub enum TimerId {
     SelectionScrolling,
     DelayedSearch,
+    CursorBlinking,
 }
 
 /// Event scheduled to be emitted at a specific time.

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -14,7 +14,7 @@ type Event = GlutinEvent<'static, AlacrittyEvent>;
 pub enum TimerId {
     SelectionScrolling,
     DelayedSearch,
-    CursorBlinking,
+    BlinkCursor,
 }
 
 /// Event scheduled to be emitted at a specific time.

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -141,6 +141,9 @@ pub trait Handler {
     /// Set the cursor style.
     fn set_cursor_style(&mut self, _: Option<CursorStyle>) {}
 
+    /// Set the cursor shape.
+    fn set_cursor_shape(&mut self, _shape: CursorShape) {}
+
     /// A character to be displayed.
     fn input(&mut self, _c: char) {}
 
@@ -875,8 +878,6 @@ where
                 unhandled(params);
             },
 
-            // TODO: 50 still supported? https://iterm2.com/documentation-escape-codes.html
-            //
             // Set cursor style.
             b"50" | b"1337" => {
                 if params.len() >= 2
@@ -889,9 +890,7 @@ where
                         '2' => CursorShape::Underline,
                         _ => return unhandled(params),
                     };
-                    // TODO: Don't just disable blinking what the fuck?
-                    let style = CursorStyle { shape, blinking: false };
-                    self.handler.set_cursor_style(Some(style));
+                    self.handler.set_cursor_shape(shape);
                     return;
                 }
                 unhandled(params);

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -328,14 +328,14 @@ pub trait Handler {
 }
 
 /// Terminal cursor configuration.
-#[derive(Default, Debug, Eq, PartialEq, Copy, Clone, Hash, Deserialize)]
+#[derive(Deserialize, Default, Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct CursorStyle {
     pub shape: CursorShape,
     pub blinking: bool,
 }
 
 /// Terminal cursor shape.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Deserialize)]
+#[derive(Deserialize, Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum CursorShape {
     /// Cursor is a block like `▒`.
     Block,
@@ -879,7 +879,7 @@ where
             },
 
             // Set cursor style.
-            b"50" | b"1337" => {
+            b"50" => {
                 if params.len() >= 2
                     && params[1].len() >= 13
                     && params[1][0..12] == *b"CursorShape="

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -161,7 +161,7 @@ impl Default for Cursor {
             vi_mode_style: Default::default(),
             thickness: Percentage::new(DEFAULT_CURSOR_THICKNESS),
             unfocused_hollow: Default::default(),
-            blink_rate: 666,
+            blink_rate: 500,
         }
     }
 }
@@ -205,11 +205,11 @@ impl Default for ConfigCursorStyle {
 }
 
 impl ConfigCursorStyle {
-    /// Determine blinking configuration based on current terminal blinking state.
-    pub fn blinking(&self, blinking_state: bool) -> bool {
+    /// Check if blinking is force enabled/disabled.
+    pub fn blinking_override(&self) -> Option<bool> {
         match self {
-            Self::Shape(_) => blinking_state,
-            Self::WithBlinking { blinking, .. } => blinking.enabled(blinking_state),
+            Self::Shape(_) => None,
+            Self::WithBlinking { blinking, .. } => blinking.blinking_override(),
         }
     }
 }
@@ -240,11 +240,11 @@ impl Default for CursorBlinking {
 }
 
 impl CursorBlinking {
-    fn enabled(&self, blinking_state: bool) -> bool {
+    fn blinking_override(&self) -> Option<bool> {
         match self {
-            Self::Never => false,
-            Self::Off | Self::On => blinking_state,
-            Self::Always => true,
+            Self::Never => Some(false),
+            Self::Off | Self::On => None,
+            Self::Always => Some(true),
         }
     }
 }

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -161,7 +161,7 @@ impl Default for Cursor {
             vi_mode_style: Default::default(),
             thickness: Percentage::new(DEFAULT_CURSOR_THICKNESS),
             unfocused_hollow: Default::default(),
-            blink_interval: 500,
+            blink_interval: 750,
         }
     }
 }

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -124,6 +124,8 @@ pub struct Cursor {
     pub style: CursorStyle,
     #[serde(deserialize_with = "option_explicit_none")]
     pub vi_mode_style: Option<CursorStyle>,
+    #[serde(deserialize_with = "failure_default")]
+    pub blink_rate: u64,
     #[serde(deserialize_with = "deserialize_cursor_thickness")]
     thickness: Percentage,
     #[serde(deserialize_with = "failure_default")]
@@ -149,6 +151,7 @@ impl Default for Cursor {
             vi_mode_style: Default::default(),
             thickness: Percentage::new(DEFAULT_CURSOR_THICKNESS),
             unfocused_hollow: Default::default(),
+            blink_rate: 500,
         }
     }
 }

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -1,7 +1,7 @@
+use std::cmp::max;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::path::PathBuf;
-use std::cmp::max;
 
 use log::error;
 use serde::{Deserialize, Deserializer};
@@ -127,7 +127,7 @@ pub struct Cursor {
     #[serde(deserialize_with = "option_explicit_none")]
     pub vi_mode_style: Option<ConfigCursorStyle>,
     #[serde(deserialize_with = "failure_default")]
-    pub blink_interval: BlinkInterval,
+    blink_interval: BlinkInterval,
     #[serde(deserialize_with = "deserialize_cursor_thickness")]
     thickness: Percentage,
     #[serde(deserialize_with = "failure_default")]

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -125,7 +125,7 @@ pub struct Cursor {
     #[serde(deserialize_with = "option_explicit_none")]
     pub vi_mode_style: Option<ConfigCursorStyle>,
     #[serde(deserialize_with = "failure_default")]
-    pub blink_rate: u64,
+    pub blink_interval: u64,
     #[serde(deserialize_with = "deserialize_cursor_thickness")]
     thickness: Percentage,
     #[serde(deserialize_with = "failure_default")]
@@ -161,7 +161,7 @@ impl Default for Cursor {
             vi_mode_style: Default::default(),
             thickness: Percentage::new(DEFAULT_CURSOR_THICKNESS),
             unfocused_hollow: Default::default(),
-            blink_rate: 500,
+            blink_interval: 500,
         }
     }
 }

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -10,7 +10,7 @@ mod bell;
 mod colors;
 mod scrolling;
 
-use crate::ansi::{CursorStyle, CursorShape};
+use crate::ansi::{CursorShape, CursorStyle};
 
 pub use crate::config::bell::{BellAnimation, BellConfig};
 pub use crate::config::colors::Colors;
@@ -200,19 +200,14 @@ pub enum ConfigCursorStyle {
 
 impl Default for ConfigCursorStyle {
     fn default() -> Self {
-        Self::WithBlinking {
-            shape: CursorShape::default(),
-            blinking: false,
-        }
+        Self::WithBlinking { shape: CursorShape::default(), blinking: false }
     }
 }
 
 impl From<ConfigCursorStyle> for CursorStyle {
     fn from(config_style: ConfigCursorStyle) -> Self {
         match config_style {
-            ConfigCursorStyle::Shape(shape) => Self {
-                shape, blinking: false,
-            },
+            ConfigCursorStyle::Shape(shape) => Self { shape, blinking: false },
             ConfigCursorStyle::WithBlinking { shape, blinking } => Self { shape, blinking },
         }
     }

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -11,8 +11,7 @@ pub enum Event {
     ResetTitle,
     ClipboardStore(ClipboardType, String),
     ClipboardLoad(ClipboardType, Arc<dyn Fn(&str) -> String + Sync + Send + 'static>),
-    // TODO: This really isn't a great name?
-    CursorBlinking(bool),
+    CursorBlinkingChange(bool),
     Wakeup,
     Bell,
     Exit,
@@ -29,7 +28,7 @@ impl Debug for Event {
             Event::Wakeup => write!(f, "Wakeup"),
             Event::Bell => write!(f, "Bell"),
             Event::Exit => write!(f, "Exit"),
-            Event::CursorBlinking(blinking) => write!(f, "CursorBlinking({})", blinking),
+            Event::CursorBlinkingChange(blinking) => write!(f, "CursorBlinking({})", blinking),
         }
     }
 }

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -11,12 +11,10 @@ pub enum Event {
     ResetTitle,
     ClipboardStore(ClipboardType, String),
     ClipboardLoad(ClipboardType, Arc<dyn Fn(&str) -> String + Sync + Send + 'static>),
+    CursorBlinking(bool),
     Wakeup,
     Bell,
     Exit,
-    CursorStartBlinking,
-    CursorBlink,
-    CursorStopBlinking,
 }
 
 impl Debug for Event {
@@ -30,9 +28,7 @@ impl Debug for Event {
             Event::Wakeup => write!(f, "Wakeup"),
             Event::Bell => write!(f, "Bell"),
             Event::Exit => write!(f, "Exit"),
-            Event::CursorStartBlinking => write!(f, "CursorStartBlinking"),
-            Event::CursorBlink => write!(f, "CursorBlink"),
-            Event::CursorStopBlinking => write!(f, "CursorStopBlinking"),
+            Event::CursorBlinking(blinking) => write!(f, "CursorBlinking({})", blinking),
         }
     }
 }

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -11,6 +11,7 @@ pub enum Event {
     ResetTitle,
     ClipboardStore(ClipboardType, String),
     ClipboardLoad(ClipboardType, Arc<dyn Fn(&str) -> String + Sync + Send + 'static>),
+    // TODO: This really isn't a great name?
     CursorBlinking(bool),
     Wakeup,
     Bell,

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -14,6 +14,9 @@ pub enum Event {
     Wakeup,
     Bell,
     Exit,
+    CursorStartBlinking,
+    CursorBlink,
+    CursorStopBlinking,
 }
 
 impl Debug for Event {
@@ -27,6 +30,9 @@ impl Debug for Event {
             Event::Wakeup => write!(f, "Wakeup"),
             Event::Bell => write!(f, "Bell"),
             Event::Exit => write!(f, "Exit"),
+            Event::CursorStartBlinking => write!(f, "CursorStartBlinking"),
+            Event::CursorBlink => write!(f, "CursorBlink"),
+            Event::CursorStopBlinking => write!(f, "CursorStopBlinking"),
         }
     }
 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2113,7 +2113,7 @@ impl<T: EventListener> Handler for Term<T> {
         self.mode &= TermMode::VI;
         self.mode.insert(TermMode::default());
 
-        self.event_proxy.send_event(Event::CursorBlinking(self.default_cursor_style.blinking));
+        self.event_proxy.send_event(Event::CursorBlinkingChange(self.default_cursor_style.blinking));
     }
 
     #[inline]
@@ -2217,7 +2217,7 @@ impl<T: EventListener> Handler for Term<T> {
             ansi::Mode::BlinkingCursor => {
                 let style = self.cursor_style.get_or_insert(self.default_cursor_style);
                 style.blinking = true;
-                self.event_proxy.send_event(Event::CursorBlinking(true));
+                self.event_proxy.send_event(Event::CursorBlinkingChange(true));
             }
         }
     }
@@ -2259,7 +2259,7 @@ impl<T: EventListener> Handler for Term<T> {
             ansi::Mode::BlinkingCursor => {
                 let style = self.cursor_style.get_or_insert(self.default_cursor_style);
                 style.blinking = false;
-                self.event_proxy.send_event(Event::CursorBlinking(false));
+                self.event_proxy.send_event(Event::CursorBlinkingChange(false));
             }
         }
     }
@@ -2319,7 +2319,7 @@ impl<T: EventListener> Handler for Term<T> {
 
         // Notify UI about blinking changes.
         let blinking = style.unwrap_or(self.default_cursor_style).blinking;
-        self.event_proxy.send_event(Event::CursorBlinking(blinking));
+        self.event_proxy.send_event(Event::CursorBlinkingChange(blinking));
     }
 
     #[inline]

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2299,6 +2299,14 @@ impl<T: EventListener> Handler for Term<T> {
     }
 
     #[inline]
+    fn set_cursor_shape(&mut self, shape: CursorShape) {
+        trace!("Setting cursor shape {:?}", shape);
+
+        let style = self.cursor_style.get_or_insert(self.default_cursor_style);
+        style.shape = shape;
+    }
+
+    #[inline]
     fn set_title(&mut self, title: Option<String>) {
         trace!("Setting title to '{:?}'", title);
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1207,7 +1207,10 @@ impl<T> Term<T> {
 
     /// Toggle the vi mode.
     #[inline]
-    pub fn toggle_vi_mode(&mut self) {
+    pub fn toggle_vi_mode(&mut self)
+    where
+        T: EventListener,
+    {
         self.mode ^= TermMode::VI;
 
         let vi_mode = self.mode.contains(TermMode::VI);
@@ -1225,6 +1228,9 @@ impl<T> Term<T> {
         } else {
             self.cancel_search();
         }
+
+        // Update UI about cursor blinking state changes.
+        self.event_proxy.send_event(Event::CursorBlinkingChange(self.cursor_style().blinking));
 
         self.dirty = true;
     }
@@ -2113,7 +2119,8 @@ impl<T: EventListener> Handler for Term<T> {
         self.mode &= TermMode::VI;
         self.mode.insert(TermMode::default());
 
-        self.event_proxy.send_event(Event::CursorBlinkingChange(self.default_cursor_style.blinking));
+        let blinking = self.cursor_style().blinking;
+        self.event_proxy.send_event(Event::CursorBlinkingChange(blinking));
     }
 
     #[inline]
@@ -2218,7 +2225,7 @@ impl<T: EventListener> Handler for Term<T> {
                 let style = self.cursor_style.get_or_insert(self.default_cursor_style);
                 style.blinking = true;
                 self.event_proxy.send_event(Event::CursorBlinkingChange(true));
-            }
+            },
         }
     }
 
@@ -2260,7 +2267,7 @@ impl<T: EventListener> Handler for Term<T> {
                 let style = self.cursor_style.get_or_insert(self.default_cursor_style);
                 style.blinking = false;
                 self.event_proxy.send_event(Event::CursorBlinkingChange(false));
-            }
+            },
         }
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2214,7 +2214,11 @@ impl<T: EventListener> Handler for Term<T> {
             ansi::Mode::Origin => self.mode.insert(TermMode::ORIGIN),
             ansi::Mode::DECCOLM => self.deccolm(),
             ansi::Mode::Insert => self.mode.insert(TermMode::INSERT),
-            ansi::Mode::BlinkingCursor => self.event_proxy.send_event(Event::CursorBlinking(true)),
+            ansi::Mode::BlinkingCursor => {
+                let style = self.cursor_style.get_or_insert(self.default_cursor_style);
+                style.blinking = true;
+                self.event_proxy.send_event(Event::CursorBlinking(true));
+            }
         }
     }
 
@@ -2252,7 +2256,11 @@ impl<T: EventListener> Handler for Term<T> {
             ansi::Mode::Origin => self.mode.remove(TermMode::ORIGIN),
             ansi::Mode::DECCOLM => self.deccolm(),
             ansi::Mode::Insert => self.mode.remove(TermMode::INSERT),
-            ansi::Mode::BlinkingCursor => self.event_proxy.send_event(Event::CursorBlinking(false)),
+            ansi::Mode::BlinkingCursor => {
+                let style = self.cursor_style.get_or_insert(self.default_cursor_style);
+                style.blinking = false;
+                self.event_proxy.send_event(Event::CursorBlinking(false));
+            }
         }
     }
 

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -68,7 +68,7 @@ brevity.
 | `CSI m`    | PARTIAL     | Only singular straight underlines are supported   |
 | `CSI n`    | IMPLEMENTED |                                                   |
 | `CSI P`    | IMPLEMENTED |                                                   |
-| `CSI SP q` | PARTIAL     | No blinking support                               |
+| `CSI SP q` | IMPLEMENTED |                                                   |
 | `CSI r`    | IMPLEMENTED |                                                   |
 | `CSI S`    | IMPLEMENTED |                                                   |
 | `CSI s`    | IMPLEMENTED |                                                   |

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -96,7 +96,6 @@ brevity.
 | `OSC 110`  | IMPLEMENTED |                                                    |
 | `OSC 111`  | IMPLEMENTED |                                                    |
 | `OSC 112`  | IMPLEMENTED |                                                    |
-| `OSC 1337` | IMPLEMENTED |                                                    |
 
 ### DCS (Device Control String) - `ESC P`
 

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -81,21 +81,22 @@ brevity.
 
 ### OSC (Operating System Command) - `ESC ]`
 
-| ESCAPE    | STATUS      | NOTE                                               |
-| --------- | ----------- | -------------------------------------------------- |
-| `OSC 0`   | IMPLEMENTED | Icon names are not supported                       |
-| `OSC 1`   | REJECTED    | Icon names are not supported                       |
-| `OSC 2`   | IMPLEMENTED |                                                    |
-| `OSC 4`   | IMPLEMENTED |                                                    |
-| `OSC 10`  | IMPLEMENTED |                                                    |
-| `OSC 11`  | IMPLEMENTED |                                                    |
-| `OSC 12`  | IMPLEMENTED |                                                    |
-| `OSC 50`  | IMPLEMENTED | Only `CursorShape` is supported                    |
-| `OSC 52`  | IMPLEMENTED | Only Clipboard and primary selection supported     |
-| `OSC 104` | IMPLEMENTED |                                                    |
-| `OSC 110` | IMPLEMENTED |                                                    |
-| `OSC 111` | IMPLEMENTED |                                                    |
-| `OSC 112` | IMPLEMENTED |                                                    |
+| ESCAPE     | STATUS      | NOTE                                               |
+| ---------- | ----------- | -------------------------------------------------- |
+| `OSC 0`    | IMPLEMENTED | Icon names are not supported                       |
+| `OSC 1`    | REJECTED    | Icon names are not supported                       |
+| `OSC 2`    | IMPLEMENTED |                                                    |
+| `OSC 4`    | IMPLEMENTED |                                                    |
+| `OSC 10`   | IMPLEMENTED |                                                    |
+| `OSC 11`   | IMPLEMENTED |                                                    |
+| `OSC 12`   | IMPLEMENTED |                                                    |
+| `OSC 50`   | IMPLEMENTED | Only `CursorShape` is supported                    |
+| `OSC 52`   | IMPLEMENTED | Only Clipboard and primary selection supported     |
+| `OSC 104`  | IMPLEMENTED |                                                    |
+| `OSC 110`  | IMPLEMENTED |                                                    |
+| `OSC 111`  | IMPLEMENTED |                                                    |
+| `OSC 112`  | IMPLEMENTED |                                                    |
+| `OSC 1337` | IMPLEMENTED |                                                    |
 
 ### DCS (Device Control String) - `ESC P`
 

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -81,21 +81,21 @@ brevity.
 
 ### OSC (Operating System Command) - `ESC ]`
 
-| ESCAPE     | STATUS      | NOTE                                               |
-| ---------- | ----------- | -------------------------------------------------- |
-| `OSC 0`    | IMPLEMENTED | Icon names are not supported                       |
-| `OSC 1`    | REJECTED    | Icon names are not supported                       |
-| `OSC 2`    | IMPLEMENTED |                                                    |
-| `OSC 4`    | IMPLEMENTED |                                                    |
-| `OSC 10`   | IMPLEMENTED |                                                    |
-| `OSC 11`   | IMPLEMENTED |                                                    |
-| `OSC 12`   | IMPLEMENTED |                                                    |
-| `OSC 50`   | IMPLEMENTED | Only `CursorShape` is supported                    |
-| `OSC 52`   | IMPLEMENTED | Only Clipboard and primary selection supported     |
-| `OSC 104`  | IMPLEMENTED |                                                    |
-| `OSC 110`  | IMPLEMENTED |                                                    |
-| `OSC 111`  | IMPLEMENTED |                                                    |
-| `OSC 112`  | IMPLEMENTED |                                                    |
+| ESCAPE    | STATUS      | NOTE                                               |
+| --------- | ----------- | -------------------------------------------------- |
+| `OSC 0`   | IMPLEMENTED | Icon names are not supported                       |
+| `OSC 1`   | REJECTED    | Icon names are not supported                       |
+| `OSC 2`   | IMPLEMENTED |                                                    |
+| `OSC 4`   | IMPLEMENTED |                                                    |
+| `OSC 10`  | IMPLEMENTED |                                                    |
+| `OSC 11`  | IMPLEMENTED |                                                    |
+| `OSC 12`  | IMPLEMENTED |                                                    |
+| `OSC 50`  | IMPLEMENTED | Only `CursorShape` is supported                    |
+| `OSC 52`  | IMPLEMENTED | Only Clipboard and primary selection supported     |
+| `OSC 104` | IMPLEMENTED |                                                    |
+| `OSC 110` | IMPLEMENTED |                                                    |
+| `OSC 111` | IMPLEMENTED |                                                    |
+| `OSC 112` | IMPLEMENTED |                                                    |
 
 ### DCS (Device Control String) - `ESC P`
 


### PR DESCRIPTION
> Please make sure to document all user-facing changes in the
> `CHANGELOG.md` file.

Done

> If support for a new escape sequence was added, it should be documented
> in `./docs/escape_support.md`.

Done
note: `CSI ? 12 h` and `CSI ? 12 l` were already marked as supported.

The default blinking rate is 500ms hide -> 500ms show -> …

TODO:
- [x] wether to blink or not by default
- [x] start blinking at startup if configuration says so
- [x] start or stop blinking at vi/normal mode change according to configuration
- [x] handle `CSI 1/3/5 SP q` (set cursor style to blinking block/underline/bar)
- [x] make the "blinking cursor" an option on each cursor style instead of separate new styles
- [x] make the vi cursor blink too

Optionally:
- [x] the blinking rate
- [x] completely disable blinking (ignore escape sequences), possibly by setting the rate to `0`
- [x] reinitialize the blinking cycle on user input
- (?) allow different blinking rate for the default cursor and vi cursor

Fixes #302 