### PR TITLE
Unify term dimension calls

### DIFF
--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -242,7 +242,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollPageUp => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = term.grid().screen_lines().0 as isize;
+                let scroll_lines = term.screen_lines().0 as isize;
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::PageUp);
@@ -250,7 +250,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollPageDown => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = -(term.grid().screen_lines().0 as isize);
+                let scroll_lines = -(term.screen_lines().0 as isize);
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::PageDown);
@@ -258,7 +258,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollHalfPageUp => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = term.grid().screen_lines().0 as isize / 2;
+                let scroll_lines = term.screen_lines().0 as isize / 2;
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::Delta(scroll_lines));
@@ -266,7 +266,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollHalfPageDown => {
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                let scroll_lines = -(term.grid().screen_lines().0 as isize / 2);
+                let scroll_lines = -(term.screen_lines().0 as isize / 2);
                 term.vi_mode_cursor = term.vi_mode_cursor.scroll(term, scroll_lines);
 
                 ctx.scroll(Scroll::Delta(scroll_lines));
@@ -274,8 +274,8 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ScrollLineUp => {
                 // Move vi mode cursor.
                 let term = ctx.terminal();
-                if term.grid().display_offset() != term.grid().history_size()
-                    && term.vi_mode_cursor.point.line + 1 != term.grid().screen_lines()
+                if term.grid().display_offset() != term.history_size()
+                    && term.vi_mode_cursor.point.line + 1 != term.screen_lines()
                 {
                     ctx.terminal_mut().vi_mode_cursor.point.line += 1;
                 }
@@ -304,7 +304,7 @@ impl<T: EventListener> Execute<T> for Action {
 
                 // Move vi mode cursor.
                 let term = ctx.terminal_mut();
-                term.vi_mode_cursor.point.line = term.grid().screen_lines() - 1;
+                term.vi_mode_cursor.point.line = term.screen_lines() - 1;
 
                 // Move to beginning twice, to always jump across linewraps.
                 term.vi_motion(ViMotion::FirstOccupied);
@@ -557,7 +557,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             // Load mouse point, treating message bar and padding as the closest cell.
             let mouse = self.ctx.mouse();
             let mut point = self.ctx.size_info().pixels_to_coords(mouse.x, mouse.y);
-            point.line = min(point.line, self.ctx.terminal().grid().screen_lines() - 1);
+            point.line = min(point.line, self.ctx.terminal().screen_lines() - 1);
 
             match button {
                 MouseButton::Left => self.on_left_click(point),
@@ -770,7 +770,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
             // Reset cursor when message bar height changed or all messages are gone.
             let size = self.ctx.size_info();
-            let current_lines = (size.lines() - self.ctx.terminal().grid().screen_lines()).0;
+            let current_lines = (size.lines() - self.ctx.terminal().screen_lines()).0;
             let new_lines = self.ctx.message().map(|m| m.text(&size).len()).unwrap_or(0);
 
             let new_icon = match current_lines.cmp(&new_lines) {
@@ -978,7 +978,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
     /// Check if the cursor is hovering above the message bar.
     fn message_at_cursor(&mut self) -> bool {
-        self.ctx.mouse().line >= self.ctx.terminal().grid().screen_lines()
+        self.ctx.mouse().line >= self.ctx.terminal().screen_lines()
     }
 
     /// Whether the point is over the message bar's close button.
@@ -990,7 +990,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
 
         mouse.inside_text_area
             && mouse.column + message_bar::CLOSE_BUTTON_TEXT.len() >= self.ctx.size_info().cols()
-            && mouse.line == self.ctx.terminal().grid().screen_lines() + search_height
+            && mouse.line == self.ctx.terminal().screen_lines() + search_height
     }
 
     /// Copy text selection.

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -71,12 +71,12 @@ impl<'a> RenderableSearch<'a> {
     /// Create a new renderable search iterator.
     fn new<T>(term: &'a Term<T>) -> Self {
         let viewport_end = term.grid().display_offset();
-        let viewport_start = viewport_end + term.grid().screen_lines().0 - 1;
+        let viewport_start = viewport_end + term.screen_lines().0 - 1;
 
         // Compute start of the first and end of the last line.
         let start_point = Point::new(viewport_start, Column(0));
         let mut start = term.line_search_left(start_point);
-        let end_point = Point::new(viewport_end, term.grid().cols() - 1);
+        let end_point = Point::new(viewport_end, term.cols() - 1);
         let mut end = term.line_search_right(end_point);
 
         // Set upper bound on search before/after the viewport to prevent excessive blocking.
@@ -986,7 +986,7 @@ impl<T> Term<T> {
         } else if let Some(selection) = self.selection.take() {
             // Move the selection if only number of lines changed.
             let delta = if num_lines > old_lines {
-                (num_lines - old_lines.0).saturating_sub(self.grid.history_size()) as isize
+                (num_lines - old_lines.0).saturating_sub(self.history_size()) as isize
             } else {
                 let cursor_line = self.grid.cursor.point.line;
                 -(min(old_lines - cursor_line - 1, old_lines - num_lines).0 as isize)
@@ -1812,7 +1812,7 @@ impl<T: EventListener> Handler for Term<T> {
             },
         }
 
-        let cursor_buffer_line = (self.grid.screen_lines() - self.grid.cursor.point.line - 1).0;
+        let cursor_buffer_line = (self.screen_lines() - self.grid.cursor.point.line - 1).0;
         self.selection = self
             .selection
             .take()
@@ -1941,7 +1941,7 @@ impl<T: EventListener> Handler for Term<T> {
 
                 self.selection = self.selection.take().filter(|s| !s.intersects_range(..num_lines));
             },
-            ansi::ClearMode::Saved if self.grid.history_size() > 0 => {
+            ansi::ClearMode::Saved if self.history_size() > 0 => {
                 self.grid.clear_history();
 
                 self.selection = self.selection.take().filter(|s| !s.intersects_range(num_lines..));
@@ -2584,14 +2584,14 @@ mod tests {
         for _ in 0..19 {
             term.newline();
         }
-        assert_eq!(term.grid.history_size(), 10);
+        assert_eq!(term.history_size(), 10);
         assert_eq!(term.grid.cursor.point, Point::new(Line(9), Column(0)));
 
         // Increase visible lines.
         size.height = 30.;
         term.resize(&size);
 
-        assert_eq!(term.grid.history_size(), 0);
+        assert_eq!(term.history_size(), 0);
         assert_eq!(term.grid.cursor.point, Point::new(Line(19), Column(0)));
     }
 
@@ -2612,7 +2612,7 @@ mod tests {
         for _ in 0..19 {
             term.newline();
         }
-        assert_eq!(term.grid.history_size(), 10);
+        assert_eq!(term.history_size(), 10);
         assert_eq!(term.grid.cursor.point, Point::new(Line(9), Column(0)));
 
         // Enter alt screen.
@@ -2625,7 +2625,7 @@ mod tests {
         // Leave alt screen.
         term.unset_mode(ansi::Mode::SwapScreenAndSetRestoreCursor);
 
-        assert_eq!(term.grid().history_size(), 0);
+        assert_eq!(term.history_size(), 0);
         assert_eq!(term.grid.cursor.point, Point::new(Line(19), Column(0)));
     }
 
@@ -2646,14 +2646,14 @@ mod tests {
         for _ in 0..19 {
             term.newline();
         }
-        assert_eq!(term.grid.history_size(), 10);
+        assert_eq!(term.history_size(), 10);
         assert_eq!(term.grid.cursor.point, Point::new(Line(9), Column(0)));
 
         // Increase visible lines.
         size.height = 5.;
         term.resize(&size);
 
-        assert_eq!(term.grid().history_size(), 15);
+        assert_eq!(term.history_size(), 15);
         assert_eq!(term.grid.cursor.point, Point::new(Line(4), Column(0)));
     }
 
@@ -2674,7 +2674,7 @@ mod tests {
         for _ in 0..19 {
             term.newline();
         }
-        assert_eq!(term.grid.history_size(), 10);
+        assert_eq!(term.history_size(), 10);
         assert_eq!(term.grid.cursor.point, Point::new(Line(9), Column(0)));
 
         // Enter alt screen.
@@ -2687,7 +2687,7 @@ mod tests {
         // Leave alt screen.
         term.unset_mode(ansi::Mode::SwapScreenAndSetRestoreCursor);
 
-        assert_eq!(term.grid().history_size(), 15);
+        assert_eq!(term.history_size(), 15);
         assert_eq!(term.grid.cursor.point, Point::new(Line(4), Column(0)));
     }
 


### PR DESCRIPTION
Since the `Term` implements the `Dimensions` trait itself, we shouldn't
call `term.grid()` to call methods from the `Dimensions` trait.

This removes all instances of this that I could find in the code at the
moment.