### PR TITLE
Fix visual bell getting stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Feature checking when cross compiling between different operating systems
 - Crash when writing to the clipboard fails on Wayland
 - Crash with large negative `font.offset.x/y`
+- Visual bell getting stuck on the first frame
 
 ## 0.5.0
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -297,8 +297,8 @@
   #   - Linear
   #animation: EaseOutExpo
 
-  # Duration of the visual bell flash. A `duration` of `0` will disable the
-  # visual bell animation.
+  # Duration of the visual bell flash in milliseconds. A `duration` of `0` will
+  # disable the visual bell animation.
   #duration: 0
 
   # Visual bell animation color.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -874,6 +874,8 @@ impl<N: Notify + OnResize> Processor<N> {
                 if !terminal.visual_bell.completed() {
                     let event: Event = TerminalEvent::Wakeup.into();
                     self.event_queue.push(event.into());
+
+                    *control_flow = ControlFlow::Poll;
                 }
 
                 // Redraw screen.


### PR DESCRIPTION
This resolves a problem with the visual bell where it would not
automatically trigger a redraw itself after the initial frame has been
rendered.

Since the unit of the visual bell duration is also unclear, it has been
clarified.