### PR TITLE
Fix CLI arguments without config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Pasting into clients only supporting `UTF8_STRING` mime type on Wayland
 - Crash when copying/pasting with neither pointer nor keyboard focus on Wayland
 - Crash due to fd leak on Wayland
+- CLI arguments ignored without a configuration file present
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Pasting into clients only supporting `UTF8_STRING` mime type on Wayland
 - Crash when copying/pasting with neither pointer nor keyboard focus on Wayland
 - Crash due to fd leak on Wayland
-- CLI arguments ignored without a configuration file present
 
 ## 0.5.0
 


### PR DESCRIPTION
Since we only applied the CLI arguments as overrides to the
configuration file after the file was loaded, all CLI arguments that are
stored on the config would be dropped without a configuration file in
place.

This also makes sure that all configuration file config overrides are
still loaded if the configuration file could not be loaded for any
reason, since there's no reason why we'd just drop everything in that
case.