### PR TITLE
Fix vi mode terminal reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Wide characters sometimes being cut off
+- Preserve vi mode across terminal `reset`
 
 ## 0.6.0
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2083,7 +2083,6 @@ impl<T: EventListener> Handler for Term<T> {
             mem::swap(&mut self.grid, &mut self.inactive_grid);
         }
         self.active_charset = Default::default();
-        self.mode = Default::default();
         self.colors = self.original_colors;
         self.color_modified = [false; color::COUNT];
         self.cursor_style = None;
@@ -2095,6 +2094,10 @@ impl<T: EventListener> Handler for Term<T> {
         self.title = None;
         self.selection = None;
         self.regex_search = None;
+
+        // Preserve vi mode across resets.
+        self.mode &= TermMode::VI;
+        self.mode.insert(TermMode::default());
     }
 
     #[inline]


### PR DESCRIPTION
Since the vi mode is unrelated to the terminal emulation itself, it
should not be reset during a `reset` to prevent unnecessary confusion.

This also prevents the search from switching from vi mode to vi-less
search without any indication to the user.