### PR TITLE
Fix zerowidth chars on last column handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash when writing to the clipboard fails on Wayland
 - Crash with large negative `font.offset.x/y`
 - Visual bell getting stuck on the first frame
+- Zerowidth characters on the last column in the line being one column before
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash when writing to the clipboard fails on Wayland
 - Crash with large negative `font.offset.x/y`
 - Visual bell getting stuck on the first frame
-- Zerowidth characters on the last column in the line being one column before
+- Zerowidth characters in the last column of the line
 
 ## 0.5.0
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1480,14 +1480,18 @@ impl<T: EventListener> Handler for Term<T> {
 
         // Handle zero-width characters.
         if width == 0 {
+            // Get previous column.
             let mut col = self.grid.cursor.point.col.0;
             if !self.grid.cursor.input_needs_wrap {
                 col = col.saturating_sub(1);
             }
+
+            // Put zerowidth characters over first fullwidth character cell.
             let line = self.grid.cursor.point.line;
             if self.grid[line][Column(col)].flags.contains(Flags::WIDE_CHAR_SPACER) {
                 col = col.saturating_sub(1);
             }
+
             self.grid[line][Column(col)].push_zerowidth(c);
             return;
         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1480,7 +1480,10 @@ impl<T: EventListener> Handler for Term<T> {
 
         // Handle zero-width characters.
         if width == 0 {
-            let mut col = self.grid.cursor.point.col.0.saturating_sub(1);
+            let mut col = self.grid.cursor.point.col.0;
+            if !self.grid.cursor.input_needs_wrap {
+                col = col.saturating_sub(1);
+            }
             let line = self.grid.cursor.point.line;
             if self.grid[line][Column(col)].flags.contains(Flags::WIDE_CHAR_SPACER) {
                 col = col.saturating_sub(1);


### PR DESCRIPTION
This commit fixes the issue when zerowidth characters on the last
column were written one cell before.

Fixes #4227.
