### PR TITLE
Fix compilation for windows-gnu with default features 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Minimum Rust version has been bumped to 1.43.0
 - The snapcraft.yaml file has been removed
 - Updated `setab`/`setaf` capabilities in `alacritty-direct` to use colons
+- WinPTY is now enabled only when targeting MSVC
 
 ### Added
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -36,7 +36,7 @@ winapi = { version = "0.3.7", features = [
 ]}
 mio-anonymous-pipes = "0.1"
 
-# Winpty crate supports only MSVC
+# Winpty crate supports only MSVC.
 [target.'cfg(all(target_os="windows", target_env="msvc"))'.dependencies]
 winpty = { version = "0.2.0", optional = true }
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -28,7 +28,6 @@ nix = "0.17.0"
 signal-hook = { version = "0.1", features = ["mio-support"] }
 
 [target.'cfg(windows)'.dependencies]
-winpty = { version = "0.2.0", optional = true }
 mio-named-pipes = "0.1"
 miow = "0.3"
 winapi = { version = "0.3.7", features = [
@@ -36,6 +35,10 @@ winapi = { version = "0.3.7", features = [
     "wincon", "wincontypes", "winerror", "winnt", "winuser",
 ]}
 mio-anonymous-pipes = "0.1"
+
+# Winpty crate supports only MSVC
+[target.'cfg(all(target_os="windows", target_env="msvc"))'.dependencies]
+winpty = { version = "0.2.0", optional = true }
 
 [features]
 default = ["winpty"]

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -17,9 +17,9 @@ mod conpty;
 #[cfg(all(feature = "winpty", target_env = "msvc"))]
 mod winpty;
 
-#[cfg(any(not(feature = "winpty"), not(target_env = "msvc")))]
+#[cfg(not(all(feature = "winpty", target_env = "msvc")))]
 use conpty::Conpty as Backend;
-#[cfg(any(not(feature = "winpty"), not(target_env = "msvc")))]
+#[cfg(not(all(feature = "winpty", target_env = "msvc")))]
 use mio_anonymous_pipes::{EventedAnonRead as ReadPipe, EventedAnonWrite as WritePipe};
 
 #[cfg(all(feature = "winpty", target_env = "msvc"))]
@@ -39,7 +39,7 @@ pub struct Pty {
     child_watcher: ChildExitWatcher,
 }
 
-#[cfg(any(not(feature = "winpty"), not(target_env = "msvc")))]
+#[cfg(not(all(feature = "winpty", target_env = "msvc")))]
 pub fn new<C>(config: &Config<C>, size: &SizeInfo, window_id: Option<usize>) -> Pty {
     conpty::new(config, size, window_id).expect("Failed to create ConPTY backend")
 }

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -10,19 +10,19 @@ use crate::term::SizeInfo;
 use crate::tty::windows::child::ChildExitWatcher;
 use crate::tty::{ChildEvent, EventedPty, EventedReadWrite};
 
-#[cfg(feature = "winpty")]
+#[cfg(all(feature = "winpty", target_env = "msvc"))]
 mod automatic_backend;
 mod child;
 mod conpty;
-#[cfg(feature = "winpty")]
+#[cfg(all(feature = "winpty", target_env = "msvc"))]
 mod winpty;
 
-#[cfg(not(feature = "winpty"))]
+#[cfg(any(not(feature = "winpty"), not(target_env = "msvc")))]
 use conpty::Conpty as Backend;
-#[cfg(not(feature = "winpty"))]
+#[cfg(any(not(feature = "winpty"), not(target_env = "msvc")))]
 use mio_anonymous_pipes::{EventedAnonRead as ReadPipe, EventedAnonWrite as WritePipe};
 
-#[cfg(feature = "winpty")]
+#[cfg(all(feature = "winpty", target_env = "msvc"))]
 use automatic_backend::{
     EventedReadablePipe as ReadPipe, EventedWritablePipe as WritePipe, PtyBackend as Backend,
 };
@@ -39,12 +39,12 @@ pub struct Pty {
     child_watcher: ChildExitWatcher,
 }
 
-#[cfg(not(feature = "winpty"))]
+#[cfg(any(not(feature = "winpty"), not(target_env = "msvc")))]
 pub fn new<C>(config: &Config<C>, size: &SizeInfo, window_id: Option<usize>) -> Pty {
     conpty::new(config, size, window_id).expect("Failed to create ConPTY backend")
 }
 
-#[cfg(feature = "winpty")]
+#[cfg(all(feature = "winpty", target_env = "msvc"))]
 pub fn new<C>(config: &Config<C>, size: &SizeInfo, window_id: Option<usize>) -> Pty {
     automatic_backend::new(config, size, window_id)
 }


### PR DESCRIPTION
WinPTY crate supports only windows-msvc right now so leaving it enabled for windows-gnu results in build errors unless `--no-default-features` is added.