### PR TITLE
Set ALACRITTY_PID environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use yellow/red from the config for error and warning messages instead of fixed colors
 - Existing CLI parameters are now passed to instances spawned using `SpawnNewInstance`
 - Wayland's Client side decorations now use the search bar colors
+- Set `$ALACRITTY_PID` to the terminal PID on start
 
 ### Fixed
 

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -135,6 +135,7 @@ fn run(
 
     // Set environment variables.
     tty::setup_env(&config);
+    std::env::set_var("ALACRITTY_PID", &format!("{}", std::process::id()));
 
     let event_proxy = EventProxy::new(window_event_loop.create_proxy());
 


### PR DESCRIPTION
Useful in scripts and daemons when trying to figure out the parent terminal.

I used this to solve the issue highlighted in this comment:
https://github.com/alacritty/alacritty/issues/1072#issuecomment-674310366

With the environment variable available, I just drop in a short shell script containing the following, and point to it with bell -> command -> program:
```
#!/bin/sh
swaymsg "[pid=$ALACRITTY_PID] urgent enable"
```
Or just use sh directly:
```
bell:
  command:
    program: sh
    args: ["-c", 'swaymsg "[pid=$ALACRITTY_PID] urgent enable"']
```