### PR TITLE
Make logo key convert characters to control characters, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Configuration file option for sourcing other files (`import`)
 - CLI parameter `--option`/`-o` to override any configuration field
 - Escape sequences to report text area size in pixels (`CSI 14 t`) and in characters (`CSI 18 t`)
+- New `logo_as_ctrl` option for controlling if logo key should convert written
+  characters to control characters, like the ctrl key does. On X11 only.
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -390,6 +390,10 @@
 # Send ESC (\x1b) before characters when alt is pressed.
 #alt_send_esc: true
 
+# Make logo key convert characters written to the terminal to
+# control characters, like the ctrl key does. On X11 only.
+#logo_as_ctrl: false
+
 #mouse:
   # Click settings
   #

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -40,6 +40,10 @@ pub struct UIConfig {
     #[serde(default, deserialize_with = "failure_default")]
     alt_send_esc: DefaultTrueBool,
 
+    /// Make logo key convert characters to control characters, too. On X11.
+    #[serde(default, deserialize_with = "failure_default")]
+    logo_as_ctrl: bool,
+
     /// Live config reload.
     #[serde(default, deserialize_with = "failure_default")]
     live_config_reload: DefaultTrueBool,
@@ -67,6 +71,7 @@ impl Default for UIConfig {
             mouse_bindings: default_mouse_bindings(),
             debug: Default::default(),
             alt_send_esc: Default::default(),
+            logo_as_ctrl: Default::default(),
             background_opacity: Default::default(),
             live_config_reload: Default::default(),
             dynamic_title: Default::default(),
@@ -106,6 +111,12 @@ impl UIConfig {
     #[inline]
     pub fn alt_send_esc(&self) -> bool {
         self.alt_send_esc.0
+    }
+
+    /// Make logo key convert characters to control characters, too. On X11.
+    #[inline]
+    pub fn logo_as_ctrl(&self) -> bool {
+        self.logo_as_ctrl
     }
 }
 


### PR DESCRIPTION
So I figured out this is the only thing which I need to allow me to use ctrl key everywhere around my system for the UI keyboard shortcut key, so `ctrl-c` then copies to the clipboard in all apps, including alacritty. I then configure keyboard shortcut in alacritty the same as I have them system wide. And then I can use the super key to send control characters to the terminal. With this configuration option enabled, both ctrl and super keys send control characters to the terminal, but you can override them with alacritty shortcuts which then suppress that particular combination.

I in fact configure system-wide modifier keys to be in a different order (super, fn, alt, ctrl) so that the key closest to the space key behaves like Mac's command key. But this is unrelated to alacritty. For some more background on this see: https://github.com/alacritty/alacritty/issues/4193