### PR TITLE
Use user's background color for render timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cursors are now inverted when their fixed color is similar to the cell's background
 - Use working directory of active process instead of shell for SpawnNewInstance action
 - Fallback to normal underline for unsupported underline types in `CSI 4 : ? m` escapes
+- The user's background color is now used as the foreground for the render timer
 
 ### Fixed
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -674,7 +674,7 @@ impl Display {
         let glyph_cache = &mut self.glyph_cache;
 
         let timing = format!("{:.3} usec", self.meter.average());
-        let fg = config.colors.normal().black;
+        let fg = config.colors.primary.background;
         let bg = config.colors.normal().red;
 
         self.renderer.with_api(&config.ui_config, config.cursor, &size_info, |mut api| {


### PR DESCRIPTION
Using user's background color in pair with red color
should provide better contrast.
