### PR TITLE
Close the message bar on release of button press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fallback to normal underline for unsupported underline types in `CSI 4 : ? m` escapes
 - The user's background color is now used as the foreground for the render timer
 - Use yellow/red from the config for error and warning messages instead of fixed colors
+- The message bar close button now activates on release instead of inital press
 
 ### Fixed
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -773,7 +773,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         }
 
         // Skip normal mouse events if the message bar has been clicked.
-        if self.message_close_at_cursor() && state == ElementState::Pressed {
+        if self.message_close_at_cursor() && state == ElementState::Released {
             self.ctx.clear_selection();
             self.ctx.pop_message();
 


### PR DESCRIPTION
This is a tiny fix for the expected UX of our message bar's button. I was a little startled when the button triggered on press, so I've updated it to trigger on release.

### TODO

- [x] Changelog entry