### PR TITLE
Added search field to key-bindings

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -587,6 +587,17 @@
 #    `args` array of command line parameter strings. For example:
 #       `{ program: "alacritty", args: ["-e", "vttest"] }`
 #
+# - 'search': Search the buffer either forwards (default) or backwards for a string
+#
+#   The search field can be either a string or a map containing a regex `string` and
+#   `direction` string specifying one of "Right" | "Forward" | "Left" | "Backward". For example:
+#       `"http.?:"` or
+#       `{ string: "http.?", direction: "Backward" }`
+#
+#   If the string is empty a prompt is triggered for input. For example:
+#       `""` or
+#       `{ string: "", direction: "Backward" }`
+#
 # And optionally:
 #
 # - `mods`: Key modifiers to filter binding actions

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -714,7 +714,8 @@ impl<'a> Deserialize<'a> for RawBinding {
     where
         D: Deserializer<'a>,
     {
-        const FIELDS: &[&str] = &["key", "mods", "mode", "action", "chars", "mouse", "command", "search"];
+        const FIELDS: &[&str] =
+            &["key", "mods", "mode", "action", "chars", "mouse", "command", "search"];
 
         enum Field {
             Key,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -351,22 +351,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
     }
 
-    /*
-    #[inline]
-    fn string_search(&mut self, string:String, direction: Direction) {
-        self.start_search(direction);
-        self.search_state.regex = Some(string);
-        self.update_search();
-
-        // submit the search in Vi mode or exit the search
-        if self.terminal.mode().contains(TermMode::VI) {
-            self.confirm_search();
-        } /* else {
-            self.cancel_search();
-        } */
-    }
-    */
-
     #[inline]
     fn start_search(&mut self, string: String, direction: Direction) {
         let num_lines = self.terminal.screen_lines();

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -209,10 +209,7 @@ impl Program {
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum SearchString {
     Just(String),
-    WithArgs {
-        string: String,
-        direction: String,
-    },
+    WithArgs { string: String, direction: String },
 }
 
 impl SearchString {
@@ -224,7 +221,7 @@ impl SearchString {
                     "left" | "backward" | "back" | "backwards" => Direction::Left,
                     _ => Direction::Right,
                 }
-            }
+            },
         }
     }
 
@@ -235,7 +232,6 @@ impl SearchString {
         }
     }
 }
-
 
 /// Wrapper around f32 that represents a percentage value between 0.0 and 1.0.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -15,6 +15,7 @@ use crate::ansi::CursorStyle;
 pub use crate::config::bell::{BellAnimation, BellConfig};
 pub use crate::config::colors::Colors;
 pub use crate::config::scrolling::Scrolling;
+pub use crate::index::Direction;
 
 pub const LOG_TARGET_CONFIG: &str = "alacritty_config";
 const MAX_SCROLLBACK_LINES: u32 = 100_000;
@@ -203,6 +204,38 @@ impl Program {
         }
     }
 }
+
+#[serde(untagged)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum SearchString {
+    Just(String),
+    WithArgs {
+        string: String,
+        direction: String,
+    },
+}
+
+impl SearchString {
+    pub fn direction(&self) -> Direction {
+        match self {
+            SearchString::Just(_) => Direction::Right,
+            SearchString::WithArgs { direction, .. } => {
+                match direction.trim().to_lowercase().as_str() {
+                    "left" | "backward" | "back" | "backwards" => Direction::Left,
+                    _ => Direction::Right,
+                }
+            }
+        }
+    }
+
+    pub fn string(&self) -> String {
+        match self {
+            SearchString::Just(string) => string.clone(),
+            SearchString::WithArgs { string, .. } => string.clone(),
+        }
+    }
+}
+
 
 /// Wrapper around f32 that represents a percentage value between 0.0 and 1.0.
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
Added new field to key-bindings, 'search', to go with 'action',
'command' and 'char'.
Field takes either a String or a map of { string: 'regex string', direction: 'forward' |     'backward' }
Changed the start_search function to take an additional String argument with current acti    ons SearchForward & SearchBackward passing an empty string.

This is usefull for keybindings to open URLs or copy the output from the
last command, for example:

```
key_bindings:
  - { key: G, mods: Command, mode: ~Vi, action: ToggleViMode }
  - { key: G, mods: Command, mode: Vi, search: {string: 'http.?://', direction: "backward"} }
  - { key: G, mods: Command, mode: Vi, action: Open }
  - { key: G, mods: Command, mode: Vi, action: ClearSelection }
  - { key: G, mods: Command, mode: Vi, action: ToggleViMode }
```

Linked Issue: #4073 

> Please make sure to document all user-facing changes in the
> `CHANGELOG.md` file.

Done

> If support for a new escape sequence was added, it should be documented
> in `./docs/escape_support.md`.

N/A

> Since `alacritty_terminal`'s version always tracks the next release, make sure
> that the version is bumped according to semver when necessary.

I haven't changed any versions
