### PR TITLE
Feature gate 'image' when building without x11 feature

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -37,7 +37,7 @@ gl_generator = "0.14.0"
 xdg = "2"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-image = { version = "0.23.3", default-features = false, features = ["ico"] }
+image = { version = "0.23.3", default-features = false, features = ["ico"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.2"
@@ -57,7 +57,7 @@ embed-resource = "1.3"
 
 [features]
 default = ["wayland", "x11"]
-x11 = ["copypasta/x11", "glutin/x11", "x11-dl"]
+x11 = ["copypasta/x11", "glutin/x11", "x11-dl", "image"]
 wayland = ["copypasta/wayland", "glutin/wayland", "wayland-client"]
 winpty = ["alacritty_terminal/winpty"]
 # Enabling this feature makes shaders automatically reload when changed


### PR DESCRIPTION
On Wayland there's no way to embed icon into the window,
thus there's no point in loading it when x11 feature is disabled.

I'd like to include into v0.6.0 to include with the massive feature gating, that was done for it.