### PR TITLE
Remove Unused Linear Type

### DIFF
--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -220,28 +220,6 @@ impl fmt::Display for Column {
     }
 }
 
-/// A linear index.
-///
-/// Newtype to avoid passing values incorrectly.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
-pub struct Linear(pub usize);
-
-impl Linear {
-    pub fn new(columns: Column, column: Column, line: Line) -> Self {
-        Linear(line.0 * columns.0 + column.0)
-    }
-
-    pub fn from_point(columns: Column, point: Point<usize>) -> Self {
-        Linear(point.line * columns.0 + point.col.0)
-    }
-}
-
-impl fmt::Display for Linear {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Linear({})", self.0)
-    }
-}
-
 // Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -485,7 +463,6 @@ macro_rules! ops {
 
 ops!(Line, Line);
 ops!(Column, Column);
-ops!(Linear, Linear);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Just noticed that this new type isn't used anywhere, and I frankly can't imagine what it's purpose could be. Perhaps this is motivated by my long standing desire to remove `Line` and `Column` as well... but at least this is a smaller, and hopefully less contentious removal.