### PR TITLE
Non-VI mode selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `cursor.style.blinking` option to set the default blinking state
 - New `cursor.blink_interval` option to configure the blinking frequency
 - Support for cursor blinking escapes (`CSI ? 12 h`, `CSI ? 12 l` and `CSI Ps SP q`)
+- SelectNextLine, SelectPreviousLine, SelectAddPreviousLine, SelectAddNextLine actions.
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -545,6 +545,14 @@
 #       Spawn a new instance of Alacritty.
 #   - ClearLogNotice
 #       Clear Alacritty's UI warning and error notice.
+#   - SelectAddNextLine,
+#       Extend selection with the line above
+#   - SelectAddPreviousLine,
+#       Extend selection with the line below
+#   - SelectNextLine,
+#       Select line below the selection or below the cursor when there is no selection
+#   - SelectPreviousLine,
+#       Select line above the selection or below the cursor when there is no selection
 #   - ClearSelection
 #       Remove the active selection.
 #   - ReceiveChar

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -167,6 +167,18 @@ pub enum Action {
     #[cfg(target_os = "macos")]
     ToggleSimpleFullscreen,
 
+    // Extend selection with the line above
+    SelectAddNextLine,
+
+    // Extend selection with the line below
+    SelectAddPreviousLine,
+
+    // Select line below the selection or below the cursor when there is no selection
+    SelectNextLine,
+
+    // Select line above the selection or below the cursor when there is no selection
+    SelectPreviousLine,
+
     /// Clear active selection.
     ClearSelection,
 


### PR DESCRIPTION
# I added several new actions to non-vi mode:

- **SelectAddNextLine**
       Extend selection with the line above
- **SelectAddPreviousLine**
       Extend selection with the line below
- **SelectNextLine**
       Select line below the selection or below the cursor when there is no selection
- **SelectPreviousLine**
       Select line above the selection or below the cursor when there is no selection

The main problem that this PR solves: copying the example code from git push. 
![image](https://user-images.githubusercontent.com/12275699/101268904-02066780-3769-11eb-8aad-fe5b3d2bc3ac.png)

Yes, I can do this currently in VI mode, but it is easier to use my mouse, which I wanted to avoid.

**Any ideas about the default shortcuts?**
I wanted Ctrl+Alt+{Up, Down}, Ctrl+Alt+Shift+{Up, Down} but that didn't work, unfortunately. 