### PR TITLE
Remove unneeded `collect()` in `RenderLines.rects`

### DIFF
--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -142,10 +142,9 @@ impl RenderLines {
     pub fn rects(&self, metrics: &Metrics, size: &SizeInfo) -> Vec<RenderRect> {
         self.inner
             .iter()
-            .map(|(flag, lines)| -> Vec<RenderRect> {
-                lines.iter().map(|line| line.rects(*flag, metrics, size)).flatten().collect()
+            .flat_map(|(flag, lines)| {
+                lines.iter().flat_map(move |line| line.rects(*flag, metrics, size))
             })
-            .flatten()
             .collect()
     }
 


### PR DESCRIPTION
Just something I noticed while looking around and it seemed easy/safe to improve. I ran the benchmarks a couple times and it wasn't _obviously_ faster but I was just looking number-by-number in my editor because, for whatever reason, when I run `./gnuplot/summary.sh *.dat output.svg` I get `line 0: undefined variable plot` 🤷 But, if someone else can help me get the plotter set up I can confirm if this is indeed an improvement.

**This Commit**
Uses `move` semantics to copy a `Flags` instance instead of allocating a
`Vec<RenderRect>`.

**Why?**
I expect the performance is better here - `Flags` is a `u16` so making
copies of that should be very cheap while heap-allocating a
`Vec<RenderRect>` is probably more costly. Although, of course, the
compiler could be doing all sorts of witchcraft to optimize away an
unnecessary allocation.

I also used `flat_map` which
seemed more idiomatic than `.map(...).flatten()` but I believe they're
functionally equivalent.