### PR TITLE
Add config option to use "default" mouse cursor style instead of "text"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Configuration file option for sourcing other files (`import`)
 - CLI parameter `--option`/`-o` to override any configuration field
 - Escape sequences to report text area size in pixels (`CSI 14 t`) and in characters (`CSI 18 t`)
+- Option `mouse.force_default_cursor` to force the use of "default" mouse cursor style instead of "text"
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -402,6 +402,9 @@
   # If this is `true`, the cursor is temporarily hidden when typing.
   #hide_when_typing: false
 
+  # If this is `true`, "default" cursor style will be used instead of "text".
+  #force_default_cursor: false
+
   #url:
     # URL launcher
     #

--- a/alacritty/src/config/mouse.rs
+++ b/alacritty/src/config/mouse.rs
@@ -18,6 +18,8 @@ pub struct Mouse {
     #[serde(deserialize_with = "failure_default")]
     pub hide_when_typing: bool,
     #[serde(deserialize_with = "failure_default")]
+    pub force_default_cursor: bool,
+    #[serde(deserialize_with = "failure_default")]
     pub url: Url,
 }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1039,7 +1039,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         }
 
         // Check mouse mode if location is not special.
-        if !self.ctx.modifiers().shift() && mouse_mode {
+        if (!self.ctx.modifiers().shift() && mouse_mode) || self.ctx.config().ui_config.mouse.force_default_cursor {
             MouseState::Mouse
         } else {
             MouseState::Text


### PR DESCRIPTION
Since I've upgraded from Alacritty v0.3.3 I've noticed that the [bug was fixed](https://github.com/alacritty/alacritty/commit/4dd327f0aec53d4501601281b796b1d7dda9a5d3) making the "text selection" mouse cursor an actual default.

I would really like an option to get back to how it was before and be able to choose whether "text" or "default" cursor style should be used.

I understand that adding a config option just for this might be excessive and I would love to hear any better/simpler ways to provide this choice for the user. Even though the "text" cursor [is a default in many terminals](https://github.com/alacritty/alacritty/pull/778) it still varies in my experience.