### PR TITLE
Remove rustc_tools_util dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,6 @@ dependencies = [
  "notify",
  "objc",
  "parking_lot",
- "rustc_tools_util",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1753,12 +1752,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_tools_util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b725dadae9fabc488df69a287f5a99c5eaf5d10853842a8a3dfac52476f544ee"
 
 [[package]]
 name = "rusttype"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -32,7 +32,6 @@ unicode-width = "0.1"
 
 [build-dependencies]
 gl_generator = "0.14.0"
-rustc_tools_util = "0.2.0"
 
 [target.'cfg(not(windows))'.dependencies]
 xdg = "2"

--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -1,12 +1,12 @@
-use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
-
 use std::env;
 use std::fs::File;
 use std::path::Path;
+use std::process::Command;
+
+use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
 
 fn main() {
-    let hash = rustc_tools_util::get_commit_hash().unwrap_or_default();
-    println!("cargo:rustc-env=GIT_HASH={}", hash);
+    println!("cargo:rustc-env=GIT_HASH={}", commit_hash());
 
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(&Path::new(&dest).join("gl_bindings.rs")).unwrap();
@@ -17,4 +17,13 @@ fn main() {
 
     #[cfg(windows)]
     embed_resource::compile("../extra/windows/windows.rc");
+}
+
+fn commit_hash() -> String {
+    Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .unwrap_or_default()
 }


### PR DESCRIPTION
Since our usage of the rustc_tools_util crate is so trivial, it seems
like we should be able to just inline it directly into Alacritty.

It's a very well trusted crate, being hosted directly by rust-lang and
it does not pull in any other dependencies, but having a dependency for
just 6 lines of code seems a bit extreme.
