### PR TITLE
Fix negative window position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Cursors are now inverted when their fixed color is similar to the cell's background
 
+### Fixed
+
+- Incorrect window location with negative `window.position` config options
+
 ## 0.5.0
 
 ### Packaging

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -334,7 +334,7 @@ impl Window {
     #[cfg(windows)]
     pub fn set_urgent(&self, _is_urgent: bool) {}
 
-    pub fn set_outer_position(&self, pos: PhysicalPosition<u32>) {
+    pub fn set_outer_position(&self, pos: PhysicalPosition<i32>) {
         self.window().set_outer_position(pos);
     }
 


### PR DESCRIPTION
This resolves an issue where negative window positions set in the
configuration file would not place the Alacritty window in the correct
location.

Fixes #4061.
