### PR TITLE
Remove redundant CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Wide characters sometimes being cut off
 - Preserve vi mode across terminal `reset`
 
+### Removed
+
+- The following CLI arguments have been removed in favor of the `--option` flag:
+    * `--persistent-logging`
+    * `--live-config-reload`
+    * `--no-live-config-reload`
+    * `--dimensions`
+    * `--position`
+
 ## 0.6.0
 
 ### Packaging

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -97,11 +97,6 @@ impl UIConfig {
         self.live_config_reload.0
     }
 
-    #[inline]
-    pub fn set_live_config_reload(&mut self, live_config_reload: bool) {
-        self.live_config_reload.0 = live_config_reload;
-    }
-
     /// Send escape sequences using the alt key.
     #[inline]
     pub fn alt_send_esc(&self) -> bool {

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -77,11 +77,6 @@ impl WindowConfig {
     }
 
     #[inline]
-    pub fn set_dimensions(&mut self, dimensions: Dimensions) {
-        self.dimensions = dimensions;
-    }
-
-    #[inline]
     pub fn dimensions(&self) -> Option<Dimensions> {
         if self.dimensions.columns.0 != 0
             && self.dimensions.lines.0 != 0

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -17,15 +17,6 @@ Prints help information
 \fB\-\-hold\fR
 Remain open after child process exits
 .TP
-\fB\-\-live\-config\-reload\fR
-Enable automatic config reloading
-.TP
-\fB\-\-no\-live\-config\-reload\fR
-Disable automatic config reloading
-.TP
-\fB\-\-persistent\-logging\fR
-Keep the log file after quitting Alacritty
-.TP
 \fB\-\-print\-events\fR
 Print all events to stdout
 .TP
@@ -61,17 +52,11 @@ Alacritty looks for the configuration file at the following paths:
 
 On Windows, the configuration file is located at %APPDATA%\\alacritty\\alacritty.yml.
 .TP
-\fB\-d\fR, \fB\-\-dimensions\fR <columns> <lines>
-Defines the window dimensions. Falls back to size specified by window manager if set to 0x0 [default: 0x0]
-.TP
 \fB\-\-embed\fR <parent>
 Defines the X11 window ID (as a decimal integer) to embed Alacritty within
 .TP
 \fB\-o\fR, \fB\-\-option\fR <option>...
 Override configuration file options [example: cursor.style=Beam]
-.TP
-\fB\-\-position\fR <x-pos> <y-pos>
-Defines the window position. Falls back to position specified by window manager if unset [default: unset]
 .TP
 \fB\-t\fR, \fB\-\-title\fR <title>
 Defines the window title [default: Alacritty]


### PR DESCRIPTION
This removes some of Alacritty's CLI flags since the same functionality
is provided by the `--option` flag now.

The removed flags are:
 * `--persistent-logging`
 * `--live-config-reload`
 * `--no-live-config-reload`
 * `--dimensions`
 * `--position`

Fixes #4246.
