### PR TITLE
Fix config import log calls

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -4,7 +4,7 @@
 #
 # These configuration files will be loaded in order, replacing values in files
 # loaded earlier with those loaded later in the chain. The file itself will
-# always be loaded last. If an import path cannot be found it will be skipped.
+# always be loaded last. If an import path cannot be found, it will be skipped.
 #import:
 #  - /path/to/alacritty.yml
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -223,8 +223,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
         };
 
         if !path.exists() {
-            info!(target: LOG_TARGET_CONFIG, "Skipping importing config; not found:");
-            info!(target: LOG_TARGET_CONFIG, "  {:?}", path.display());
+            info!(target: LOG_TARGET_CONFIG, "Config import not found: {:?}", path);
             continue;
         }
 


### PR DESCRIPTION
This removes the two separate missing config import log calls and
combines them into one. Since each log call acquires a separate log,
having two separate calls can cause problems with multithreading.
Handling everything in just one should prevent any other log from
showing up in between.
