### PR TITLE
Follow xterm and preserve foreground color on reset

### DIFF
--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -55,7 +55,6 @@ impl GridCell for Cell {
         (self.c == ' ' || self.c == '\t')
             && self.extra[0] == ' '
             && self.bg == Color::Named(NamedColor::Background)
-            && self.fg == Color::Named(NamedColor::Foreground)
             && !self.flags.intersects(
                 Flags::INVERSE
                     | Flags::UNDERLINE
@@ -131,7 +130,7 @@ impl Cell {
     #[inline]
     pub fn reset(&mut self, template: &Cell) {
         // memcpy template to self.
-        *self = Cell { c: template.c, bg: template.bg, ..Cell::default() };
+        *self = Cell { c: template.c, bg: template.bg, fg: template.fg, ..Cell::default() };
     }
 
     #[inline]


### PR DESCRIPTION
Xterm preserves foreground color on reset, but those cells are
considered empty in it, thus we change our 'is_empty' and 'reset' logic
to match it.

Fixes #4264.

