### PR TITLE
Render wide characters correctly to avoid being cut off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cursors are now inverted when their fixed color is similar to the cell's background
 
+### Fixed
+
+- Wide characters (like cjk words) sometimes cut off
+
 ## 0.5.0-dev
 
 ### Packaging

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -30,6 +30,9 @@ layout (location = 4) in vec4 backgroundColor;
 // Set to 1 if the glyph colors should be kept.
 layout (location = 5) in int coloredGlyph;
 
+// Set to 1 if the glyph is a WIDE CHAR.
+layout (location = 6) in int isWideChar;
+
 out vec2 TexCoords;
 flat out vec3 fg;
 flat out vec4 bg;
@@ -56,7 +59,9 @@ void main()
     vec2 cellPosition = cellDim * gridCoords;
 
     if (backgroundPass != 0) {
-        vec2 finalPosition = cellPosition + cellDim * position;
+        vec2 dim = cellDim;
+        if (isWideChar != 0) { dim = vec2(dim.x*2, dim.y); }
+        vec2 finalPosition = cellPosition + dim * position;
         gl_Position = vec4(projectionOffset + projectionScale * finalPosition, 0.0, 1.0);
 
         TexCoords = vec2(0, 0);


### PR DESCRIPTION
The commit contains a realistically tested workaround with no performance impact.

I made a few necessary changes to the shaders in the GLSL code, fixing the
background width of the wide characters and skipping everything about spacer
handling (in fact, they shouldn't be displayed on the screen at all, either
foreground or background).

This should close #791, cc #4038.