### PR TITLE
Log new padding and cell size on 'SizeInfo' update

### DIFF
--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -435,10 +435,10 @@ impl Display {
         let physical = PhysicalSize::new(self.size_info.width as u32, self.size_info.height as u32);
         self.window.resize(physical);
 
+        self.renderer.resize(&self.size_info);
+        
         info!("Padding: {} x {}", self.size_info.padding_x, self.size_info.padding_y);
         info!("Width: {}, Height: {}", self.size_info.width, self.size_info.height);
-
-        self.renderer.resize(&self.size_info);
     }
 
     /// Draw the screen.

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -357,6 +357,8 @@ impl Display {
         let (cell_width, cell_height) = compute_cell_size(config, &self.glyph_cache.font_metrics());
         size_info.cell_width = cell_width;
         size_info.cell_height = cell_height;
+
+        info!("Cell Size: {} x {}", cell_width, cell_height);
     }
 
     /// Clear glyph cache.
@@ -432,6 +434,10 @@ impl Display {
         // Resize renderer.
         let physical = PhysicalSize::new(self.size_info.width as u32, self.size_info.height as u32);
         self.window.resize(physical);
+
+        info!("Padding: {} x {}", self.size_info.padding_x, self.size_info.padding_y);
+        info!("Width: {}, Height: {}", self.size_info.width, self.size_info.height);
+
         self.renderer.resize(&self.size_info);
     }
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -435,7 +435,7 @@ impl Display {
         let physical = PhysicalSize::new(self.size_info.width as u32, self.size_info.height as u32);
         self.window.resize(physical);
         self.renderer.resize(&self.size_info);
-        
+
         info!("Padding: {} x {}", self.size_info.padding_x, self.size_info.padding_y);
         info!("Width: {}, Height: {}", self.size_info.width, self.size_info.height);
     }

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -434,7 +434,6 @@ impl Display {
         // Resize renderer.
         let physical = PhysicalSize::new(self.size_info.width as u32, self.size_info.height as u32);
         self.window.resize(physical);
-
         self.renderer.resize(&self.size_info);
         
         info!("Padding: {} x {}", self.size_info.padding_x, self.size_info.padding_y);

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1219,8 +1219,6 @@ impl TextShaderProgram {
         let offset_x = -1.;
         let offset_y = 1.;
 
-        info!("Width: {}, Height: {}", width, height);
-
         unsafe {
             gl::Uniform4f(self.u_projection, offset_x, offset_y, scale_x, scale_y);
         }


### PR DESCRIPTION
This makes our logging of 'SizeInfo' changes more consistent
with the one we're using when creating a new 'Display'.
