### PR TITLE
Add secondary DA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.6.0-dev
 
+### Added
+
+- Secondary device attributes escape (`CSI > 0 c`)
+
 ## 0.5.0-dev
 
 ### Packaging

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1499,14 +1499,14 @@ impl<T: EventListener> Handler for Term<T> {
     fn identify_terminal<W: io::Write>(&mut self, writer: &mut W, intermediate: Option<char>) {
         match intermediate {
             None => {
-                println!("Reporting primary device attributes");
+                trace!("Reporting primary device attributes");
                 let _ = writer.write_all(b"\x1b[?6c");
             },
             Some('>') => {
-                println!("Reporting secondary device attributes");
+                trace!("Reporting secondary device attributes");
                 let _ = writer.write_all(format!("\x1b[>0;{};1c", version_number()).as_bytes());
             },
-            _ => println!("Unsupported device attributes intermediate"),
+            _ => debug!("Unsupported device attributes intermediate"),
         }
     }
 

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -43,7 +43,7 @@ brevity.
 | `CSI B`    | IMPLEMENTED |                                                   |
 | `CSI b`    | IMPLEMENTED |                                                   |
 | `CSI C`    | IMPLEMENTED |                                                   |
-| `CSI c`    | PARTIAL     | No parameter support                              |
+| `CSI c`    | IMPLEMENTED |                                                   |
 | `CSI D`    | IMPLEMENTED |                                                   |
 | `CSI d`    | IMPLEMENTED |                                                   |
 | `CSI E`    | IMPLEMENTED |                                                   |


### PR DESCRIPTION
This adds support for the secondary DA escape sequence response.
Alacritty's version is formatted allowing for up to 99 minor and patch
versions, which should be sufficient.

The tertiary DA is intentionally not implemented and marked as rejected
in the documentation, since a lot of terminals do not support it, or
report useless data (XTerm/URxvt/Kitty).

Fixes #3100.