### PR TITLE
Add 'Reset' action to clear scrollback buffer and reset the terminal

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -142,6 +142,9 @@ pub enum Action {
     /// Scroll all the way to the bottom.
     ScrollToBottom,
 
+    /// Clears scrollback buffer and resets the terminal
+    Reset,
+
     /// Clear the display buffer(s) to remove history.
     ClearHistory,
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -308,6 +308,7 @@ impl<T: EventListener> Execute<T> for Action {
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
             Action::ClearLogNotice => ctx.pop_message(),
+            Action::Reset => ctx.terminal_mut().reset_state(),
             Action::SpawnNewInstance => ctx.spawn_new_instance(),
             Action::ReceiveChar | Action::None => (),
         }


### PR DESCRIPTION
The missing ability to reset the screen while another program is running inside the terminal was bugging me too.

See https://github.com/alacritty/alacritty/issues/3997
and https://github.com/alacritty/alacritty/issues/4199

This adds the Action "Reset".