### PR TITLE
Add a cursor inspired by the Plan 9 terminal

### DIFF
--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -28,6 +28,7 @@ pub fn get_cursor_glyph(
     match cursor {
         CursorStyle::HollowBlock => get_box_cursor_glyph(height, width, line_width),
         CursorStyle::Underline => get_underline_cursor_glyph(width, line_width),
+        CursorStyle::Plan9 => get_plan9_cursor(height, line_width),
         CursorStyle::Beam => get_beam_cursor_glyph(height, line_width),
         CursorStyle::Block => get_block_cursor_glyph(height, width),
         CursorStyle::Hidden => RasterizedGlyph::default(),
@@ -64,6 +65,27 @@ pub fn get_beam_cursor_glyph(height: i32, line_width: i32) -> RasterizedGlyph {
         width: line_width,
         buf: BitmapBuffer::RGB(buf),
     }
+}
+
+/// Draw a cursor that looks like the cursor in Plan 9
+pub fn get_plan9_cursor(height: i32, line_width: i32) -> RasterizedGlyph {
+    let l = 3 * line_width;
+    let mut buf = Vec::with_capacity((l * height * 3) as usize);
+
+    for y in 0..height {
+        for x in 0..l {
+            if y < l-1 || y > height - l {
+                buf.append(&mut vec![255u8; 3]);
+            } else if x >= line_width && x < 2 * line_width {
+                buf.append(&mut vec![255u8; 3]);
+            } else {
+                buf.append(&mut vec![0u8; 3]);
+            };
+        }
+    }
+
+    // Create a custom glyph with the rectangle data attached to it.
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width: line_width * 3, buf: BitmapBuffer::RGB(buf) }
 }
 
 /// Returns a custom box cursor character.

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -334,6 +334,10 @@ pub enum CursorStyle {
     #[serde(skip)]
     HollowBlock,
 
+    /// Cursor is vertical bar, but with thicker squares at both ends (like the
+    /// Plan 9 cursor)
+    Plan9,
+
     /// Invisible cursor.
     #[serde(skip)]
     Hidden,


### PR DESCRIPTION
This adds another glyph that is is similar to the beam cursor, except
both ends are slightly thicker. Like an I-beam, but the "beams" are
square.

I haven't updated any documentation or versions, because I'm not sure this is something that anyone wants, I just thought it could be fun to add this as an option.

How it looks with my configuration:

![image](https://user-images.githubusercontent.com/390428/90499874-649c0f00-e14a-11ea-87d2-3b72129630bb.png)

with the default configuration:

![image](https://user-images.githubusercontent.com/390428/90499982-8eedcc80-e14a-11ea-9d0d-f4f4a5058ea4.png)

Screenshot from Plan 9 for reference:

![image](https://user-images.githubusercontent.com/390428/90500060-a7f67d80-e14a-11ea-9208-76d94853651a.png)


TODO:
 - [ ] Update `CHANGELOG.md`
 - [ ] Update version of `alacritty_terminal` (?)

