### PR TITLE
Add OpenConsole support for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `cursor.style.blinking` option to set the default blinking state
 - New `cursor.blink_interval` option to configure the blinking frequency
 - Support for cursor blinking escapes (`CSI ? 12 h`, `CSI ? 12 l` and `CSI Ps SP q`)
+- Support for using conhost.dll and OpenConsole.exe on Windows
 
 ### Changed
 


### PR DESCRIPTION
If the conpty.dll and OpenConsole.exe files from the Windows Terminal project are placed in the same directory as the alacritty executable they will be used instead of implementation provided by Windows.

This way you don't need to wait for new Windows releases to get bug fixes and new features.

Implements https://github.com/alacritty/alacritty/issues/3889, and using a more recent version of OpenConsole, fixes issues like bad mouse support https://github.com/alacritty/alacritty/issues/1663, curror issues, and probably much more.

In the future Alacritty could probably bundle the files with the release to make sure that a compatible version is used, but right now it's up to the user to compile the Windows Terminal project himself and copy the files.