### PR TITLE
Remove Ubuntu PPA installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,6 @@ zypper in alacritty
 
 ### Pop!\_OS
 
-> **Since this requires a Pop!\_OS specific PPA, it will not work on other Ubuntu
-> distributions.**
-
 ```sh
 apt install alacritty
 ```

--- a/README.md
+++ b/README.md
@@ -95,13 +95,10 @@ nix-env -iA nixos.alacritty
 zypper in alacritty
 ```
 
-### Pop!\_OS / Ubuntu
+### Pop!\_OS
 
-> If you're not running Pop!_OS, you'll have to add a third party repository first:
->
-> ```sh
-> add-apt-repository ppa:mmstick76/alacritty
-> ```
+> **Since this requires a Pop!\_OS specific PPA, it will not work on other Ubuntu
+> distributions.**
 
 ```sh
 apt install alacritty


### PR DESCRIPTION
Since the Ubuntu PPA from mmstick is apparently not maintained anymore,
people should no longer be instructed to install the outdated version
that is available from the PPA.

The System76 PPA repository still contains an up to date version of
Alacritty, but since it also comes with several other packages we cannot
recommend users to install it outside of Pop!_OS.

Fixes #3863.
