### PR TITLE
Bump version to 0.5.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0-dev
+## 0.5.0-rc1
 
 ### Packaging
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "alacritty"
-version = "0.5.0-dev"
+version = "0.5.0-rc1"
 dependencies = [
- "alacritty_terminal 0.5.0-dev",
+ "alacritty_terminal 0.5.0-rc1",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.5.0-dev"
+version = "0.5.0-rc1"
 dependencies = [
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.5.0-dev"
+version = "0.5.0-rc1"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "GPU-accelerated terminal emulator"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.5.0-dev"
+version = "0.5.0-rc1"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -1,4 +1,4 @@
-.TH ALACRITTY "1" "August 2018" "alacritty 0.5.0-dev" "User Commands"
+.TH ALACRITTY "1" "August 2018" "alacritty 0.5.0-rc1" "User Commands"
 .SH NAME
 alacritty \- a cross-platform, gpu-accelerated terminal emulator
 .SH "SYNOPSIS"

--- a/extra/linux/io.alacritty.Alacritty.appdata.xml
+++ b/extra/linux/io.alacritty.Alacritty.appdata.xml
@@ -28,7 +28,7 @@ However, it does allow configuration of many aspects of the terminal.</p>
   <url type="homepage">https://github.com/alacritty/alacritty</url>
   <url type="bugtracker">https://github.com/alacritty/alacritty/issues</url>
   <releases>
-    <release version="0.5.0-dev" date="2019-06-16" unix_timestamp="1560694196"/>
+    <release version="0.5.0-rc1" date="2019-06-16" unix_timestamp="1560694196"/>
   </releases>
   <update_contact>https://github.com/alacritty/alacritty/blob/master/CONTRIBUTING.md#contact</update_contact>
   <developer_name>Joe Wilm</developer_name>

--- a/extra/linux/redhat/alacritty.spec
+++ b/extra/linux/redhat/alacritty.spec
@@ -1,5 +1,5 @@
 Name:          alacritty
-Version:       0.5.0-dev
+Version:       0.5.0-rc1
 Release:       1%{?dist}
 Summary:       A cross-platform, GPU enhanced terminal emulator
 License:       ASL 2.0

--- a/extra/linux/snap/snapcraft.yaml
+++ b/extra/linux/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: alacritty
-version: '0.5.0-dev'
+version: '0.5.0-rc1'
 summary: Modern, GPU accelerated terminal emulator
 description: |
   Alacritty is a terminal emulator with a strong focus on simplicity and

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.5.0-dev</string>
+  <string>0.5.0-rc1</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>

--- a/extra/windows/wix/alacritty.wxs
+++ b/extra/windows/wix/alacritty.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
-    <Product Name="Alacritty" Id="*" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.5.0-dev" Manufacturer="Alacritty">
+    <Product Name="Alacritty" Id="*" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.5.0-rc1" Manufacturer="Alacritty">
         <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine"/>
         <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed."/>
         <Icon Id="AlacrittyIco" SourceFile="..\extra\windows\alacritty.ico"/>


### PR DESCRIPTION
Fixed version of https://github.com/alacritty/alacritty/pull/3980 against the correct branch.