### PR TITLE
Make use of glutin wayland/x11 features

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -12,10 +12,16 @@ sources:
 tasks:
   - rustup: |
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
-  - 1-43-1: |
       $HOME/.cargo/bin/rustup toolchain install --profile minimal 1.43.1
+  - 1-43-1: |
       cd alacritty
       $HOME/.cargo/bin/cargo +1.43.1 test
+  - 1-43-1-wayland: |
+      cd alacritty
+      $HOME/.cargo/bin/cargo +1.43.1 test --no-default-features --features=wayland
+  - 1-43-1-x11: |
+      cd alacritty
+      $HOME/.cargo/bin/cargo +1.43.1 test --no-default-features --features=x11
   - stable: |
       cd alacritty
       $HOME/.cargo/bin/cargo +stable test

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -17,10 +17,10 @@ tasks:
       cd alacritty
       $HOME/.cargo/bin/cargo +1.43.1 test
   - 1-43-1-wayland: |
-      cd alacritty
+      cd alacritty/alacritty
       $HOME/.cargo/bin/cargo +1.43.1 test --no-default-features --features=wayland
   - 1-43-1-x11: |
-      cd alacritty
+      cd alacritty/alacritty
       $HOME/.cargo/bin/cargo +1.43.1 test --no-default-features --features=x11
   - stable: |
       cd alacritty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "glutin"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94c05751b6948879d2b15d49930e16ecc0144e51fcb8cd873686d6c4b5ebed"
