### PR TITLE
Fix an issue where self.grid[point.line] would be out of bounds

### DIFF
--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -421,6 +421,7 @@ impl<T> Term<T> {
     /// Find the end of the current line across linewraps.
     pub fn line_search_right(&self, mut point: Point<usize>) -> Point<usize> {
         while point.line > 0
+            && point.line < self.total_lines()
             && self.grid[point.line][self.cols() - 1].flags.contains(Flags::WRAPLINE)
         {
             point.line -= 1;


### PR DESCRIPTION
Hi,

I got this panic when running Alacritty:

```
RUST_BACKTRACE=full alacritty
thread 'main' panicked at 'index out of bounds: the len is 4894 but the index is 18446744073709546721', /build/alacritty/src/alacritty/alacritty_terminal/src/term/search.rs:423:15
stack backtrace:
   0:     0x559289703450 - <unknown>
   1:     0x5592895ec5cc - <unknown>
   2:     0x559289702c36 - <unknown>
   3:     0x559289702500 - <unknown>
   4:     0x559289701bf2 - <unknown>
   5:     0x559289701838 - <unknown>
   6:     0x559289701804 - <unknown>
   7:     0x5592897017bd - <unknown>
   8:     0x5592895e9d50 - <unknown>
   9:     0x5592895e9be1 - <unknown>
  10:     0x559289571af8 - <unknown>
  11:     0x55928950231a - <unknown>
  12:     0x55928957a432 - <unknown>
  13:     0x5592895532e2 - <unknown>
  14:     0x559289411086 - <unknown>
  15:     0x5592894b90fb - <unknown>
  16:     0x55928953bac3 - <unknown>
  17:     0x5592894b0d58 - <unknown>
  18:     0x7f2913329152 - __libc_start_main
  19:     0x5592893e70ae - <unknown>
  20:                0x0 - <unknown>
```

This is using the [`alacritty 0.5.0-3`](https://github.com/archlinux/svntogit-community/blob/packages/alacritty/trunk/PKGBUILD) package that comes with Arch Linux, which uses the `v0.5.0` git tag.

The error was triggered by editing a `PKGBUILD` file with the [`o`](https://github.com/xyproto/o) text editor, then repeatedly alternating between frenetically resizing the window and pressing `ctrl-a` and `ctrl-e`, until Alacritty crashed. I could not find the exact steps to reproduce this, it seems to crash after crossing a certain threshold of abusive window resizing.

This small patch seems to fix the issue.

All tests pass.

Best regards,
Alexander F. Rødseth