### PR TITLE
Fix message bar color being picked from background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Slow rendering performance with HiDPI displays, especially on macOS
 - Keys swallowed during search when pressing them right before releasing backspace
 - Crash when a wrapped line is rotated into the last line
+- Yellow/Red colors for message bar not being picked from user's config
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use working directory of active process instead of shell for SpawnNewInstance action
 - Fallback to normal underline for unsupported underline types in `CSI 4 : ? m` escapes
 - The user's background color is now used as the foreground for the render timer
+- Use yellow/red from the config for error and warning messages instead of fixed colors
 
 ### Fixed
 
@@ -33,7 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Slow rendering performance with HiDPI displays, especially on macOS
 - Keys swallowed during search when pressing them right before releasing backspace
 - Crash when a wrapped line is rotated into the last line
-- Yellow/Red colors for message bar not being picked from user's config
 
 ## 0.5.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 name = "alacritty"
 version = "0.6.0-dev"
 dependencies = [
- "alacritty_terminal 0.10.1-dev",
+ "alacritty_terminal 0.11.0-dev",
  "clap 2.33.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossfont 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.10.1-dev"
+version = "0.11.0-dev"
 dependencies = [
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.10.1-dev"
+version = "0.11.0-dev"
 default-features = false
 
 [dependencies]

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -25,8 +25,7 @@ use crossfont::set_font_smoothing;
 use crossfont::{self, Rasterize, Rasterizer};
 
 use alacritty_terminal::event::{EventListener, OnResize};
-use alacritty_terminal::index::{Column, Point};
-use alacritty_terminal::index::{Direction, Line};
+use alacritty_terminal::index::{Column, Direction, Line, Point};
 use alacritty_terminal::selection::Selection;
 use alacritty_terminal::term::{RenderableCell, SizeInfo, Term, TermMode};
 
@@ -34,7 +33,7 @@ use crate::config::font::Font;
 use crate::config::window::StartupMode;
 use crate::config::Config;
 use crate::event::{Mouse, SearchState};
-use crate::message_bar::MessageBuffer;
+use crate::message_bar::{MessageBuffer, MessageType};
 use crate::meter::Meter;
 use crate::renderer::rects::{RenderLines, RenderRect};
 use crate::renderer::{self, GlyphCache, QuadRenderer};
@@ -545,8 +544,14 @@ impl Display {
             // Create a new rectangle for the background.
             let start_line = size_info.lines().0 - message_bar_lines;
             let y = size_info.cell_height.mul_add(start_line as f32, size_info.padding_y);
+
+            let color = match message.ty() {
+                MessageType::Error => config.colors.normal().red,
+                MessageType::Warning => config.colors.normal().yellow,
+            };
+
             let message_bar_rect =
-                RenderRect::new(0., y, size_info.width, size_info.height - y, message.color(), 1.);
+                RenderRect::new(0., y, size_info.width, size_info.height - y, color, 1.);
 
             // Push message_bar in the end, so it'll be above all other content.
             rects.push(message_bar_rect);

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -15,11 +15,9 @@ use std::sync::{Arc, Mutex};
 use glutin::event_loop::EventLoopProxy;
 use log::{self, Level};
 
-use alacritty_terminal::term::color;
-
 use crate::cli::Options;
 use crate::event::Event;
-use crate::message_bar::Message;
+use crate::message_bar::{Message, MessageType};
 
 const ALACRITTY_LOG_ENV: &str = "ALACRITTY_LOG";
 
@@ -97,14 +95,14 @@ impl log::Log for Logger {
                         env_var,
                         record.args(),
                     );
-                    let color = match record.level() {
-                        Level::Error => color::RED,
-                        Level::Warn => color::YELLOW,
+                    let message_type = match record.level() {
+                        Level::Error => MessageType::Error,
+                        Level::Warn => MessageType::Warning,
                         _ => unreachable!(),
                     };
 
                     if let Ok(event_proxy) = self.event_proxy.lock() {
-                        let mut message = Message::new(msg, color);
+                        let mut message = Message::new(msg, message_type);
                         message.set_target(record.target().to_owned());
 
                         let _ = event_proxy.send_event(Event::Message(message));

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 
-use alacritty_terminal::term::color::Rgb;
 use alacritty_terminal::term::SizeInfo;
 
 pub const CLOSE_BUTTON_TEXT: &str = "[X]";
@@ -12,14 +11,24 @@ const TRUNCATED_MESSAGE: &str = "[MESSAGE TRUNCATED]";
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Message {
     text: String,
-    color: Rgb,
+    ty: MessageType,
     target: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+/// Message's contents hint.
+pub enum MessageType {
+    /// A message represents an error.
+    Error,
+
+    /// A message represents a warning.
+    Warning,
 }
 
 impl Message {
     /// Create a new message.
-    pub fn new(text: String, color: Rgb) -> Message {
-        Message { text, color, target: None }
+    pub fn new(text: String, ty: MessageType) -> Message {
+        Message { text, ty, target: None }
     }
 
     /// Formatted message text lines.
@@ -78,10 +87,10 @@ impl Message {
         lines
     }
 
-    /// Message color.
+    /// Message type.
     #[inline]
-    pub fn color(&self) -> Rgb {
-        self.color
+    pub fn ty(&self) -> MessageType {
+        self.ty
     }
 
     /// Message target.
@@ -160,14 +169,14 @@ impl MessageBuffer {
 
 #[cfg(test)]
 mod tests {
-    use super::{Message, MessageBuffer, MIN_FREE_LINES};
-    use alacritty_terminal::term::{color, SizeInfo};
+    use super::{Message, MessageBuffer, MessageType, MIN_FREE_LINES};
+    use alacritty_terminal::term::SizeInfo;
 
     #[test]
     fn appends_close_button() {
         let input = "a";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 7.,
             height: 10.,
@@ -187,7 +196,7 @@ mod tests {
     fn multiline_close_button_first_line() {
         let input = "fo\nbar";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 6.,
             height: 10.,
@@ -207,7 +216,7 @@ mod tests {
     fn splits_on_newline() {
         let input = "a\nb";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 6.,
             height: 10.,
@@ -227,7 +236,7 @@ mod tests {
     fn splits_on_length() {
         let input = "foobar1";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 6.,
             height: 10.,
@@ -247,7 +256,7 @@ mod tests {
     fn empty_with_shortterm() {
         let input = "foobar";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 6.,
             height: 0.,
@@ -267,7 +276,7 @@ mod tests {
     fn truncates_long_messages() {
         let input = "hahahahahahahahahahaha truncate this because it's too long for the term";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 22.,
             height: (MIN_FREE_LINES + 2) as f32,
@@ -290,7 +299,7 @@ mod tests {
     fn hide_button_when_too_narrow() {
         let input = "ha";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 2.,
             height: 10.,
@@ -310,7 +319,7 @@ mod tests {
     fn hide_truncated_when_too_narrow() {
         let input = "hahahahahahahahaha";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 2.,
             height: (MIN_FREE_LINES + 2) as f32,
@@ -330,7 +339,7 @@ mod tests {
     fn add_newline_for_button() {
         let input = "test";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 5.,
             height: 10.,
@@ -350,7 +359,7 @@ mod tests {
     fn remove_target() {
         let mut message_buffer = MessageBuffer::new();
         for i in 0..10 {
-            let mut msg = Message::new(i.to_string(), color::RED);
+            let mut msg = Message::new(i.to_string(), MessageType::Error);
             if i % 2 == 0 && i < 5 {
                 msg.set_target("target".into());
             }
@@ -372,9 +381,9 @@ mod tests {
     #[test]
     fn pop() {
         let mut message_buffer = MessageBuffer::new();
-        let one = Message::new(String::from("one"), color::RED);
+        let one = Message::new(String::from("one"), MessageType::Error);
         message_buffer.push(one.clone());
-        let two = Message::new(String::from("two"), color::YELLOW);
+        let two = Message::new(String::from("two"), MessageType::Warning);
         message_buffer.push(two.clone());
 
         assert_eq!(message_buffer.message(), Some(&one));
@@ -388,7 +397,7 @@ mod tests {
     fn wrap_on_words() {
         let input = "a\nbc defg";
         let mut message_buffer = MessageBuffer::new();
-        message_buffer.push(Message::new(input.into(), color::RED));
+        message_buffer.push(Message::new(input.into(), MessageType::Error));
         let size = SizeInfo {
             width: 5.,
             height: 10.,
@@ -412,11 +421,11 @@ mod tests {
     fn remove_duplicates() {
         let mut message_buffer = MessageBuffer::new();
         for _ in 0..10 {
-            let msg = Message::new(String::from("test"), color::RED);
+            let msg = Message::new(String::from("test"), MessageType::Error);
             message_buffer.push(msg);
         }
-        message_buffer.push(Message::new(String::from("other"), color::RED));
-        message_buffer.push(Message::new(String::from("test"), color::YELLOW));
+        message_buffer.push(Message::new(String::from("other"), MessageType::Error));
+        message_buffer.push(Message::new(String::from("test"), MessageType::Warning));
         let _ = message_buffer.message();
 
         message_buffer.pop();

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -15,8 +15,8 @@ pub struct Message {
     target: Option<String>,
 }
 
+/// Purpose of the message.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-/// Message's contents hint.
 pub enum MessageType {
     /// A message represents an error.
     Error,

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.10.1-dev"
+version = "0.11.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -15,9 +15,6 @@ pub const COUNT: usize = 269;
 /// Factor for automatic computation of dim colors used by terminal.
 pub const DIM_FACTOR: f32 = 0.66;
 
-pub const RED: Rgb = Rgb { r: 0xff, g: 0x0, b: 0x0 };
-pub const YELLOW: Rgb = Rgb { r: 0xff, g: 0xff, b: 0x0 };
-
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Serialize)]
 pub struct Rgb {
     pub r: u8,


### PR DESCRIPTION
This commit reverts the message bar coloring to an old one, so the text
is always colored with #000000 over predefined red and yellow colors.

Fixes #4116.

--

I'd not that I don't really like how it looks, as an alternative solution I'd suggest to use foreground over yellow/red colors, but having predefined colors, like we had before seems also fine.