+checksum = "d8bae26a39a728b003e9fad473ea89527de0de050143b4df866f18bb154bc86e"
 dependencies = [
  "android_glue",
  "cgl",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -21,7 +21,7 @@ fnv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1"
-glutin = { version = "0.25.0", features = ["serde"] }
+glutin = { version = "0.25.1", default-features = false, features = ["serde"] }
 notify = "4"
 parking_lot = "0.11.0"
 crossfont = { version = "0.1.0", features = ["force_system_fontconfig"] }
@@ -47,8 +47,8 @@ objc = "0.2.2"
 dirs = "2.0.2"
 
 [target.'cfg(not(any(target_os="windows", target_os="macos")))'.dependencies]
-x11-dl = "2"
-wayland-client = { version = "0.28.0", features = ["dlopen"] }
+x11-dl = { version = "2", optional = true }
+wayland-client = { version = "0.28.0", features = ["dlopen"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.7", features = ["impl-default", "wincon"]}
@@ -58,8 +58,8 @@ embed-resource = "1.3"
 
 [features]
 default = ["wayland", "x11", "winpty"]
-x11 = ["copypasta/x11"]
-wayland = ["copypasta/wayland"]
+x11 = ["copypasta/x11", "glutin/x11", "x11-dl"]
+wayland = ["copypasta/wayland", "glutin/wayland", "wayland-client"]
 winpty = ["alacritty_terminal/winpty"]
 # Enabling this feature makes shaders automatically reload when changed
 live-shader-reload = []

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -726,14 +726,7 @@ impl<N: Notify + OnResize> Processor<N> {
         cli_options: CLIOptions,
     ) -> Processor<N> {
         #[cfg(not(any(target_os = "macos", windows)))]
-        let clipboard = {
-            #[cfg(all(feature = "x11", not(feature = "wayland")))]
-            let wayland_display = None;
-            #[cfg(feature = "wayland")]
-            let wayland_display = display.window.wayland_display();
-
-            Clipboard::new(wayland_display)
-        };
+        let clipboard = Clipboard::new(display.window.wayland_display());
         #[cfg(any(target_os = "macos", windows))]
         let clipboard = Clipboard::new();
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -19,7 +19,7 @@ use glutin::dpi::PhysicalSize;
 use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, MouseButton, WindowEvent};
 use glutin::event_loop::{ControlFlow, EventLoop, EventLoopProxy, EventLoopWindowTarget};
 use glutin::platform::desktop::EventLoopExtDesktop;
-#[cfg(not(any(target_os = "macos", windows)))]
+#[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
 use glutin::platform::unix::EventLoopWindowTargetExtUnix;
 use log::info;
 use serde_json as json;
@@ -726,7 +726,14 @@ impl<N: Notify + OnResize> Processor<N> {
         cli_options: CLIOptions,
     ) -> Processor<N> {
         #[cfg(not(any(target_os = "macos", windows)))]
-        let clipboard = Clipboard::new(display.window.wayland_display());
+        let clipboard = {
+            #[cfg(all(feature = "x11", not(feature = "wayland")))]
+            let wayland_display = None;
+            #[cfg(feature = "wayland")]
+            let wayland_display = display.window.wayland_display();
+
+            Clipboard::new(wayland_display)
+        };
         #[cfg(any(target_os = "macos", windows))]
         let clipboard = Clipboard::new();
 
@@ -749,7 +756,7 @@ impl<N: Notify + OnResize> Processor<N> {
 
     /// Return `true` if `event_queue` is empty, `false` otherwise.
     #[inline]
-    #[cfg(not(any(target_os = "macos", windows)))]
+    #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
     fn event_queue_empty(&mut self) -> bool {
         let wayland_event_queue = match self.display.wayland_event_queue.as_mut() {
             Some(wayland_event_queue) => wayland_event_queue,
@@ -767,7 +774,7 @@ impl<N: Notify + OnResize> Processor<N> {
 
     /// Return `true` if `event_queue` is empty, `false` otherwise.
     #[inline]
-    #[cfg(any(target_os = "macos", windows))]
+    #[cfg(any(target_os = "macos", windows, not(feature = "wayland")))]
     fn event_queue_empty(&mut self) -> bool {
         self.event_queue.is_empty()
     }
@@ -863,7 +870,7 @@ impl<N: Notify + OnResize> Processor<N> {
 
             // Skip rendering on Wayland until we get frame event from compositor.
             #[cfg(not(any(target_os = "macos", windows)))]
-            if event_loop.is_wayland() && !self.display.window.should_draw.load(Ordering::Relaxed) {
+            if !self.display.is_x11 && !self.display.window.should_draw.load(Ordering::Relaxed) {
                 return;
             }
 
@@ -1114,7 +1121,7 @@ impl<N: Notify + OnResize> Processor<N> {
             processor.ctx.window.set_title(&config.ui_config.window.title);
         }
 
-        #[cfg(not(any(target_os = "macos", windows)))]
+        #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
         if processor.ctx.event_loop.is_wayland() {
             processor.ctx.window.set_wayland_theme(&config.colors);
         }

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -160,10 +160,7 @@ fn run(
     // The PTY forks a process to run the shell on the slave side of the
     // pseudoterminal. A file descriptor for the master side is retained for
     // reading/writing to the shell.
-    #[cfg(not(any(target_os = "macos", windows)))]
     let pty = tty::new(&config, &display.size_info, display.window.x11_window_id());
-    #[cfg(any(target_os = "macos", windows))]
-    let pty = tty::new(&config, &display.size_info, None);
 
     // Create the pseudoterminal I/O loop.
     //

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -48,7 +48,7 @@ mod scheduler;
 mod url;
 mod window;
 
-#[cfg(not(any(target_os = "macos", windows)))]
+#[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
 mod wayland_theme;
 
 mod gl {

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -348,7 +348,7 @@ impl Window {
     pub fn x11_window_id(&self) -> Option<usize> {
         #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
         return self.window().xlib_window().map(|xlib_window| xlib_window as usize);
-        #[cfg(not(any(feature = "x11", target_os = "macos", windows)))]
+        #[cfg(any(target_os = "macos", windows, not(feature = "x11")))]
         return None;
     }
 

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -163,7 +163,7 @@ impl Window {
         let window_config = &config.ui_config.window;
         let window_builder = Window::get_platform_window(&window_config.title, &window_config);
 
-        // Disable vsync on Wayland.
+        // Check if we're running Wayland to disable vsync.
         #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
         let is_wayland = event_loop.is_wayland();
         #[cfg(any(target_os = "macos", windows, not(feature = "wayland")))]
@@ -393,14 +393,14 @@ impl Window {
         self.window().set_simple_fullscreen(simple_fullscreen);
     }
 
-    #[cfg(any(not(feature = "wayland"), any(target_os = "macos", windows)))]
-    pub fn wayland_display(&self) -> Option<*mut std::ffi::c_void> {
-        None
-    }
-
     #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
     pub fn wayland_display(&self) -> Option<*mut std::ffi::c_void> {
         self.window().wayland_display()
+    }
+
+    #[cfg(any(not(feature = "wayland"), any(target_os = "macos", windows)))]
+    pub fn wayland_display(&self) -> Option<*mut std::ffi::c_void> {
+        None
     }
 
     #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -271,9 +271,9 @@ impl Window {
             .with_fullscreen(window_config.fullscreen())
             .with_window_icon(icon.ok());
 
-        // Wayland.
         #[cfg(feature = "wayland")]
         let builder = builder.with_app_id(class.instance.clone());
+
         #[cfg(feature = "x11")]
         let builder = builder.with_class(class.instance.clone(), class.general.clone());
 
@@ -325,8 +325,8 @@ impl Window {
     }
 
     #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
-    pub fn set_urgent(&self, _is_urgent: bool) {
-        self.window().set_urgent(_is_urgent);
+    pub fn set_urgent(&self, is_urgent: bool) {
+        self.window().set_urgent(is_urgent);
     }
 
     #[cfg(target_os = "macos")]
@@ -345,11 +345,14 @@ impl Window {
         self.window().set_outer_position(pos);
     }
 
+    #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
     pub fn x11_window_id(&self) -> Option<usize> {
-        #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
-        return self.window().xlib_window().map(|xlib_window| xlib_window as usize);
-        #[cfg(any(target_os = "macos", windows, not(feature = "x11")))]
-        return None;
+        self.window().xlib_window().map(|xlib_window| xlib_window as usize)
+    }
+
+    #[cfg(any(target_os = "macos", windows, not(feature = "x11")))]
+    pub fn x11_window_id(&self) -> Option<usize> {
+        None
     }
 
     pub fn window_id(&self) -> WindowId {
@@ -388,12 +391,14 @@ impl Window {
         self.window().set_simple_fullscreen(simple_fullscreen);
     }
 
-    #[cfg(not(any(target_os = "macos", windows)))]
+    #[cfg(any(not(feature = "wayland"), any(target_os = "macos", windows)))]
     pub fn wayland_display(&self) -> Option<*mut std::ffi::c_void> {
-        #[cfg(feature = "wayland")]
-        return self.window().wayland_display();
-        #[cfg(not(feature = "wayland"))]
-        return None;
+        None
+    }
+
+    #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
+    pub fn wayland_display(&self) -> Option<*mut std::ffi::c_void> {
+        self.window().wayland_display()
     }
 
     #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]


### PR DESCRIPTION
This should allow users that are not using Wayland/X11
to reduce the resulted binary size and compilation times.


This honestly looks nicer than I expected, so I feel like it should be fine to merge it.

For reference striped binary sizes:
```
x11: 4.6M
wayland: 5.9M
both: 6.4M
```