### PR TITLE
Add a config option to disable vsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `gopher` and `gemini` URLs
 - Unicode 13 support
 - Option to run command on bell which can be set in `bell.command`
+- Option `window.disable_vsync` to explicitly disable vsync
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -78,6 +78,13 @@
   # Set this to `None` to use the default theme variant.
   #gtk_theme_variant: None
 
+  # Disable vsync (changes require restart)
+  #
+  # Force to disable vsync, what can improve the input latency but can also add tearing.
+  # A worse throughput performance is also expected by disabling the vsync (about 35% slower).
+  # On Wayland, vsync is always disabled, setting this option has no effect.
+  #disable_vsync: false
+
 #scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -58,6 +58,10 @@ pub struct WindowConfig {
     /// Use dynamic title.
     #[serde(default, deserialize_with = "failure_default")]
     dynamic_title: DefaultTrueBool,
+
+    /// Disable vsync.
+    #[serde(deserialize_with = "failure_default")]
+    pub disable_vsync: bool,
 }
 
 pub fn default_title() -> String {
@@ -90,6 +94,7 @@ impl Default for WindowConfig {
             gtk_theme_variant: Default::default(),
             title: default_title(),
             dynamic_title: Default::default(),
+            disable_vsync: Default::default(),
         }
     }
 }

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -604,7 +604,7 @@ impl Display {
 
         #[cfg(not(any(target_os = "macos", windows)))]
         {
-            if self.is_x11 {
+            if self.is_x11 && !config.ui_config.window.disable_vsync {
                 // On X11 `swap_buffers` does not block for vsync. However the next OpenGl command
                 // will block to synchronize (this is `glClear` in Alacritty), which causes a
                 // permanent one frame delay.

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -159,9 +159,9 @@ impl Window {
 
         // Disable vsync on Wayland.
         #[cfg(not(any(target_os = "macos", windows)))]
-        let vsync = !event_loop.is_wayland();
+        let vsync = !window_config.disable_vsync && !event_loop.is_wayland();
         #[cfg(any(target_os = "macos", windows))]
-        let vsync = true;
+        let vsync = !window_config.disable_vsync;
 
         let windowed_context =
             create_gl_window(window_builder.clone(), &event_loop, false, vsync, size)


### PR DESCRIPTION
Disabling vsync can be useful to improve input latency.  In some cases, having vsync in alacritty can be redundant, for example when using a compositor that already handles vsync.

Default is to let the vsync on, but can be explicitely disabled by the user in the config via the `window.disable_vsync` option.