### PR TITLE
Add note regarding release tags

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,13 @@ git clone https://github.com/alacritty/alacritty.git
 cd alacritty
 ```
 
+You may then also want to pick a specific (stable) release to compile, e.g.:
+
+```sh
+git tag
+git checkout v0.5.0
+```
+
 ### Install the Rust compiler with `rustup`
 
 1. Install [`rustup.rs`](https://rustup.rs/).


### PR DESCRIPTION
I think this is worth mentioning, now that more Linux users may decide to build from source themselves. They likely want to pick a stable release and not the current state of `master`.