### PR TITLE
Fix dimming of indexed colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Wide characters sometimes being cut off
 - Preserve vi mode across terminal `reset`
 - Escapes `CSI Ps b` and `CSI Ps Z` with large parameters locking up Alacritty
+- Dimming colors which use the indexed `CSI 38 : 5 : Ps m` notation
 
 ### Removed
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -401,7 +401,7 @@ impl RenderableCell {
                 ) {
                     (true, Flags::BOLD, 0..=7) => idx as usize + 8,
                     (false, Flags::DIM, 8..=15) => idx as usize - 8,
-                    (false, Flags::DIM, 0..=7) => idx as usize + 260,
+                    (false, Flags::DIM, 0..=7) => NamedColor::DimBlack as usize + idx as usize,
                     _ => idx as usize,
                 };
 


### PR DESCRIPTION
It seems like the list of colors might have changed a bit, leading to
indexed colors not being transformed into their dim colors correctly.

To prevent this from happening in the future, the dimming for colors in
the range `0..=7` is now performed by offsetting them from the
`NamedColor::DimBlack`. Since this is the first dimmed color, this
should always work as long as all dimmed colors are added in the correct
order.