### PR TITLE
support paste/paste_selection to search regex.

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -458,6 +458,19 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     }
 
     #[inline]
+    fn push_string_search(&mut self, s: &str) {
+        if let Some(regex) = self.search_state.regex.as_mut() {
+            if !self.terminal.mode().contains(TermMode::VI) {
+                // Clear selection so we do not obstruct any matches.
+                self.terminal.selection = None;
+            }
+
+            regex.push_str(s);
+            self.update_search();
+        }
+    }
+
+    #[inline]
     fn pop_search(&mut self) {
         if let Some(regex) = self.search_state.regex.as_mut() {
             regex.pop();


### PR DESCRIPTION
Please make sure to document all user-facing changes in the
`CHANGELOG.md` file.

If support for a new escape sequence was added, it should be documented
in `./docs/escape_support.md`.

Since `alacritty_terminal`'s version always tracks the next release, make sure
that the version is bumped according to semver when necessary.

Draft PRs are always welcome, though unless otherwise requested PRs will
not be reviewed until all required and optional CI steps are successful
and they have left the draft stage.
