### PR TITLE
Allow to apply opacity to all background colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Urgency support on Windows
 - Customizable keybindings for search
 - History for search mode, bound to ^P/^N/Up/Down by default
+- Option `colors.opaque_background_color` to allow applying opacity to all background colors
 
 ### Changed
 
 - Nonexistent config imports are ignored instead of raising an error
 - Value for disabling logging with `config.log_level` is `Off` instead of `None`
+- Moved config option `background_opacity` to `window.background_opacity`
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -93,6 +93,12 @@
   # and `light`. Set this to `None` to use the default theme variant.
   #gtk_theme_variant: None
 
+  # Background opacity
+  #
+  # Window opacity as a floating point number from `0.0` to `1.0`.
+  # The value `0.0` is completely transparent and `1.0` is opaque.
+  #background_opacity: 1.0
+
 #scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.
@@ -284,6 +290,13 @@
   #
   #indexed_colors: []
 
+  # Opaque backgrounds with transparency enabled
+  #
+  # Whether or not `background_opacity` applies to all backgrounds or only the
+  # default background. When set to `false` all cells will be transparent
+  # regardless of their background color.
+  #opaque_background_colors: true
+
 # Bell
 #
 # The bell is rung every time the BEL control character is received.
@@ -324,12 +337,6 @@
   #     args: ["Hello, World!"]
   #
   #command: None
-
-# Background opacity
-#
-# Window opacity as a floating point number from `0.0` to `1.0`.
-# The value `0.0` is completely transparent and `1.0` is opaque.
-#background_opacity: 1.0
 
 #selection:
   # This string contains all characters that are used as separators for

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -292,7 +292,7 @@
 
   # Opaque backgrounds with transparency enabled
   #
-  # Whether or not `background_opacity` applies to all backgrounds or only the
+  # Whether or not `background_opacity` applies to all backgrounds or only to the
   # default background. When set to `false` all cells will be transparent
   # regardless of their background color.
   #opaque_background_colors: true

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -18,7 +18,7 @@ void main() {
         }
 
         alphaMask = vec4(1.0);
