### PR TITLE
Increase font size in CSD decorations on Wayland

### DIFF
--- a/alacritty/src/wayland_theme.rs
+++ b/alacritty/src/wayland_theme.rs
@@ -67,6 +67,10 @@ impl WaylandTheme for AlacrittyWaylandTheme {
             (_, Button::Close) => self.hovered_close_icon,
         }
     }
+
+    fn font(&self) -> Option<(String, f32)> {
+        Some((String::from("sans-serif"), 17.))
+    }
 }
 
 trait IntoARGBColor {


### PR DESCRIPTION
Winit changed the default font size for CSD from 17pt to 11pt, so
restoring it, since it's way too small.

Fixes #4443.

