### PR TITLE
Fix sr.ht clippy job

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -24,7 +24,7 @@ tasks:
   - clippy: |
       cd alacritty
       rustup component add clippy
-      cargo clippy
+      cargo clippy --all-targets
   - oldstable: |
       cd alacritty
       rustup toolchain install --profile minimal 1.43.1

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -27,7 +27,7 @@ tasks:
   - clippy: |
       cd alacritty
       rustup component add clippy
-      cargo clippy
+      cargo clippy --all-targets
   - oldstable: |
       cd alacritty
       rustup toolchain install --profile minimal 1.43.1


### PR DESCRIPTION
This commit brings back '--all-targets' parameter for clippy,
which was accidentally removed in dae0145.
