### PR TITLE
Add installation instructions for Ubuntu based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ apt install alacritty
 eopkg install alacritty
 ```
 
+### Ubuntu
+
+```sh
+sudo add-apt-repository ppa:mmstick76/alacritty
+sudo apt update
+sudo apt install alacritty
+```
+
 ### Void Linux
 
 ```sh


### PR DESCRIPTION
Hey guys! 

First thing, thanks to the contributors who works on the project! I love this terminal so muich! 

I just noticed that there were no instructions on how to install `alacritty` on a Ubuntu-based distribution other than Pop!_OS. 

So here it is! 