### PR TITLE
Load only necessary gl functions

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::env;
 use std::fs::File;
 use std::path::Path;
@@ -11,7 +12,7 @@ fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(&Path::new(&dest).join("gl_bindings.rs")).unwrap();
 
-    Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, ["GL_ARB_blend_func_extended"])
+    Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, ["GL_ARB_blend_func_extended"])
         .write_bindings(GlobalGenerator, &mut file)
         .unwrap();
 


### PR DESCRIPTION
This commit make 'gl::load_with' only load
symbols alacritty will actually use. Doing so
slightly improves compilation times, since the gl_bindings.rs
file size is reduced from 21K LoC to 2K LoC, and also the actual
loading by up to 20x, though the loading is usually sub millisecond
anyway.

I'm not sure if this one needs a changelog entry, since it's not really noticeable for the user.
