### PR TITLE
Man page: add path to Linux example config file

### DIFF
--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -51,6 +51,7 @@ Alacritty looks for the configuration file at the following paths:
     4. $HOME/.alacritty.yml
 
 On Windows, the configuration file is located at %APPDATA%\\alacritty\\alacritty.yml.
+On Linux, an example is available at /usr/share/doc/alacritty/example/alacritty.yml.
 .TP
 \fB\-\-embed\fR <parent>
 Defines the X11 window ID (as a decimal integer) to embed Alacritty within


### PR DESCRIPTION
Refer to `/usr/share/doc/alacritty/example/alacritty.yml` in man page.