### PR TITLE
Fix selection incorrectly expanding when scrolled in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash when copying/pasting with neither pointer nor keyboard focus on Wayland
 - Crash due to fd leak on Wayland
 - IME window position with fullwidth characters in the search bar
+- Selection sometimes expanding over 2 chars when scrolled up in history
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash when copying/pasting with neither pointer nor keyboard focus on Wayland
 - Crash due to fd leak on Wayland
 - IME window position with fullwidth characters in the search bar
-- Selection sometimes expanding over 2 chars when scrolled up in history
+- Selection expanding over 2 characters when scrolled in history with fullwidth characters in use
 
 ## 0.5.0
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -211,8 +211,7 @@ impl<'a, C> RenderableCellsIter<'a, C> {
 
         let num_cols = self.grid.cols();
 
-        // Since we can have non zero display offset, we must take points from a grid in buffer
-        // coordinates.
+        // Convert to absolute coordinates to adjust for the display offset.
         let buffer_point = self.grid.visible_to_buffer(point);
         let cell = self.grid[buffer_point];
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -210,23 +210,29 @@ impl<'a, C> RenderableCellsIter<'a, C> {
         }
 
         let num_cols = self.grid.cols();
-        let cell = self.grid[&point];
+
+        // Since we can have non zero display offset, we must take points from a grid in buffer
+        // coordinates.
+        let buffer_point = self.grid.visible_to_buffer(point);
+        let cell = self.grid[buffer_point];
 
         // Check if wide char's spacers are selected.
         if cell.flags.contains(Flags::WIDE_CHAR) {
             let prev = point.sub(num_cols, 1);
+            let buffer_prev = self.grid.visible_to_buffer(prev);
             let next = point.add(num_cols, 1);
 
             // Check trailing spacer.
             selection.contains(next.col, next.line)
                 // Check line-wrapping, leading spacer.
-                || (self.grid[&prev].flags.contains(Flags::LEADING_WIDE_CHAR_SPACER)
+                || (self.grid[buffer_prev].flags.contains(Flags::LEADING_WIDE_CHAR_SPACER)
                     && selection.contains(prev.col, prev.line))
         } else if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
             // Check if spacer's wide char is selected.
             let prev = point.sub(num_cols, 1);
+            let buffer_prev = self.grid.visible_to_buffer(prev);
 
-            if self.grid[&prev].flags.contains(Flags::WIDE_CHAR) {
+            if self.grid[buffer_prev].flags.contains(Flags::WIDE_CHAR) {
                 // Check previous cell for trailing spacer.
                 self.is_selected(prev)
             } else {


### PR DESCRIPTION
When doing selection expansion we were checking for wide char flags
on a cells from the bottom of the terminal instead of in a current
viewport when scrolled up in history, which was leading to expanding
more than needed if we had wide chars on the same viewport cell,
but in the bottom of the terminal.

Fixes #4257.
