### PR TITLE
Fix travis release deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,9 @@ deploy:
     on:
       tags: true
       rust: stable
-      condition: $CLIPPY != true
+      condition:
+        - $CLIPPY != true
+        - "$TRAVIS_TAG" =~ ^v[0-9]*\.[0-9]*\.[0-9]*$
       repo: alacritty/alacritty
   - provider: releases
     api_key:
@@ -67,5 +69,7 @@ deploy:
     on:
       tags: true
       rust: stable-x86_64-pc-windows-msvc
-      condition: $CLIPPY != true
+      condition:
+        - $CLIPPY != true
+        - "$TRAVIS_TAG" =~ ^v[0-9]*\.[0-9]*\.[0-9]*$
       repo: alacritty/alacritty

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ deploy:
       rust: stable
       condition:
         - $CLIPPY != true
-        - "$TRAVIS_TAG" =~ ^v[0-9]*\.[0-9]*\.[0-9]*$
+        - $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$
       repo: alacritty/alacritty
   - provider: releases
     api_key:
@@ -71,5 +71,5 @@ deploy:
       rust: stable-x86_64-pc-windows-msvc
       condition:
         - $CLIPPY != true
-        - "$TRAVIS_TAG" =~ ^v[0-9]*\.[0-9]*\.[0-9]*$
+        - $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$
       repo: alacritty/alacritty


### PR DESCRIPTION
This resolves an issue with travis release deployment where tags would
cause a release deployment even if the tag did not match the `vX.Y.Z`
format.