### PR TITLE
Fix selection scrolling with message bar visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Slow rendering performance with HiDPI displays, especially on macOS
 - Keys swallowed during search when pressing them right before releasing backspace
 - Crash when a wrapped line is rotated into the last line
+- Selection wrapping to the top when selecting below the error/warning bar
 
 ## 0.5.0
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -377,7 +377,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         self.ctx.mouse_mut().x = x;
         self.ctx.mouse_mut().y = y;
 
-        let inside_grid = size_info.contains_point(x, y);
+        let inside_text_area = size_info.contains_point(x, y);
         let point = size_info.pixels_to_coords(x, y);
         let cell_side = self.get_mouse_side();
 
@@ -387,12 +387,12 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         // If the mouse hasn't changed cells, do nothing.
         if !cell_changed
             && self.ctx.mouse().cell_side == cell_side
-            && self.ctx.mouse().inside_grid == inside_grid
+            && self.ctx.mouse().inside_text_area == inside_text_area
         {
             return;
         }
 
-        self.ctx.mouse_mut().inside_grid = inside_grid;
+        self.ctx.mouse_mut().inside_text_area = inside_text_area;
         self.ctx.mouse_mut().cell_side = cell_side;
         self.ctx.mouse_mut().line = point.line;
         self.ctx.mouse_mut().column = point.col;
@@ -405,23 +405,14 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         self.update_url_state(&mouse_state);
         self.ctx.window_mut().set_mouse_cursor(mouse_state.into());
 
-        let last_term_line = self.ctx.terminal().grid().screen_lines() - 1;
         if (lmb_pressed || rmb_pressed)
             && (self.ctx.modifiers().shift() || !self.ctx.mouse_mode())
             && !search_active
         {
-            // Treat motion over message bar like motion over the last line.
-            let line = min(point.line, last_term_line);
-
-            // Move vi mode cursor to mouse cursor position.
-            if self.ctx.terminal().mode().contains(TermMode::VI) {
-                self.ctx.terminal_mut().vi_mode_cursor.point = point;
-            }
-
-            self.ctx.update_selection(Point { line, col: point.col }, cell_side);
-        } else if inside_grid
+            self.ctx.update_selection(point, cell_side);
+        } else if inside_text_area
             && cell_changed
-            && point.line <= last_term_line
+            && point.line < self.ctx.terminal().screen_lines()
             && self.ctx.terminal().mode().intersects(TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG)
         {
             if lmb_pressed {
@@ -997,7 +988,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         // Since search is above the message bar, the button is offset by search's height.
         let search_height = if self.ctx.search_active() { 1 } else { 0 };
 
-        mouse.inside_grid
+        mouse.inside_text_area
             && mouse.column + message_bar::CLOSE_BUTTON_TEXT.len() >= self.ctx.size_info().cols()
             && mouse.line == self.ctx.terminal().grid().screen_lines() + search_height
     }

--- a/alacritty/src/url.rs
+++ b/alacritty/src/url.rs
@@ -163,7 +163,7 @@ impl Urls {
 
         // Make sure all prerequisites for highlighting are met.
         if selection
-            || !mouse.inside_grid
+            || !mouse.inside_text_area
             || config.ui_config.mouse.url.launcher.is_none()
             || required_mods != mods
             || mouse.left_button_state == ElementState::Pressed


### PR DESCRIPTION
This resolves an issue with selection scrolling which would cause the
selection to wrap to the top of the screen once the cursor enters the
padding below the message bar.

Fixes #4120.