### PR TITLE
added ResetAndClear action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for colon separated SGR 38/48
 - New Ctrl+C binding to cancel search and leave vi mode
 - Escapes for double underlines (`CSI 4 : 2 m`) and underline reset (`CSI 4 : 0 m`)
+- ResetAndClear action which clears scrollback and resets
 
 ### Changed
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -145,6 +145,9 @@ pub enum Action {
     /// Clear the display buffer(s) to remove history.
     ClearHistory,
 
+    /// Reset and clear the display
+    ResetAndClear,
+
     /// Hide the Alacritty window.
     Hide,
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -311,6 +311,11 @@ impl<T: EventListener> Execute<T> for Action {
                 term.vi_motion(ViMotion::FirstOccupied);
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
+            Action::ResetAndClear => {
+                ctx.terminal_mut().clear_screen(ClearMode::All);
+                ctx.terminal_mut().reset_state();
+                ctx.terminal_mut().dirty = true;
+            },
             Action::ClearLogNotice => ctx.pop_message(),
             Action::SpawnNewInstance => ctx.spawn_new_instance(),
             Action::ReceiveChar | Action::None => (),


### PR DESCRIPTION
Resets the terminal, same as
- "Clear Scrollback and Reset" in xcfe4-terminal
- "Clear Scrollback and Reset" in konsole
- "Reset and Clear" in gnome-terminal

Fixes #3997 