### PR TITLE
Bump alacritty_terminal version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,9 @@ Please make sure to document all user-facing changes in the
 If support for a new escape sequence was added, it should be documented
 in `./docs/escape_support.md`.
 
+Since `alacritty_terminal`'s version always tracks the next release, make sure
+that the version is bumped according to semver when necessary.
+
 Draft PRs are always welcome, though unless otherwise requested PRs will
 not be reviewed until all required and optional CI steps are successful
 and they have left the draft stage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ issues.
 Please note that the minimum supported version of Alacritty is Rust 1.41.0. All patches are expected
 to work with the minimum supported version.
 
-If you have made any breaking changes to `alacritty_terminal`, make sure to bump its version
-according to semver.
+Since `alacritty_terminal`'s version always tracks the next release, make sure that the version is
+bumped according to semver when necessary.
 
 ### Testing
 
@@ -131,10 +131,11 @@ The exact steps for an exemplary `0.2.0` release might look like this:
      major issues are found in the release candidates
   9. In the branch, the version is bumped to `0.2.0`
  10. The new commit in the branch is tagged as `v0.2.0`
- 11. A GitHub release is created for the `v0.2.0` tag
- 12. The changelog since the last stable release (**not** RC) is added to the GitHub release
+ 11. The new version is published to crates.io
+ 12. A GitHub release is created for the `v0.2.0` tag
+ 13. The changelog since the last stable release (**not** RC) is added to the GitHub release
      description
- 13. The `-dev` is stripped from the `0.2.0-dev` changelog entries on master
+ 14. The `-dev` is stripped from the `0.2.0-dev` changelog entries on master
 
 On master and with new planned releases, only the minor version is bumped. This makes it possible to
 create bug fix releases by incrementing the patch version of a previous minor release, without
@@ -148,11 +149,11 @@ The exact steps for an exemplary `0.2.3` release might look like this:
  6. Follow Steps 5-12 of the regular release's example
  7. The release's changelog is ported back to master, removing fixes from the `0.2.3` release
 
-The `alacritty_terminal` crate follows the same process as `alacritty`, tagging its releases as
-`-dev` and `-rc1` at the same time as the `alacritty` crate. New releases are tagged as
-`alacritty_terminal_vX.Y.Z` whenever a new Alacritty stable release is made. Versions are always
-bumped based on semver, increasing just the patch version until there is a breaking change or new
-feature introduced.
+The `alacritty_terminal` crate is released in synchronization with `alacritty`, keeping the `-dev`
+and `-rcX` version suffix identical across the two crates. As soon as the new Alacritty stable
+release is made, releases are tagged as `alacritty_terminal_vX.Y.Z` and pushed to crates.io. During
+a release, only the patch version is bumped on master, since there haven't been any changes since
+the last release yet.
 
 # Contact
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,9 @@ issues.
 Please note that the minimum supported version of Alacritty is Rust 1.41.0. All patches are expected
 to work with the minimum supported version.
 
+If you have made any breaking changes to `alacritty_terminal`, make sure to bump its version
+according to semver.
+
 ### Testing
 
 To make sure no regressions were introduced, all tests should be run before sending a pull request.
@@ -144,6 +147,12 @@ The exact steps for an exemplary `0.2.3` release might look like this:
  5. The version is bumped to `v0.2.3-rc1` and the changelog is updated to include all fixes
  6. Follow Steps 5-12 of the regular release's example
  7. The release's changelog is ported back to master, removing fixes from the `0.2.3` release
+
+The `alacritty_terminal` crate follows the same process as `alacritty`, tagging its releases as
+`-dev` and `-rc1` at the same time as the `alacritty` crate. New releases are tagged as
+`alacritty_terminal_vX.Y.Z` whenever a new Alacritty stable release is made. Versions are always
+bumped based on semver, increasing just the patch version until there is a breaking change or new
+feature introduced.
 
 # Contact
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 name = "alacritty"
 version = "0.5.0-dev"
 dependencies = [
- "alacritty_terminal 0.10.0",
+ "alacritty_terminal 0.10.0-dev",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossfont 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.10.0"
+version = "0.10.0-dev"
 dependencies = [
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 name = "alacritty"
 version = "0.5.0-dev"
 dependencies = [
- "alacritty_terminal 0.5.0-dev",
+ "alacritty_terminal 0.10.0",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossfont 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.5.0-dev"
+version = "0.10.0"
 dependencies = [
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -8,8 +8,12 @@ readme = "../README.md"
 homepage = "https://github.com/alacritty/alacritty"
 edition = "2018"
 
+[dependencies.alacritty_terminal]
+path = "../alacritty_terminal"
+version = "0.10.0-dev"
+default-features = false
+
 [dependencies]
-alacritty_terminal = { path = "../alacritty_terminal", default-features = false }
 clap = "2"
 log = { version = "0.4", features = ["std"] }
 time = "0.1.40"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.10.0"
+version = "0.10.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.5.0-dev"
+version = "0.10.0"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"


### PR DESCRIPTION
This change bumps the version of the `alacritty_terminal` crate to force
it out of sync with the Alacritty application. Since it is a library
that will be published on crates.io, it should be following semver
rather than our binary's release version.

While it would be possible to just keep it at 0.5.0 and remove the
`-dev` suffix, explicitly disconnecting it from the Alacritty version
should give it a clean starting-off point and prevent unnecessary
confusion. Bumping it to 0.10.0 instead of something like 0.6.0 should
allow for a nice gap between the different versions without being too
arbitrary. Changing the version to 0.1.0 or something similar is not an
option since decreasing semver version would likely cause a lot of
problems.

While it would be possible to further separate the Alacritty terminal
library from the Alacritty terminal emulator, by renaming it from
`alacritty_terminal` to something different, I don't think that is
necessary or a good idea at the moment. While the `alacritty_terminal`
library *can* be used for other terminals, its primary goal is still to
support the Alacritty terminal emulator and I don't see that changing.
So making that clear in its name seems like a good idea. Since there is
no plan to maintain this library separately from Alacritty, but to keep
both tied together, the naming should reflect this.