-        color = vec4(bg.rgb, 1.0);
+        color = vec4(bg.rgb, 1.0) * bg.a;
     } else if ((int(fg.a) & COLORED) != 0) {
         // Color glyphs, like emojis.
         vec4 glyphColor = texture(mask, TexCoords);

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -18,7 +18,7 @@ void main() {
         }
 
         alphaMask = vec4(1.0);
-        color = vec4(bg.rgb, 1.0) * bg.a;
+        color = vec4(bg.rgb, bg.a);
     } else if ((int(fg.a) & COLORED) != 0) {
         // Color glyphs, like emojis.
         vec4 glyphColor = texture(mask, TexCoords);

--- a/alacritty/res/text.v.glsl
+++ b/alacritty/res/text.v.glsl
@@ -65,6 +65,6 @@ void main() {
         TexCoords = uvOffset + position * uvSize;
     }
 
-    bg = vec4(backgroundColor.rgb / 255.0, backgroundColor.a);
+    bg = backgroundColor / 255.0;
     fg = vec4(textColor.rgb / 255.0, textColor.a);
 }

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -65,10 +65,7 @@ impl Default for UIConfig {
 impl UIConfig {
     #[inline]
     pub fn background_opacity(&self) -> f32 {
-        match self.background_opacity {
-            Some(x) => x.as_f32(),
-            None => self.window.background_opacity(),
-        }
+        self.background_opacity.map(Percentage::as_f32).unwrap_or_else(|| self.window.background_opacity())
     }
 
     #[inline]

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -41,8 +41,9 @@ pub struct UIConfig {
     /// Bindings for the mouse.
     mouse_bindings: MouseBindings,
 
-    /// Background opacity from 0.0 to 1.0.
-    background_opacity: Percentage,
+    /// TODO: Deprcated
+    #[config(deprecated = "use `window.background_opacity` instead")]
+    pub background_opacity: Option<Percentage>,
 }
 
 impl Default for UIConfig {
@@ -65,7 +66,10 @@ impl Default for UIConfig {
 impl UIConfig {
     #[inline]
     pub fn background_opacity(&self) -> f32 {
-        self.background_opacity.as_f32()
+        match self.background_opacity {
+            Some(x) => x.as_f32(),
+            None => self.window.background_opacity(),
+        }
     }
 
     #[inline]

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -65,7 +65,9 @@ impl Default for UIConfig {
 impl UIConfig {
     #[inline]
     pub fn background_opacity(&self) -> f32 {
-        self.background_opacity.map(Percentage::as_f32).unwrap_or_else(|| self.window.background_opacity())
+        self.background_opacity
+            .map(Percentage::as_f32)
+            .unwrap_or_else(|| self.window.background_opacity())
     }
 
     #[inline]

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -41,7 +41,6 @@ pub struct UIConfig {
     /// Bindings for the mouse.
     mouse_bindings: MouseBindings,
 
-    /// TODO: Deprcated
     #[config(deprecated = "use `window.background_opacity` instead")]
     pub background_opacity: Option<Percentage>,
 }

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -7,7 +7,7 @@ use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
 use alacritty_config_derive::ConfigDeserialize;
-use alacritty_terminal::config::LOG_TARGET_CONFIG;
+use alacritty_terminal::config::{Percentage, LOG_TARGET_CONFIG};
 use alacritty_terminal::index::{Column, Line};
 
 use crate::config::ui_config::Delta;
@@ -15,7 +15,7 @@ use crate::config::ui_config::Delta;
 /// Default Alacritty name, used for window title and class.
 pub const DEFAULT_NAME: &str = "Alacritty";
 
-#[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Clone, PartialEq)]
 pub struct WindowConfig {
     /// Initial position.
     pub position: Option<Delta<i32>>,
@@ -50,6 +50,9 @@ pub struct WindowConfig {
 
     /// Initial dimensions.
     dimensions: Dimensions,
+
+    /// Background opacity from 0.0 to 1.0.
+    background_opacity: Percentage,
 }
 
 impl Default for WindowConfig {
@@ -66,6 +69,7 @@ impl Default for WindowConfig {
             class: Default::default(),
             padding: Default::default(),
             dimensions: Default::default(),
+            background_opacity: Default::default(),
         }
     }
 }
@@ -102,6 +106,11 @@ impl WindowConfig {
     #[inline]
     pub fn maximized(&self) -> bool {
         self.startup_mode == StartupMode::Maximized
+    }
+
+    #[inline]
+    pub fn background_opacity(&self) -> f32 {
+        self.background_opacity.as_f32()
     }
 }
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -246,7 +246,7 @@ impl Display {
 
         // Clear screen.
         let background_color = config.colors.primary.background;
-        renderer.with_api(&config.ui_config, config.cursor, &size_info, |api| {
+        renderer.with_api(&config, config.cursor, &size_info, |api| {
             api.clear(background_color);
         });
 
@@ -264,7 +264,7 @@ impl Display {
         #[cfg(not(any(target_os = "macos", windows)))]
         if is_x11 {
             window.swap_buffers();
-            renderer.with_api(&config.ui_config, config.cursor, &size_info, |api| {
+            renderer.with_api(&config, config.cursor, &size_info, |api| {
                 api.finish();
             });
         }
@@ -467,7 +467,7 @@ impl Display {
         // Drop terminal as early as possible to free lock.
         drop(terminal);
 
-        self.renderer.with_api(&config.ui_config, config.cursor, &size_info, |api| {
+        self.renderer.with_api(&config, config.cursor, &size_info, |api| {
             api.clear(background_color);
         });
 
@@ -478,7 +478,7 @@ impl Display {
         {
             let _sampler = self.meter.sampler();
 
-            self.renderer.with_api(&config.ui_config, config.cursor, &size_info, |mut api| {
+            self.renderer.with_api(&config, config.cursor, &size_info, |mut api| {
                 // Iterate over all non-empty cells in the grid.
                 for mut cell in grid_cells {
                     // Invert the active match in vi-less search.
@@ -572,7 +572,7 @@ impl Display {
             // Relay messages to the user.
             let fg = config.colors.primary.background;
             for (i, message_text) in text.iter().enumerate() {
-                self.renderer.with_api(&config.ui_config, config.cursor, &size_info, |mut api| {
+                self.renderer.with_api(&config, config.cursor, &size_info, |mut api| {
                     api.render_string(glyph_cache, start_line + i, &message_text, fg, None);
                 });
             }
@@ -623,7 +623,7 @@ impl Display {
             // On X11 `swap_buffers` does not block for vsync. However the next OpenGl command
             // will block to synchronize (this is `glClear` in Alacritty), which causes a
             // permanent one frame delay.
-            self.renderer.with_api(&config.ui_config, config.cursor, &size_info, |api| {
+            self.renderer.with_api(&config, config.cursor, &size_info, |api| {
                 api.finish();
             });
         }
@@ -670,7 +670,7 @@ impl Display {
 
         let fg = config.colors.search_bar_foreground();
         let bg = config.colors.search_bar_background();
-        self.renderer.with_api(&config.ui_config, config.cursor, &size_info, |mut api| {
+        self.renderer.with_api(&config, config.cursor, &size_info, |mut api| {
             api.render_string(glyph_cache, size_info.screen_lines(), &text, fg, Some(bg));
         });
     }
@@ -686,7 +686,7 @@ impl Display {
         let fg = config.colors.primary.background;
         let bg = config.colors.normal.red;
 
-        self.renderer.with_api(&config.ui_config, config.cursor, &size_info, |mut api| {
+        self.renderer.with_api(&config, config.cursor, &size_info, |mut api| {
             api.render_string(glyph_cache, size_info.screen_lines() - 2, &timing[..], fg, Some(bg));
         });
     }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -502,7 +502,7 @@ impl Batch {
             bg_r: cell.bg.r,
             bg_g: cell.bg.g,
             bg_b: cell.bg.b,
-            bg_a: cell.bg_alpha as u8,
+            bg_a: (cell.bg_alpha * 255.0) as u8,
         });
     }
 
@@ -851,7 +851,6 @@ impl<'a> RenderApi<'a> {
 
     #[inline]
     fn add_render_item(&mut self, cell: &mut RenderableCell, glyph: &Glyph) {
-        cell.bg_alpha *= 255.;
         if !self.config.colors.opaque_background_colors {
             cell.bg_alpha *= self.config.ui_config.background_opacity();
         }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -760,9 +760,9 @@ impl<'a> RenderApi<'a> {
         unsafe {
             let alpha = self.config.ui_config.background_opacity();
             gl::ClearColor(
-                (f32::from(color.r) / 255.0).min(1.0) * alpha,
-                (f32::from(color.g) / 255.0).min(1.0) * alpha,
-                (f32::from(color.b) / 255.0).min(1.0) * alpha,
+                (f32::from(color.r) / 255.0).min(1.0),
+                (f32::from(color.g) / 255.0).min(1.0),
+                (f32::from(color.b) / 255.0).min(1.0),
                 alpha,
             );
             gl::Clear(gl::COLOR_BUFFER_BIT);

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -5,7 +5,7 @@ use alacritty_config_derive::ConfigDeserialize;
 
 use crate::term::color::{CellRgb, Rgb};
 
-#[derive(ConfigDeserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Colors {
     pub primary: PrimaryColors,
     pub cursor: InvertedCellColors,
@@ -16,6 +16,24 @@ pub struct Colors {
     pub dim: Option<DimColors>,
     pub indexed_colors: Vec<IndexedColor>,
     pub search: SearchColors,
+    pub opaque_background_colors: bool,
+}
+
+impl Default for Colors {
+    fn default() -> Self {
+        Self {
+            primary: Default::default(),
+            cursor: Default::default(),
+            vi_mode_cursor: Default::default(),
+            selection: Default::default(),
+            normal: Default::default(),
+            bright: Default::default(),
+            dim: Default::default(),
+            indexed_colors: Default::default(),
+            search: Default::default(),
+            opaque_background_colors: true,
+        }
+    }
 }
 
 impl Colors {

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -22,6 +22,7 @@ pub struct Colors {
 impl Default for Colors {
     fn default() -> Self {
         Self {
+            opaque_background_colors: true,
             primary: Default::default(),
             cursor: Default::default(),
             vi_mode_cursor: Default::default(),
@@ -31,7 +32,6 @@ impl Default for Colors {
             dim: Default::default(),
             indexed_colors: Default::default(),
             search: Default::default(),
-            opaque_background_colors: true,
         }
     }
 }


### PR DESCRIPTION
Alacritty currently only applies the value of `background_opacity` to
the default background and not to all (e.g. #807, addressed in #847).
However this is not necessarily always desired (e.g. #1082, #1180).

This patch adds a configuration option and logic (by partly re-instating
code removed in #847) to toggle the behavior between either applying
only to the default background color, or all background colors.  For
example iterm2 also has this option and the naming of the toggle is
borrowed from there.

Fixes #741.