### PR TITLE
Fix CI upload assets tag matching

### DIFF
--- a/.github/workflows/upload_asset.sh
+++ b/.github/workflows/upload_asset.sh
@@ -35,7 +35,7 @@ upload_url=$(\
         2> /dev/null \
     | grep -E "(upload_url|tag_name)" \
     | paste - - \
-    | grep -e "tag_name\": \"$tag" \
+    | grep -e "tag_name\": \"$tag\"" \
     | head -n 1 \
     | sed 's/.*\(https.*assets\).*/\1/' \
 )


### PR DESCRIPTION
The previous version would search for the last tag by matching the
beginning of the tag name. By explicitly searching for the trailing `"`
with grep, an exact tag match is now enforced.

Since releases like v1.2.3 always match the beginning of their RCs
(v1.2.3-rc4), this makes sure that the assets aren't pushed to the
previous release.