### PR TITLE
Fix CellForeground and CellBackground cursor colors

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -399,8 +399,8 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
 
                     if self.cursor.key.style == CursorStyle::Block {
                         cell.fg = match self.cursor.cursor_color {
-                            // Invert cursor if static background is close to the cell's
-                            // background.
+                            // Apply cursor color, or invert the cursor if it has a fixed background
+                            // close to the cell's background.
                             CellRgb::Rgb(col) if col.contrast(cell.bg) < MIN_CURSOR_CONTRAST => {
                                 cell.bg
                             },
@@ -423,8 +423,8 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                     let mut cell = RenderableCell::new(self, cell);
                     cell.inner = RenderableCellContent::Cursor(self.cursor.key);
 
-                    // Only apply static color if it isn't close to the cell's current
-                    // background or refers to cell colors.
+                    // Apply cursor color, or invert the cursor if it has a fixed background close
+                    // to the cell's background.
                     match self.cursor.cursor_color {
                         CellRgb::Rgb(color) if color.contrast(cell.bg) < MIN_CURSOR_CONTRAST => (),
                         _ => cell.fg = self.cursor.cursor_color.color(cell.fg, cell.bg),

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -423,14 +423,12 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                     let mut cell = RenderableCell::new(self, cell);
                     cell.inner = RenderableCellContent::Cursor(self.cursor.key);
 
-                    cell.fg = match self.cursor.cursor_color {
-                        // Only apply static color if it isn't close to the cell's current
-                        // background.
-                        CellRgb::Rgb(color) if color.contrast(cell.bg) < MIN_CURSOR_CONTRAST => {
-                            cell.fg
-                        },
-                        _ => self.cursor.cursor_color.color(cell.fg, cell.bg),
-                    };
+                    // Only apply static color if it isn't close to the cell's current
+                    // background or refers to cell colors.
+                    match self.cursor.cursor_color {
+                        CellRgb::Rgb(color) if color.contrast(cell.bg) < MIN_CURSOR_CONTRAST => (),
+                        _ => cell.fg = self.cursor.cursor_color.color(cell.fg, cell.bg),
+                    }
 
                     return Some(cell);
                 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -399,17 +399,12 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
 
                     if self.cursor.key.style == CursorStyle::Block {
                         cell.fg = match self.cursor.cursor_color {
-                            CellRgb::Rgb(col) => {
-                                // Invert cursor if static background is close to the cell's
-                                // background.
-                                if col.contrast(cell.bg) >= MIN_CURSOR_CONTRAST {
-                                    self.cursor.text_color.color(cell.fg, cell.bg)
-                                } else {
-                                    cell.bg
-                                }
+                            // Invert cursor if static background is close to the cell's
+                            // background.
+                            CellRgb::Rgb(col) if col.contrast(cell.bg) < MIN_CURSOR_CONTRAST => {
+                                cell.bg
                             },
-                            CellRgb::CellForeground => cell.fg,
-                            CellRgb::CellBackground => cell.bg,
+                            _ => self.cursor.text_color.color(cell.fg, cell.bg),
                         };
                     }
 
@@ -429,17 +424,12 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                     cell.inner = RenderableCellContent::Cursor(self.cursor.key);
 
                     cell.fg = match self.cursor.cursor_color {
-                        CellRgb::Rgb(color) => {
-                            // Only apply static color if it isn't close to the cell's current
-                            // background.
-                            if color.contrast(cell.bg) >= MIN_CURSOR_CONTRAST {
-                                self.cursor.cursor_color.color(cell.fg, cell.bg)
-                            } else {
-                                cell.fg
-                            }
+                        // Only apply static color if it isn't close to the cell's current
+                        // background.
+                        CellRgb::Rgb(color) if color.contrast(cell.bg) < MIN_CURSOR_CONTRAST => {
+                            cell.fg
                         },
-                        CellRgb::CellForeground => cell.fg,
-                        CellRgb::CellBackground => cell.bg,
+                        _ => self.cursor.cursor_color.color(cell.fg, cell.bg),
                     };
 
                     return Some(cell);

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -403,7 +403,8 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                             CellRgb::Rgb(col) if col.contrast(cell.bg) >= MIN_CURSOR_CONTRAST => {
                                 cell.fg = self.cursor.text_color.color(cell.fg, cell.bg);
                             },
-                            _ => cell.fg = cell.bg,
+                            CellRgb::Rgb(_) => cell.fg = cell.bg,
+                            _ => cell.fg = self.cursor.text_color.color(cell.fg, cell.bg),
                         }
                     }
 
@@ -427,6 +428,8 @@ impl<'a, C> Iterator for RenderableCellsIter<'a, C> {
                         if color.contrast(cell.bg) >= MIN_CURSOR_CONTRAST {
                             cell.fg = self.cursor.cursor_color.color(cell.fg, cell.bg);
                         }
+                    } else {
+                        cell.fg = self.cursor.cursor_color.color(cell.fg, cell.bg);
                     }
 
                     return Some(cell);


### PR DESCRIPTION
This commit fixes regression introduced in
bedf5f3004e8f33011925ca471be02ead96f4581, when setting
certain CellForeground/CellBackground combinations stoppped working.

For example setting CellForeground for both foreground and background.

--
I do remember mentioning it on IRC, but I fall a sleep before commenting on PR and so it got merged, I guess.