### PR TITLE
Update example for -o flag to be more apparent.

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -182,7 +182,7 @@ impl Options {
                     .short("o")
                     .multiple(true)
                     .takes_value(true)
-                    .help("Override configuration file options [example: window.title=Alacritty]"),
+                    .help("Override configuration file options [example: cursor.style=Beam]"),
             )
             .get_matches();
 

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -68,7 +68,7 @@ Defines the window dimensions. Falls back to size specified by window manager if
 Defines the X11 window ID (as a decimal integer) to embed Alacritty within
 .TP
 \fB\-o\fR, \fB\-\-option\fR <option>...
-Override configuration file options [example: window.title=Alacritty]
+Override configuration file options [example: cursor.style=Beam]
 .TP
 \fB\-\-position\fR <x-pos> <y-pos>
 Defines the window position. Falls back to position specified by window manager if unset [default: unset]


### PR DESCRIPTION
Just a small tweak to the `--help`/man page example for the newly added `--option` flag to help make the behavior more obvious to a user who simply copies and pastes the example.

P.S. I'm wondering if it would be a good idea to write our man page or CLI help text once, and generate the other. This might now be too hard with something like [rust-cli/man](https://github.com/rust-cli/man). Thoughts?