### PR TITLE
Invert fixed color cursor if it matches cell bg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Cursors are now inverted when their fixed color matches the cell's background
+- Cursors are now inverted when their fixed color is similar to the cell's background
 
 ## 0.5.0-dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Secondary device attributes escape (`CSI > 0 c`)
 
+### Changed
+
+- Cursors are now inverted when their fixed color matches the cell's background
+
 ## 0.5.0-dev
 
 ### Packaging

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -424,10 +424,10 @@ mod tests {
 
         let rgb1 = Rgb { r: 0xff, g: 0x00, b: 0xff };
         let rgb2 = Rgb { r: 0x00, g: 0xff, b: 0x00 };
-        assert!((rgb1.contrast(rgb2) - 2.2855436081242533).abs() < EPSILON);
+        assert!((rgb1.contrast(rgb2) - 2.285_543_608_124_253_3).abs() < EPSILON);
 
         let rgb1 = Rgb { r: 0x12, g: 0x34, b: 0x56 };
         let rgb2 = Rgb { r: 0xfe, g: 0xdc, b: 0xba };
-        assert!((rgb1.contrast(rgb2) - 9.78655899725774).abs() < EPSILON);
+        assert!((rgb1.contrast(rgb2) - 9.786_558_997_257_74).abs() < EPSILON);
     }
 }

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -28,7 +28,7 @@ pub struct Rgb {
 impl Rgb {
     /// Implementation of W3C's luminance algorithm:
     /// https://www.w3.org/TR/WCAG20/#relativeluminancedef
-    fn luminance(&self) -> f64 {
+    fn luminance(self) -> f64 {
         let channel_luminance = |channel| {
             let channel = channel as f64 / 255.;
             if channel <= 0.03928 {
@@ -47,7 +47,7 @@ impl Rgb {
 
     /// Implementation of W3C's contrast algorithm:
     /// https://www.w3.org/TR/WCAG20/#contrast-ratiodef
-    pub fn contrast(&self, other: Rgb) -> f64 {
+    pub fn contrast(self, other: Rgb) -> f64 {
         let self_luminance = self.luminance();
         let other_luminance = other.luminance();
 

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -411,21 +411,23 @@ impl IndexMut<u8> for List {
 mod tests {
     use super::*;
 
+    use std::f64::EPSILON;
+
     #[test]
     fn contrast() {
         let rgb1 = Rgb { r: 0xff, g: 0xff, b: 0xff };
         let rgb2 = Rgb { r: 0x00, g: 0x00, b: 0x00 };
-        assert!((rgb1.contrast(rgb2) - 21.).abs() < f64::EPSILON);
+        assert!((rgb1.contrast(rgb2) - 21.).abs() < EPSILON);
 
         let rgb1 = Rgb { r: 0xff, g: 0xff, b: 0xff };
-        assert!((rgb1.contrast(rgb1) - 1.).abs() < f64::EPSILON);
+        assert!((rgb1.contrast(rgb1) - 1.).abs() < EPSILON);
 
         let rgb1 = Rgb { r: 0xff, g: 0x00, b: 0xff };
         let rgb2 = Rgb { r: 0x00, g: 0xff, b: 0x00 };
-        assert!((rgb1.contrast(rgb2) - 2.2855436081242533).abs() < f64::EPSILON);
+        assert!((rgb1.contrast(rgb2) - 2.2855436081242533).abs() < EPSILON);
 
         let rgb1 = Rgb { r: 0x12, g: 0x34, b: 0x56 };
         let rgb2 = Rgb { r: 0xfe, g: 0xdc, b: 0xba };
-        assert!((rgb1.contrast(rgb2) - 9.78655899725774).abs() < f64::EPSILON);
+        assert!((rgb1.contrast(rgb2) - 9.78655899725774).abs() < EPSILON);
     }
 }

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -26,6 +26,8 @@ pub struct Rgb {
 }
 
 impl Rgb {
+    /// Implementation of W3C's luminance algorithm:
+    /// https://www.w3.org/TR/WCAG20/#relativeluminancedef
     fn luminance(&self) -> f64 {
         let channel_luminance = |channel| {
             let channel = channel as f64 / 255.;
@@ -43,6 +45,8 @@ impl Rgb {
         0.2126 * r_luminance + 0.7152 * g_luminance + 0.0722 * b_luminance
     }
 
+    /// Implementation of W3C's contrast algorithm:
+    /// https://www.w3.org/TR/WCAG20/#contrast-ratiodef
     pub fn contrast(&self, other: Rgb) -> f64 {
         let self_luminance = self.luminance();
         let other_luminance = other.luminance();

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -398,7 +398,7 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                     let mut cell = RenderableCell::new(self, cell);
 
                     if self.cursor.key.style == CursorStyle::Block {
-                        // Invert cursor if static background matches the cell's background.
+                        // Invert cursor if static background is close to the cell's background.
                         match self.cursor.cursor_color {
                             CellRgb::Rgb(col) if col.contrast(cell.bg) >= MIN_CURSOR_CONTRAST => {
                                 cell.fg = self.cursor.text_color.color(cell.fg, cell.bg);
@@ -422,7 +422,7 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                     let mut cell = RenderableCell::new(self, cell);
                     cell.inner = RenderableCellContent::Cursor(self.cursor.key);
 
-                    // Only apply static color if it doesn't match the cell's current background.
+                    // Only apply static color if it isn't close to the cell's current background.
                     if let CellRgb::Rgb(color) = self.cursor.cursor_color {
                         if color.contrast(cell.bg) >= MIN_CURSOR_CONTRAST {
                             cell.fg = self.cursor.cursor_color.color(cell.fg, cell.bg);


### PR DESCRIPTION
This should reduce the number of times people with fixed cursor colors
run into troubles when existing text is already colored.

Using just the background color as a metric instead of both background
and foreground color should ensure that the cursor still has a clear
shape, since just changing the foreground color for a cursor might be
difficult to see. Always inverting the entire cursor instead of keeping
the fixed foreground color is important to make sure the contrast isn't
messed up.

Fixes #4016.