### PR TITLE
Adding Ref Test Diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "miow 0.3.5",
  "nix",
  "parking_lot",
+ "pretty_assertions",
  "regex-automata",
  "serde",
  "serde_json",
@@ -529,6 +530,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +594,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "dirs"
@@ -1498,6 +1515,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1631,18 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "difference",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-crate"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -46,3 +46,4 @@ bench = []
 
 [dev-dependencies]
 serde_json = "1.0.0"
+pretty_assertions = "*"

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -1,3 +1,4 @@
+use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use serde_json as json;
 
@@ -119,20 +120,10 @@ fn ref_test(dir: &Path) {
             for j in 0..grid.cols().0 {
                 let cell = term_grid[i][Column(j)];
                 let original_cell = grid[i][Column(j)];
-                if original_cell != cell {
-                    println!(
-                        "[{i}][{j}] {original:?} => {now:?}",
-                        i = i,
-                        j = j,
-                        original = original_cell,
-                        now = cell,
-                    );
-                }
+                println!("{}", pretty_assertions::Comparison::new(&cell, &original_cell));
             }
         }
 
-        panic!("Ref test failed; grid doesn't match");
+        panic!("ref test failed; grid doesn't match");
     }
-
-    assert_eq!(grid, term_grid);
 }

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -1,4 +1,4 @@
-use pretty_assertions::assert_eq;
+use pretty_assertions::Comparison;
 use serde::Deserialize;
 use serde_json as json;
 
@@ -120,7 +120,7 @@ fn ref_test(dir: &Path) {
             for j in 0..grid.cols().0 {
                 let cell = term_grid[i][Column(j)];
                 let original_cell = grid[i][Column(j)];
-                println!("{}", pretty_assertions::Comparison::new(&cell, &original_cell));
+                println!("{}", Comparison::new(&original_cell, &cell));
             }
         }
 


### PR DESCRIPTION
Show diffs on ref tests with the `pretty_assertions` crate. The one thing I'm not really sure about with this is if it's better to just fail immediately on the first non-match, or to keep things more like they were before as I've done here.

![screenshot-2020-10-13T18:10:30Z](https://user-images.githubusercontent.com/715947/95899939-4411bf00-0d5f-11eb-87d9-ff80474c3545.png)

vs before:

![screenshot-2020-10-13T18:22:46Z](https://user-images.githubusercontent.com/715947/95900256-a10d7500-0d5f-11eb-8c07-55608815f3f7.png)