### PR TITLE
Fix movement within search matches

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -534,8 +534,8 @@
 #   - ToggleSemanticSelection
 #   - SearchNext
 #   - SearchPrevious
-#   - SearchEndNext
-#   - SearchEndPrevious
+#   - SearchStart
+#   - SearchEnd
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -218,10 +218,10 @@ pub enum ViAction {
     SearchNext,
     /// Jump to the beginning of the previous match.
     SearchPrevious,
-    /// Jump to the end of the next match.
-    SearchEndNext,
-    /// Jump to the end of the previous match.
-    SearchEndPrevious,
+    /// Jump to the next start of a match to the left of the origin.
+    SearchStart,
+    /// Jump to the next end of a match to the right of the origin.
+    SearchEnd,
     /// Launch the URL below the vi mode cursor.
     Open,
 }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -208,20 +208,16 @@ impl<T: EventListener> Execute<T> for Action {
                     ctx.terminal_mut().vi_goto_point(*regex_match.start());
                 }
             },
-            Action::ViAction(ViAction::SearchEndNext) => {
+            Action::ViAction(ViAction::SearchStart) => {
                 let origin = ctx.terminal().visible_to_buffer(ctx.terminal().vi_mode_cursor.point);
-                let direction = ctx.search_direction();
-
-                let regex_match = ctx.terminal().search_next(origin, direction, Side::Right, None);
+                let regex_match = ctx.terminal().search_next(origin, Side::Left, Side::Left, None);
                 if let Some(regex_match) = regex_match {
-                    ctx.terminal_mut().vi_goto_point(*regex_match.end());
+                    ctx.terminal_mut().vi_goto_point(*regex_match.start());
                 }
             },
-            Action::ViAction(ViAction::SearchEndPrevious) => {
+            Action::ViAction(ViAction::SearchEnd) => {
                 let origin = ctx.terminal().visible_to_buffer(ctx.terminal().vi_mode_cursor.point);
-                let direction = ctx.search_direction().opposite();
-
-                let regex_match = ctx.terminal().search_next(origin, direction, Side::Right, None);
+                let regex_match = ctx.terminal().search_next(origin, Side::Right, Side::Right, None);
                 if let Some(regex_match) = regex_match {
                     ctx.terminal_mut().vi_goto_point(*regex_match.end());
                 }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -209,15 +209,17 @@ impl<T: EventListener> Execute<T> for Action {
                 }
             },
             Action::ViAction(ViAction::SearchStart) => {
-                let origin = ctx.terminal().visible_to_buffer(ctx.terminal().vi_mode_cursor.point);
-                let regex_match = ctx.terminal().search_next(origin, Side::Left, Side::Left, None);
+                let terminal = ctx.terminal();
+                let origin = terminal.visible_to_buffer(ctx.terminal().vi_mode_cursor.point);
+                let regex_match = terminal.search_next(origin, Direction::Left, Side::Left, None);
                 if let Some(regex_match) = regex_match {
                     ctx.terminal_mut().vi_goto_point(*regex_match.start());
                 }
             },
             Action::ViAction(ViAction::SearchEnd) => {
-                let origin = ctx.terminal().visible_to_buffer(ctx.terminal().vi_mode_cursor.point);
-                let regex_match = ctx.terminal().search_next(origin, Side::Right, Side::Right, None);
+                let terminal = ctx.terminal();
+                let origin = terminal.visible_to_buffer(ctx.terminal().vi_mode_cursor.point);
+                let regex_match = terminal.search_next(origin, Direction::Right, Side::Right, None);
                 if let Some(regex_match) = regex_match {
                     ctx.terminal_mut().vi_goto_point(*regex_match.end());
                 }


### PR DESCRIPTION
Previously the SearchEndNext and SearchEndPrevious match acted exactly
like the SearchNext and SearchPrevious action, however this is not how
vim works. In vim, regardless of direction the `gN` action always jumps
to the next match start to the left of the cursor, while the `gn` action
always jumps to the next search end to the right of the cursor.

While both approaches might seem reasonable at first, vim's approach has
a significant advantage w.r.t. predictability and automation of the
movement. By always knowing which direction the motion goes to, this
allows for mappings that reliably navigate inside the current match
regardless of the global search direction. So deleting until the end of
the match would always be `dgn` for example, regardless in which
direction the user has jumped to it.

Fixes #3953.
