### PR TITLE
Error on dead code when running clippy

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -898,8 +898,8 @@ impl<N: Notify + OnResize> Processor<N> {
     ///
     /// Doesn't take self mutably due to borrow checking.
     fn handle_event<T>(
-        event: GlutinEvent<Event>,
-        processor: &mut input::Processor<T, ActionContext<N, T>>,
+        event: GlutinEvent<'_, Event>,
+        processor: &mut input::Processor<'_, T, ActionContext<'_, N, T>>,
     ) where
         T: EventListener,
     {
@@ -1044,7 +1044,7 @@ impl<N: Notify + OnResize> Processor<N> {
     }
 
     /// Check if an event is irrelevant and can be skipped.
-    fn skip_event(event: &GlutinEvent<Event>) -> bool {
+    fn skip_event(event: &GlutinEvent<'_, Event>) -> bool {
         match event {
             GlutinEvent::WindowEvent { event, .. } => matches!(
                 event,
@@ -1066,8 +1066,10 @@ impl<N: Notify + OnResize> Processor<N> {
         }
     }
 
-    fn reload_config<T>(path: &PathBuf, processor: &mut input::Processor<T, ActionContext<N, T>>)
-    where
+    fn reload_config<T>(
+        path: &PathBuf,
+        processor: &mut input::Processor<'_, T, ActionContext<'_, N, T>>,
+    ) where
         T: EventListener,
     {
         if !processor.ctx.message_buffer.is_empty() {

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -1,6 +1,8 @@
 //! Alacritty - The GPU Enhanced Terminal.
 
+#![warn(rust_2018_idioms, future_incompatible)]
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 // With the default subsystem, 'console', windows creates an additional console
 // window for the program.

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1155,7 +1155,7 @@ where
     }
 }
 
-fn attrs_from_sgr_parameters(params: &mut ParamsIter) -> Vec<Option<Attr>> {
+fn attrs_from_sgr_parameters(params: &mut ParamsIter<'_>) -> Vec<Option<Attr>> {
     let mut attrs = Vec::with_capacity(params.size_hint().0);
 
     while let Some(param) = params.next() {

--- a/alacritty_terminal/src/lib.rs
+++ b/alacritty_terminal/src/lib.rs
@@ -1,6 +1,8 @@
 //! Alacritty - The GPU Enhanced Terminal.
 
+#![warn(rust_2018_idioms, future_incompatible)]
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 
 pub mod ansi;


### PR DESCRIPTION
It should simplify tracking of dead code on CI builds
and when cross checking.