### PR TITLE
Fix handling of Unicode characters in Message bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - IME window position with fullwidth characters in the search bar
 - Selection expanding over 2 characters when scrolled in history with fullwidth characters in use
 - Selection scrolling not starting when mouse is over the message bar
+- Incorrect text width calculation in message bar when the message contains multibyte characters
 
 ## 0.5.0
 

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -43,12 +43,13 @@ impl Message {
         let mut lines = Vec::new();
         let mut line = String::new();
         for c in self.text.trim().chars() {
+            let line_len = line.chars().count();
             if c == '\n'
-                || line.len() == num_cols
+                || line_len == num_cols
                 // Keep space in first line for button.
                 || (lines.is_empty()
                     && num_cols >= button_len
-                    && line.len() == num_cols.saturating_sub(button_len + CLOSE_BUTTON_PADDING))
+                    && line_len == num_cols.saturating_sub(button_len + CLOSE_BUTTON_PADDING))
             {
                 // Attempt to wrap on word boundaries.
                 if let (Some(index), true) = (line.rfind(char::is_whitespace), c != '\n') {

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -38,7 +38,7 @@ impl Message {
         let total_lines =
             (size_info.height() - 2. * size_info.padding_y()) / size_info.cell_height();
         let max_lines = (total_lines as usize).saturating_sub(MIN_FREE_LINES);
-        let button_len = CLOSE_BUTTON_TEXT.width();
+        let button_len = CLOSE_BUTTON_TEXT.chars().count();
 
         // Split line to fit the screen.
         let mut lines = Vec::new();

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use alacritty_terminal::term::SizeInfo;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthChar;
 
 pub const CLOSE_BUTTON_TEXT: &str = "[X]";
 const CLOSE_BUTTON_PADDING: usize = 1;

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -111,8 +111,7 @@ impl Message {
     /// Right-pad text to fit a specific number of columns.
     #[inline]
     fn pad_text(mut text: String, num_cols: usize) -> String {
-        let text_len = text.chars().count();
-        let padding_len = num_cols.saturating_sub(text_len);
+        let padding_len = num_cols.saturating_sub(text.chars().count());
         text.extend(vec![' '; padding_len]);
         text
     }

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -111,7 +111,8 @@ impl Message {
     /// Right-pad text to fit a specific number of columns.
     #[inline]
     fn pad_text(mut text: String, num_cols: usize) -> String {
-        let padding_len = num_cols.saturating_sub(text.len());
+        let text_len = text.chars().count();
+        let padding_len = num_cols.saturating_sub(text_len);
         text.extend(vec![' '; padding_len]);
         text
     }


### PR DESCRIPTION
When formating text for displaying in Message bar, allacritty was using the byte
length of the text instead of character length; this generated unnecessary blank
space at the end of lines.

Fixes #4250.