### PR TITLE
Fix handling of wrapline flag in last line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Incorrect window location with negative `window.position` config options
 - Slow rendering performance with HiDPI displays, especially on macOS
 - Keys swallowed during search when pressing them right before releasing backspace
+- Crash when a wrapped line is rotated into the last line
 
 ## 0.5.0
 

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -420,7 +420,9 @@ impl<T> Term<T> {
 
     /// Find the end of the current line across linewraps.
     pub fn line_search_right(&self, mut point: Point<usize>) -> Point<usize> {
-        while self.grid[point.line][self.cols() - 1].flags.contains(Flags::WRAPLINE) {
+        while point.line > 0
+            && self.grid[point.line][self.cols() - 1].flags.contains(Flags::WRAPLINE)
+        {
             point.line -= 1;
         }
 

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -381,8 +381,7 @@ fn is_space<T>(term: &Term<T>, point: Point<usize>) -> bool {
 }
 
 fn is_wrap<T>(term: &Term<T>, point: Point<usize>) -> bool {
-    point.line != 0
-        && term.grid()[point.line][point.col].flags.contains(Flags::WRAPLINE)
+    point.line != 0 && term.grid()[point.line][point.col].flags.contains(Flags::WRAPLINE)
 }
 
 /// Check if point is at screen boundary.

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -381,7 +381,8 @@ fn is_space<T>(term: &Term<T>, point: Point<usize>) -> bool {
 }
 
 fn is_wrap<T>(term: &Term<T>, point: Point<usize>) -> bool {
-    term.grid()[point.line][point.col].flags.contains(Flags::WRAPLINE)
+    point.line != 0
+        && term.grid()[point.line][point.col].flags.contains(Flags::WRAPLINE)
 }
 
 /// Check if point is at screen boundary.


### PR DESCRIPTION
This resolves an issue where Alacritty would crash when a wrapline flag
was present in the last column of the last line.

While it should not be possible to achieve this with normal text flow,
it is possible to rotate the content downwards using the `CSI Ps T`
escape, causing this bug to occur.

This also works around other issues like the vi cursor jumping to the
top of the screen when trying to move beyond the last column using the
`l` key. In debug mode this even lead to a crash due to the overflow.

Fixes #4109.