### PR TITLE
Add g++ to dependencies for build from source on Fedora

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,7 +113,7 @@ command that should install all of them. If something is still found to be
 missing, please open an issue.
 
 ```sh
-dnf install cmake freetype-devel fontconfig-devel libxcb-devel
+dnf install cmake freetype-devel fontconfig-devel libxcb-devel g++
 ```
 
 #### CentOS/RHEL 7


### PR DESCRIPTION
Fixes #4400.
