### PR TITLE
Fix feature checking in cross builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Touchpad scrolling scrolled less than it should on macOS/Wayland on scaled outputs
 - Incorrect modifiers at startup on X11
 - `Add` and `Subtract` keys are now named `NumpadAdd` and `NumpadSubtract` respectively
+- Feature checking when cross compiling between different operating systems
 
 ## 0.5.0
 

--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -1,6 +1,3 @@
-#[cfg(not(any(feature = "x11", feature = "wayland", target_os = "macos", windows)))]
-compile_error!(r#"at least one of the "x11"/"wayland" features must be enabled"#);
-
 use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
 
 use std::env;

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -8,6 +8,9 @@
 // See https://msdn.microsoft.com/en-us/library/4cc7ya5b.aspx for more details.
 #![windows_subsystem = "windows"]
 
+#[cfg(not(any(feature = "x11", feature = "wayland", target_os = "macos", windows)))]
+compile_error!(r#"at least one of the "x11"/"wayland" features must be enabled"#);
+
 #[cfg(target_os = "macos")]
 use std::env;
 use std::error::Error;


### PR DESCRIPTION
Checking for target os in build.rs doesn't work, since build.rs
is running for host, so checking should be done in src. Thus moving
'compile_error!' check from build.rs to main.rs.