### PR TITLE
Handling CompositionEvent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "urlocator",
  "wayland-client",
  "winapi 0.3.9",
+ "winit",
  "x11-dl",
  "xdg",
 ]
@@ -2386,8 +2387,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winit"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bc559da567d8aa671bbcd08304d49e982c7bf2cb91e10288b9188931c1b772"
+source = "git+https://github.com/rust-windowing/winit?branch=composition-event#84f26b0e5ecb2b1254206af7e3a0d485c5f78836"
 dependencies = [
  "bitflags",
  "cocoa 0.23.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winit"
 version = "0.23.0"
-source = "git+https://github.com/rust-windowing/winit?branch=composition-event#84f26b0e5ecb2b1254206af7e3a0d485c5f78836"
+source = "git+https://github.com/rust-windowing/winit?rev=84f26b0e5ecb2b1254206af7e3a0d485c5f78836#84f26b0e5ecb2b1254206af7e3a0d485c5f78836"
 dependencies = [
  "bitflags",
  "cocoa 0.23.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ incremental = false
 
 [patch.crates-io.winit]
 git = "https://github.com/rust-windowing/winit"
-branch = "composition-event"
+rev = "84f26b0e5ecb2b1254206af7e3a0d485c5f78836"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ members = [
 lto = true
 debug = 1
 incremental = false
+
+[patch.crates-io.winit]
+git = "https://github.com/rust-windowing/winit"
+branch = "composition-event"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -49,6 +49,7 @@ dirs = "2.0.2"
 [target.'cfg(not(any(target_os="windows", target_os="macos")))'.dependencies]
 x11-dl = { version = "2", optional = true }
 wayland-client = { version = "0.28.0", features = ["dlopen"], optional = true }
+winit = { git = "https://github.com/rust-windowing/winit", branch = "composition-event" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.7", features = ["impl-default", "wincon"]}

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1"
 glutin = { version = "0.25.1", default-features = false, features = ["serde"] }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "84f26b0e5ecb2b1254206af7e3a0d485c5f78836" }
 notify = "4"
 parking_lot = "0.11.0"
 crossfont = { version = "0.1.0", features = ["force_system_fontconfig"] }
@@ -49,7 +50,6 @@ dirs = "2.0.2"
 [target.'cfg(not(any(target_os="windows", target_os="macos")))'.dependencies]
 x11-dl = { version = "2", optional = true }
 wayland-client = { version = "0.28.0", features = ["dlopen"], optional = true }
-winit = { git = "https://github.com/rust-windowing/winit", rev = "84f26b0e5ecb2b1254206af7e3a0d485c5f78836" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.7", features = ["impl-default", "wincon"]}

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -49,7 +49,7 @@ dirs = "2.0.2"
 [target.'cfg(not(any(target_os="windows", target_os="macos")))'.dependencies]
 x11-dl = { version = "2", optional = true }
 wayland-client = { version = "0.28.0", features = ["dlopen"], optional = true }
-winit = { git = "https://github.com/rust-windowing/winit", branch = "composition-event" }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "84f26b0e5ecb2b1254206af7e3a0d485c5f78836" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.7", features = ["impl-default", "wincon"]}

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -981,7 +981,10 @@ impl<N: Notify + OnResize> Processor<N> {
                         processor.key_input(input);
                     },
                     WindowEvent::ReceivedCharacter(c) => processor.received_char(c),
-                    WindowEvent::Composition(CompositionEvent::CompositionUpdate(text, position)) => processor.composition_update(text, position),
+                    WindowEvent::Composition(CompositionEvent::CompositionUpdate(
+                        text,
+                        position,
+                    )) => processor.composition_update(text, position),
                     WindowEvent::MouseInput { state, button, .. } => {
                         processor.ctx.window.set_mouse_visible(true);
                         processor.mouse_input(state, button);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -981,17 +981,7 @@ impl<N: Notify + OnResize> Processor<N> {
                         processor.key_input(input);
                     },
                     WindowEvent::ReceivedCharacter(c) => processor.received_char(c),
-                    WindowEvent::Composition(composition_event) => match composition_event {
-                        CompositionEvent::CompositionStart(text) => {
-                            processor.composition_start(text);
-                        },
-                        CompositionEvent::CompositionUpdate(text, position) => {
-                            processor.composition_update(text, position);
-                        },
-                        CompositionEvent::CompositionEnd(text) => {
-                            processor.composition_end(text);
-                        },
-                    },
+                    WindowEvent::Composition(CompositionEvent::CompositionUpdate(text, position)) => processor.composition_update(text, position),
                     WindowEvent::MouseInput { state, button, .. } => {
                         processor.ctx.window.set_mouse_visible(true);
                         processor.mouse_input(state, button);
@@ -1043,7 +1033,8 @@ impl<N: Notify + OnResize> Processor<N> {
                     | WindowEvent::ThemeChanged(_)
                     | WindowEvent::HoveredFile(_)
                     | WindowEvent::Touch(_)
-                    | WindowEvent::Moved(_) => (),
+                    | WindowEvent::Moved(_)
+                    | WindowEvent::Composition(_) => (),
                 }
             },
             GlutinEvent::Suspended { .. }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -15,8 +15,10 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use winit::event::{CompositionEvent, WindowEvent};
+
 use glutin::dpi::PhysicalSize;
-use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, MouseButton, WindowEvent};
+use glutin::event::{ElementState, Event as GlutinEvent, ModifiersState, MouseButton};
 use glutin::event_loop::{ControlFlow, EventLoop, EventLoopProxy, EventLoopWindowTarget};
 use glutin::platform::desktop::EventLoopExtDesktop;
 #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
@@ -979,6 +981,17 @@ impl<N: Notify + OnResize> Processor<N> {
                         processor.key_input(input);
                     },
                     WindowEvent::ReceivedCharacter(c) => processor.received_char(c),
+                    WindowEvent::Composition(composition_event) => match composition_event {
+                        CompositionEvent::CompositionStart(text) => {
+                            processor.composition_start(text);
+                        },
+                        CompositionEvent::CompositionUpdate(text, position) => {
+                            processor.composition_update(text, position);
+                        },
+                        CompositionEvent::CompositionEnd(text) => {
+                            processor.composition_end(text);
+                        },
+                    },
                     WindowEvent::MouseInput { state, button, .. } => {
                         processor.ctx.window.set_mouse_visible(true);
                         processor.mouse_input(state, button);


### PR DESCRIPTION
## Summary

Support `CompositionEvent` implemented on winit's [sub branch](https://github.com/rust-windowing/winit/tree/composition-event) for IME preedit support

I check work on my Arch Linux + uim(byeoru)

For now this only work on X11 because winit doesn't have implementation for other platforms


## Blocking upstream issue

https://github.com/rust-windowing/winit/issues/1497