### PR TITLE
Update correct location for Windows configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ following locations:
 
 On Windows, the config file should be located at:
 
-`%APPDATA%\alacritty\alacritty.yml`
+`%APPDATA%\Roaming\alacritty\alacritty.yml`
 
 ## Contributing
 


### PR DESCRIPTION
alacritty did not load the configuration for me from `%APPDATA%\alacritty\alacritty.yml` but 
did from `%APPDATA%\Roaming\alacritty\alacritty.yml`

