### PR TITLE
Print multiline logs in one write call

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -228,8 +228,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
         }
 
         if !path.exists() {
-            info!(target: LOG_TARGET_CONFIG, "Skipping importing config; not found:");
-            info!(target: LOG_TARGET_CONFIG, "  {:?}", path.display());
+            info!(target: LOG_TARGET_CONFIG, "Config import not found:\n  {:?}", path.display());
             continue;
         }
 

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -72,7 +72,7 @@ impl Logger {
         #[cfg(windows)]
         let env_var = format!("%{}%", ALACRITTY_LOG_ENV);
 
-        let msg = format!(
+        let message = format!(
             "[{}] See log at {} ({}):\n{}",
             record.level(),
             logfile_path,
@@ -85,7 +85,7 @@ impl Logger {
             _ => unreachable!(),
         };
 
-        let mut message = Message::new(msg, message_type);
+        let mut message = Message::new(message, message_type);
         message.set_target(record.target().to_owned());
 
         let _ = event_proxy.send_event(Event::Message(message));
@@ -108,11 +108,11 @@ impl log::Log for Logger {
         }
 
         // Create log message for the given `record` and `target`.
-        let msg = create_log_message(record, &target);
+        let message = create_log_message(record, &target);
 
         if let Ok(mut logfile) = self.logfile.lock() {
             // Write to logfile.
-            let _ = logfile.write_all(msg.as_ref());
+            let _ = logfile.write_all(message.as_ref());
 
             // Write to message bar.
             if record.level() <= Level::Warn {
@@ -122,7 +122,7 @@ impl log::Log for Logger {
 
         // Write to stdout.
         if let Ok(mut stdout) = self.stdout.lock() {
-            let _ = stdout.write_all(msg.as_ref());
+            let _ = stdout.write_all(message.as_ref());
         }
     }
 
@@ -131,22 +131,22 @@ impl log::Log for Logger {
 
 fn create_log_message(record: &log::Record<'_>, target: &str) -> String {
     let now = time::strftime("%F %T.%f", &time::now()).unwrap();
-    let mut msg = format!("[{}] [{:<5}] [{}] ", now, record.level(), target);
+    let mut message = format!("[{}] [{:<5}] [{}] ", now, record.level(), target);
 
     // Alignment for the lines after the first new line character in the payload. We don't deal
-    // with fullwidth/unicode chars here, so just `msg.len()` will work fine.
-    let alignment = msg.len();
+    // with fullwidth/unicode chars here, so just `message.len()` is sufficient.
+    let alignment = message.len();
 
-    // Push lines with adding extra padding on the next line, which is trimmed later.
+    // Push lines with added extra padding on the next line, which is trimmed later.
     let lines = record.args().to_string();
     for line in lines.split('\n') {
         let line = format!("{}\n{:width$}", line, "", width = alignment);
-        msg.push_str(&line);
+        message.push_str(&line);
     }
 
     // Drop extra trailing alignment.
-    msg.truncate(msg.len() - alignment);
-    msg
+    message.truncate(message.len() - alignment);
+    message
 }
 
 struct OnDemandLogFile {

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -131,14 +131,7 @@ fn run(
     info!("Welcome to Alacritty");
 
     // Log the configuration paths.
-    {
-        let mut msg = String::from("Configuration files loaded from:");
-        for path in &config.ui_config.config_paths {
-            msg.push_str(&format!("\n  {:?}", path.display()));
-        }
-
-        info!("{}", msg);
-    }
+    log_config_path(&config);
 
     // Set environment variables.
     tty::setup_env(&config);
@@ -246,4 +239,13 @@ fn run(
     info!("Goodbye");
 
     Ok(())
+}
+
+fn log_config_path(config: &Config) {
+    let mut msg = String::from("Configuration files loaded from:");
+    for path in &config.ui_config.config_paths {
+        msg.push_str(&format!("\n  {:?}", path.display()));
+    }
+
+    info!("{}", msg);
 }

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -130,9 +130,14 @@ fn run(
 ) -> Result<(), Box<dyn Error>> {
     info!("Welcome to Alacritty");
 
-    info!("Configuration files loaded from:");
-    for path in &config.ui_config.config_paths {
-        info!("  \"{}\"", path.display());
+    // Log the configuration paths.
+    {
+        let mut msg = String::from("Configuration files loaded from:");
+        for path in &config.ui_config.config_paths {
+            msg.push_str(&format!("\n  {:?}", path.display()));
+        }
+
+        info!("{}", msg);
     }
 
     // Set environment variables.


### PR DESCRIPTION
Fixes potential split of multiline logs in the multithreaded context
by printing them in one write call.


Example of how it looks:

```
Created log file at "/tmp/Alacritty-23566.log"
[2020-11-22 00:57:51.056463821] [INFO ] [alacritty] Welcome to Alacritty
[2020-11-22 00:57:51.056571680] [INFO ] [alacritty] Configuration files loaded from:
[2020-11-22 00:57:51.056571680] [INFO ]               "/home/kchibisov/alacritty.yml"
[2020-11-22 00:57:51.056571680] [INFO ]               "/home/kchibisov/.config/alacritty/alacritty.yml"
[2020-11-22 00:57:51.056571680] [INFO ]               "/dev/null"
[2020-11-22 00:57:51.142588963] [INFO ] [alacritty] Device pixel ratio: 1
[2020-11-22 00:57:51.145890991] [INFO ] [alacritty] Initializing glyph cache...
[2020-11-22 00:57:51.176849642] [INFO ] [alacritty] ... finished initializing glyph cache in 0.030898353s
[2020-11-22 00:57:51.176949109] [INFO ] [alacritty] Cell size: 8 x 18
[2020-11-22 00:57:51.176981554] [INFO ] [alacritty] Padding: 4 x 3
[2020-11-22 00:57:51.177008465] [INFO ] [alacritty] Width: 800, Height: 600
[2020-11-22 00:57:51.178652058] [INFO ] [alacritty] PTY dimensions: Line(33) x Column(99)
[2020-11-22 00:57:51.180553903] [INFO ] [alacritty] Initialisation complete
[2020-11-22 00:57:51.197011645] [INFO ] [alacritty] Padding: 6 x 8
[2020-11-22 00:57:51.197082528] [INFO ] [alacritty] Width: 1268, Height: 1402
```