### PR TITLE
Set default FreeType properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preservation of the alternate screen's saved cursor when swapping to primary screen and back
 - Reflow of cursor during resize
 - Cursor color escape ignored when its color is set to inverted in the config
+- Fontconfig's `autohint` and `hinting` options being ignored
+- Ingoring of default FreeType properties
 
 ## 0.4.3
 

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -494,16 +494,17 @@ impl FreeTypeRasterizer {
         let antialias = pattern.antialias().next().unwrap_or(true);
         let autohint = pattern.autohint().next().unwrap_or(false);
         let hinting = pattern.hinting().next().unwrap_or(true);
-        let mut hintstyle = pattern.hintstyle().next().unwrap_or(fc::HintStyle::Full);
         let rgba = pattern.rgba().next().unwrap_or(fc::Rgba::Unknown);
         let embedded_bitmaps = pattern.embeddedbitmap().next().unwrap_or(true);
         let scalable = pattern.scalable().next().unwrap_or(true);
         let color = pattern.color().next().unwrap_or(false);
 
         // Disable hinting if so was requested.
-        if !hinting {
-            hintstyle = fc::HintStyle::None;
-        }
+        let hintstyle = if hinting {
+            pattern.hintstyle().next().unwrap_or(fc::HintStyle::Full)
+        } else {
+            hintstyle = fc::HintStyle::None
+        };
 
         let mut flags = match (antialias, hintstyle, rgba) {
             (false, fc::HintStyle::None, _) => LoadFlag::NO_HINTING | LoadFlag::MONOCHROME,

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -503,13 +503,13 @@ impl FreeTypeRasterizer {
         let hintstyle = if hinting {
             pattern.hintstyle().next().unwrap_or(fc::HintStyle::Full)
         } else {
-            hintstyle = fc::HintStyle::None
+            fc::HintStyle::None
         };
 
         let mut flags = match (antialias, hintstyle, rgba) {
             (false, fc::HintStyle::None, _) => LoadFlag::NO_HINTING | LoadFlag::MONOCHROME,
             (false, ..) => LoadFlag::TARGET_MONO | LoadFlag::MONOCHROME,
-            (true, fc::HintStyle::None, _) => LoadFlag::NO_HINTING | LoadFlag::TARGET_NORMAL,
+            (true, fc::HintStyle::None, _) => LoadFlag::NO_HINTING,
             // `hintslight` does *not* use LCD hinting even when a subpixel mode
             // is selected.
             //
@@ -528,11 +528,13 @@ impl FreeTypeRasterizer {
             (true, fc::HintStyle::Medium, _) => LoadFlag::TARGET_NORMAL,
             // If LCD hinting is to be used, must select hintmedium or hintfull,
             // have AA enabled, and select a subpixel mode.
-            (true, _, fc::Rgba::Rgb) | (true, _, fc::Rgba::Bgr) => LoadFlag::TARGET_LCD,
-            (true, _, fc::Rgba::Vrgb) | (true, _, fc::Rgba::Vbgr) => LoadFlag::TARGET_LCD_V,
+            (true, fc::HintStyle::Full, fc::Rgba::Rgb)
+            | (true, fc::HintStyle::Full, fc::Rgba::Bgr) => LoadFlag::TARGET_LCD,
+            (true, fc::HintStyle::Full, fc::Rgba::Vrgb)
+            | (true, fc::HintStyle::Full, fc::Rgba::Vbgr) => LoadFlag::TARGET_LCD_V,
             // For non-rgba modes with Full hinting, just use the default hinting algorithm.
-            (true, _, fc::Rgba::Unknown) => LoadFlag::TARGET_NORMAL,
-            (true, _, fc::Rgba::None) => LoadFlag::TARGET_NORMAL,
+            (true, fc::HintStyle::Full, fc::Rgba::Unknown)
+            | (true, fc::HintStyle::Full, fc::Rgba::None) => LoadFlag::TARGET_NORMAL,
         };
 
         // Non scalable fonts only have bitmaps, so disabling them entirely is likely not a


### PR DESCRIPTION
In addition it also starts respecting Fontconfig's `autohint`
and `hinting` options.

Fixes #3534.
