### PR TITLE
Add optional configuration imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.7.0-dev
 
+### Changed
+
+- Providing non existing paths in `import` won't result in error. Importing from these configs will be skipped
+
 ### Fixed
 
 - Wide characters sometimes being cut off
@@ -47,7 +51,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reduce memory usage by up to at least 30% with a full scrollback buffer
 - The number of zerowidth characters per cell is no longer limited to 5
 - `SpawnNewInstance` is now using the working directory of the terminal foreground process on macOS
-- Configuration `import` paths are now optional and will skip importing if path does not exist.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reduce memory usage by up to at least 30% with a full scrollback buffer
 - The number of zerowidth characters per cell is no longer limited to 5
 - `SpawnNewInstance` is now using the working directory of the terminal foreground process on macOS
+- Configuration `import` paths are now optional and will skip importing if path does not exist.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Providing non existing paths in `import` won't result in error. Importing from these configs will be skipped
+- Nonexistent config imports are ignored instead of raising an error
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -4,7 +4,8 @@
 #
 # These configuration files will be loaded in order, replacing values in files
 # loaded earlier with those loaded later in the chain. The file itself will
-# always be loaded last.
+# always be loaded last. If an import path cannot be found it will be skipped.
+# Skipped files will be logged at info level.
 #import:
 #  - /path/to/alacritty.yml
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -5,7 +5,6 @@
 # These configuration files will be loaded in order, replacing values in files
 # loaded earlier with those loaded later in the chain. The file itself will
 # always be loaded last. If an import path cannot be found it will be skipped.
-# Skipped files will be logged at info level.
 #import:
 #  - /path/to/alacritty.yml
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -66,7 +66,7 @@ impl Display for Error {
             Error::NotFound => write!(f, "Unable to locate config file"),
             Error::ReadingEnvHome(err) => {
                 write!(f, "Unable to read $HOME environment variable: {}", err)
-            },
+            }
             Error::Io(err) => write!(f, "Error reading config file: {}", err),
             Error::Yaml(err) => write!(f, "Problem with config: {}", err),
         }
@@ -137,7 +137,7 @@ fn load_from(path: &PathBuf, cli_config: Value) -> Result<Config> {
         Err(err) => {
             error!(target: LOG_TARGET_CONFIG, "Unable to load config {:?}: {}", path, err);
             Err(err)
-        },
+        }
     }
 }
 
@@ -183,7 +183,7 @@ fn parse_config(
             } else {
                 return Err(Error::Yaml(error));
             }
-        },
+        }
     };
 
     // Merge config with imports.
@@ -198,7 +198,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
         Some(_) => {
             error!(target: LOG_TARGET_CONFIG, "Invalid import type: expected a sequence");
             return Value::Null;
-        },
+        }
         None => return Value::Null,
     };
 
@@ -219,12 +219,12 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
                     "Invalid import element type: expected path string"
                 );
                 continue;
-            },
+            }
         };
 
         if !path.exists() {
             info!(target: LOG_TARGET_CONFIG, "Skipping importing config; not found:");
-            info!(target: LOG_TARGET_CONFIG, "  {}", path.display());
+            info!(target: LOG_TARGET_CONFIG, "  {:?}", path.display());
             continue;
         }
 
@@ -232,7 +232,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
             Ok(config) => merged = serde_utils::merge(merged, config),
             Err(err) => {
                 error!(target: LOG_TARGET_CONFIG, "Unable to import config {:?}: {}", path, err)
-            },
+            }
         }
     }
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -223,7 +223,8 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
         };
 
         if !path.exists() {
-            info!(target: LOG_TARGET_CONFIG, "Skip importing: '{}' not found", path.display());
+            info!(target: LOG_TARGET_CONFIG, "Skipping importing config; not found:");
+            info!(target: LOG_TARGET_CONFIG, "  {}", path.display());
             continue;
         }
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -66,7 +66,7 @@ impl Display for Error {
             Error::NotFound => write!(f, "Unable to locate config file"),
             Error::ReadingEnvHome(err) => {
                 write!(f, "Unable to read $HOME environment variable: {}", err)
-            }
+            },
             Error::Io(err) => write!(f, "Error reading config file: {}", err),
             Error::Yaml(err) => write!(f, "Problem with config: {}", err),
         }
@@ -137,7 +137,7 @@ fn load_from(path: &PathBuf, cli_config: Value) -> Result<Config> {
         Err(err) => {
             error!(target: LOG_TARGET_CONFIG, "Unable to load config {:?}: {}", path, err);
             Err(err)
-        }
+        },
     }
 }
 
@@ -183,7 +183,7 @@ fn parse_config(
             } else {
                 return Err(Error::Yaml(error));
             }
-        }
+        },
     };
 
     // Merge config with imports.
@@ -198,7 +198,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
         Some(_) => {
             error!(target: LOG_TARGET_CONFIG, "Invalid import type: expected a sequence");
             return Value::Null;
-        }
+        },
         None => return Value::Null,
     };
 
@@ -219,7 +219,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
                     "Invalid import element type: expected path string"
                 );
                 continue;
-            }
+            },
         };
 
         if !path.exists() {
@@ -232,7 +232,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
             Ok(config) => merged = serde_utils::merge(merged, config),
             Err(err) => {
                 error!(target: LOG_TARGET_CONFIG, "Unable to import config {:?}: {}", path, err)
-            }
+            },
         }
     }
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -222,6 +222,11 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
             },
         };
 
+        if !path.exists() {
+            info!(target: LOG_TARGET_CONFIG, "Skip importing: '{}' not found", path.display());
+            continue;
+        }
+
         match parse_config(&path, config_paths, recursion_limit - 1) {
             Ok(config) => merged = serde_utils::merge(merged, config),
             Err(err) => {


### PR DESCRIPTION
# Optional imports

This adds the ability to mark imports as `optional`. Optional imports
will be skip loading if they do not exist. If an import is not
explicitly marked as `optional`, then there will be an error raised like
normal.

An optional import is defined as a `path` and `optional` keys. Example:

```yaml
import:
  - /normal/path/to/config.yml
  - path: /path/to/config.yml
    optional: true
```

If both these files do not exist alacritty will raise an error on the
/normal/path/to/config.yml file.

Fixes: #4330 
