### PR TITLE
Add polling for a new config to watch when config is deleted

### DIFF
--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -10,26 +10,42 @@ use alacritty_terminal::thread;
 
 use crate::event::{Event, EventProxy};
 
-pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventProxy) {
-    // Canonicalize all paths, filtering out the ones that do not exist.
-    paths = paths
-        .drain(..)
-        .filter_map(|path| match fs::canonicalize(&path) {
-            Ok(path) => Some(path),
+struct ConfigPath {
+    path: PathBuf,
+    symlink: Option<PathBuf>,
+}
+
+impl ConfigPath {
+    fn get(path: PathBuf) -> Option<Self> {
+        // Canonicalize all paths, filtering out the ones that do not exist.
+        match fs::canonicalize(&path) {
+            Ok(path) => {
+                // Keep the symlink in case it is recreated
+                let symlink =
+                    if path.symlink_metadata().is_ok() { Some(path.clone()) } else { None };
+
+                Some(ConfigPath { path, symlink })
+            },
             Err(err) => {
                 error!("Unable to canonicalize config path {:?}: {}", path, err);
                 None
             },
-        })
-        .collect();
+        }
+    }
+}
+
+pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventProxy) {
+    // Canonicalize paths and eventually get symlinks
+    let config_paths: Vec<ConfigPath> = paths.drain(..).filter_map(ConfigPath::get).collect();
 
     // Don't monitor config if there is no path to watch.
-    if paths.is_empty() {
+    if config_paths.is_empty() {
         return;
     }
 
     // The Duration argument is a debouncing period.
     let (tx, rx) = mpsc::channel();
+
     let mut watcher = match watcher(tx, Duration::from_millis(10)) {
         Ok(watcher) => watcher,
         Err(err) => {
@@ -39,17 +55,12 @@ pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventProxy) {
     };
 
     thread::spawn_named("config watcher", move || {
-        // Get all unique parent directories.
-        let mut parents = paths
+        let paths = &config_paths
             .iter()
-            .map(|path| {
-                let mut path = path.clone();
-                path.pop();
-                path
-            })
+            .map(|config_path| config_path.path.clone())
             .collect::<Vec<PathBuf>>();
-        parents.sort_unstable();
-        parents.dedup();
+
+        let parents = get_all_unique_parent_directories(paths.as_slice());
 
         // Watch all configuration file directories.
         for parent in &parents {
@@ -69,13 +80,24 @@ pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventProxy) {
 
             match event {
                 DebouncedEvent::Rename(..) => continue,
+                DebouncedEvent::NoticeRemove(path) | DebouncedEvent::Remove(path) => {
+                    let path_is_known = config_paths.iter().any(|config_path| {
+                        path == config_path.path || config_path.symlink == Some(path.clone())
+                    });
+                    if path_has_been_recreated(&path) && path_is_known {
+                        if let Err(err) = watcher.watch(&path, RecursiveMode::NonRecursive) {
+                            debug!("Unable to watch config directory {:?}: {}", path, err);
+                        } else {
+                            event_proxy.send_event(Event::ConfigReload(paths[0].clone()));
+                        }
+                    }
+                },
                 DebouncedEvent::Write(path)
                 | DebouncedEvent::Create(path)
                 | DebouncedEvent::Chmod(path) => {
-                    if !paths.contains(&path) {
+                    if !paths.contains(&&path) {
                         continue;
                     }
-
                     // Always reload the primary configuration file.
                     event_proxy.send_event(Event::ConfigReload(paths[0].clone()));
                 },
@@ -83,4 +105,33 @@ pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventProxy) {
             }
         }
     });
+}
+
+fn get_all_unique_parent_directories(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut parents = paths
+        .iter()
+        .map(|path| {
+            let mut path = path.clone();
+            path.pop();
+            path
+        })
+        .collect::<Vec<PathBuf>>();
+    parents.sort_unstable();
+    parents.dedup();
+    parents
+}
+
+fn path_has_been_recreated(path: &PathBuf) -> bool {
+    let mut wait = 0;
+
+    while wait < 5 {
+        wait += 1;
+        std::thread::sleep(Duration::from_millis(1000));
+
+        if path.exists() {
+            return true;
+        }
+    }
+
+    false
 }


### PR DESCRIPTION
Hello , this is my first PR to alacritty so I have a few questions : 
- do this needs to be documented in changelog.md  ? 
- shall I bump the version (again I am not sure) ? 

This addresses #2237. 
Regarding the implementation I am not sure what I wrote is a 100% correct : 

- Is it safe to not resolve symlinks ? 
  ```rust
              if path.symlink_metadata().is_ok() {
                  Symlink(path.clone())
              } else {
                  ConfigPath::Path(path.clone())
              }
  ```   
  The idea here is to keep symlinks in place instead of following them. This way when config is unlinked we can wait for it to be re-linked. Symlink paths are not canonicalized in the next step, instead they are checked with `Path::exist`, could this have potential side effects ? 

- How long should we wait for config to be recreated ? 
  I have set a timeout of 6s with 100ms steps, is this appropriate ?

Let me now if anything needs to be changed. 

