### PR TITLE
Add power management config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for colon separated SGR 38/48
 - New Ctrl+C binding to cancel search and leave vi mode
 - Escapes for double underlines (`CSI 4 : 2 m`) and underline reset (`CSI 4 : 0 m`)
+- Configuration option `window.energy` to force which GPU should be used
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -81,6 +81,18 @@
   # Set this to `None` to use the default theme variant.
   #gtk_theme_variant: None
 
+  # Power management mode
+  #
+  # This will control things like the GPU used to render Alacritty. When set to
+  # `Auto`, Alacritty will automatically switch to low power mode when on
+  # battery.
+  #
+  # Values for `energy`:
+  #   - Performance
+  #   - Powersave
+  #   - Auto
+  #energy: Auto
+
 #scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -55,8 +55,12 @@ pub struct WindowConfig {
     #[serde(deserialize_with = "option_explicit_none")]
     pub gtk_theme_variant: Option<String>,
 
+    /// Power management.
+    #[serde(deserialize_with = "failure_default")]
+    pub energy: Energy,
+
     /// Use dynamic title.
-    #[serde(default, deserialize_with = "failure_default")]
+    #[serde(deserialize_with = "failure_default")]
     dynamic_title: DefaultTrueBool,
 }
 
@@ -90,7 +94,22 @@ impl Default for WindowConfig {
             gtk_theme_variant: Default::default(),
             title: default_title(),
             dynamic_title: Default::default(),
+            energy: Default::default(),
         }
+    }
+}
+
+/// Power management modes.
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Energy {
+    Performance,
+    Powersave,
+    Auto,
+}
+
+impl Default for Energy {
+    fn default() -> Self {
+        Self::Auto
     }
 }
 

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -36,7 +36,7 @@ use winapi::shared::minwindef::WORD;
 use alacritty_terminal::index::Point;
 use alacritty_terminal::term::SizeInfo;
 
-use crate::config::window::{Energy, Decorations, StartupMode, WindowConfig};
+use crate::config::window::{Decorations, Energy, StartupMode, WindowConfig};
 use crate::config::Config;
 use crate::gl;
 


### PR DESCRIPTION
The new power management configuration option `window.energy` should
allow users to select if they want to use the dedicated or integrated
GPU.

Until now it was not possible for people to force-enable their dedicated
GPUs when not on power on macOS. This should allow them to make the
choice themselves, allowing for better performance when temporarily
without power.

Fixes #3587.