### PR TITLE
Add support for `~/` in config imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.7.0-dev
 
+### Added
+
+- Support for `~/` at the beginning of configuration file imports
+
 ### Changed
 
 - Nonexistent config imports are ignored instead of raising an error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "clap",
  "copypasta",
  "crossfont",
- "dirs",
+ "dirs 3.0.1",
  "embed-resource",
  "fnv",
  "gl_generator",
@@ -592,6 +592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
  "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
  "dirs-sys",
 ]
 
@@ -2043,7 +2052,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
 dependencies = [
- "dirs",
+ "dirs 2.0.2",
  "fnv",
  "nom",
  "phf",

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -6,7 +6,7 @@
 # loaded earlier with those loaded later in the chain. The file itself will
 # always be loaded last. If an import path cannot be found it will be skipped.
 #import:
-#  - /path/to/alacritty.yml
+#  - ~/path/to/alacritty.yml
 
 # Any items in the `env` entry below will be added as
 # environment variables. Some entries may override variables

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -2,11 +2,14 @@
 
 # Import additional configuration files
 #
-# These configuration files will be loaded in order, replacing values in files
-# loaded earlier with those loaded later in the chain. The file itself will
-# always be loaded last. If an import path cannot be found it will be skipped.
+# Imports are loaded in order, skipping all missing files, with the importing
+# file being loaded last. If a field is already present in a previous import, it
+# will be replaced.
+#
+# All imports must either be absolute paths starting with `/`, or paths relative
+# to the user's home directory starting with `~/`.
 #import:
-#  - ~/path/to/alacritty.yml
+#  - /path/to/alacritty.yml
 
 # Any items in the `env` entry below will be added as
 # environment variables. Some entries may override variables

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -30,6 +30,7 @@ copypasta = { version = "0.7.0", default-features = false }
 libc = "0.2"
 unicode-width = "0.1"
 bitflags = "1"
+dirs = "3.0.1"
 
 [build-dependencies]
 gl_generator = "0.14.0"
@@ -42,9 +43,6 @@ image = { version = "0.23.3", default-features = false, features = ["ico"], opti
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.2"
-
-[target.'cfg(any(target_os = "macos", windows))'.dependencies]
-dirs = "2.0.2"
 
 [target.'cfg(not(any(target_os="windows", target_os="macos")))'.dependencies]
 x11-dl = { version = "2", optional = true }

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -30,7 +30,7 @@ copypasta = { version = "0.7.0", default-features = false }
 libc = "0.2"
 unicode-width = "0.1"
 bitflags = "1"
-dirs = "3.0.1"
+dirs = "2.0.2"
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -211,7 +211,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
     let mut merged = Value::Null;
 
     for import in imports {
-        let path = match import {
+        let mut path = match import {
             Value::String(path) => PathBuf::from(path),
             _ => {
                 error!(
@@ -221,6 +221,11 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
                 continue;
             },
         };
+
+        // Resolve paths relative to user's home directory.
+        if let (Ok(stripped), Some(home_dir)) = (path.strip_prefix("~/"), dirs::home_dir()) {
+            path = home_dir.join(stripped);
+        }
 
         if !path.exists() {
             info!(target: LOG_TARGET_CONFIG, "Skipping importing config; not found:");


### PR DESCRIPTION
This allows the configuration file imports to start with `~/` and
resolve relative to the user's home directory.

There is no support for ~user/` or `$HOME/` or any other shell
expansion. However since paths relative to the home directory should be
sufficient for everything, this provides a very simple solution without
any significant drawbacks.

Fixes #4157.
