### PR TITLE
Don't draw missing glyphs for zerowidth characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Nonexistent config imports are ignored instead of raising an error
 - Value for disabling logging with `config.log_level` is `Off` instead of `None`
+- Missing glyph symbols are no longer drawn for zerowidth characters
 
 ### Fixed
 
@@ -43,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Alacritty not discarding invalid escape sequences starting with ESC
 - Crash due to clipboard not being properly released on Wayland
 - Shadow artifacts when resizing transparent windows on macOS
+- Missing glyph symbols not being rendered for missing glyphs on macOS and Windows
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,8 +520,7 @@ dependencies = [
 [[package]]
 name = "crossfont"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4b217779694a81b60a4174f121697c9bd7550cb9a6d7e970051bea1b13dbc0"
+source = "git+https://github.com/alacritty/crossfont#536d5c6685902209b29d86f1de329ccc8ad99f51"
 dependencies = [
  "cocoa 0.24.0",
  "core-foundation 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,8 +519,9 @@ dependencies = [
 
 [[package]]
 name = "crossfont"
-version = "0.1.1"
-source = "git+https://github.com/alacritty/crossfont#536d5c6685902209b29d86f1de329ccc8ad99f51"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108946cf5228893bf470564410639b87a53f959d937f1c57bbc2a6603d98e812"
 dependencies = [
  "cocoa 0.24.0",
  "core-foundation 0.9.1",
@@ -528,7 +529,6 @@ dependencies = [
  "core-graphics 0.22.1",
  "core-text",
  "dwrote",
- "euclid",
  "foreign-types 0.5.0",
  "freetype-rs",
  "libc",
@@ -667,15 +667,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "euclid"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5337024b8293bdce5265dc9570ef6e608a34bfacbbc87fe1a5dcb5f1dac2f4e2"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1324,15 +1315,6 @@ dependencies = [
  "mio-extras",
  "walkdir",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1"
 glutin = { version = "0.26.0", default-features = false, features = ["serde"] }
 notify = "4"
 parking_lot = "0.11.0"
-crossfont = { git = "https://github.com/alacritty/crossfont", features = ["force_system_fontconfig"] }
+crossfont = { version = "0.2.0", features = ["force_system_fontconfig"] }
 urlocator = "0.1.3"
 copypasta = { version = "0.7.0", default-features = false }
 libc = "0.2"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1"
 glutin = { version = "0.26.0", default-features = false, features = ["serde"] }
 notify = "4"
 parking_lot = "0.11.0"
-crossfont = { version = "0.1.0", features = ["force_system_fontconfig"] }
+crossfont = { git = "https://github.com/alacritty/crossfont", features = ["force_system_fontconfig"] }
 urlocator = "0.1.3"
 copypasta = { version = "0.7.0", default-features = false }
 libc = "0.2"

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -37,39 +37,39 @@ pub fn get_cursor_glyph(
 /// Return a custom underline cursor character.
 pub fn get_underline_cursor_glyph(width: usize, line_width: usize) -> RasterizedGlyph {
     // Create a new rectangle, the height is relative to the font width.
-    let buf = vec![255u8; width * line_width * 3];
+    let buffer = BitmapBuffer::RGB(vec![255u8; width * line_width * 3]);
 
     // Create a custom glyph with the rectangle data attached to it.
     RasterizedGlyph {
-        c: ' ',
+        character: ' ',
         top: line_width as i32,
         left: 0,
         height: line_width as i32,
         width: width as i32,
-        buf: BitmapBuffer::RGB(buf),
+        buffer,
     }
 }
 
 /// Return a custom beam cursor character.
 pub fn get_beam_cursor_glyph(height: usize, line_width: usize) -> RasterizedGlyph {
     // Create a new rectangle that is at least one pixel wide
-    let buf = vec![255u8; line_width * height * 3];
+    let buffer = BitmapBuffer::RGB(vec![255u8; line_width * height * 3]);
 
     // Create a custom glyph with the rectangle data attached to it
     RasterizedGlyph {
-        c: ' ',
+        character: ' ',
         top: height as i32,
         left: 0,
         height: height as i32,
         width: line_width as i32,
-        buf: BitmapBuffer::RGB(buf),
+        buffer,
     }
 }
 
 /// Returns a custom box cursor character.
 pub fn get_box_cursor_glyph(height: usize, width: usize, line_width: usize) -> RasterizedGlyph {
     // Create a new box outline rectangle.
-    let mut buf = Vec::with_capacity(width * height * 3);
+    let mut buffer = Vec::with_capacity(width * height * 3);
     for y in 0..height {
         for x in 0..width {
             if y < line_width
@@ -77,36 +77,36 @@ pub fn get_box_cursor_glyph(height: usize, width: usize, line_width: usize) -> R
                 || x < line_width
                 || x >= width - line_width
             {
-                buf.append(&mut vec![255u8; 3]);
+                buffer.append(&mut vec![255u8; 3]);
             } else {
-                buf.append(&mut vec![0u8; 3]);
+                buffer.append(&mut vec![0u8; 3]);
             }
         }
     }
 
     // Create a custom glyph with the rectangle data attached to it.
     RasterizedGlyph {
-        c: ' ',
+        character: ' ',
         top: height as i32,
         left: 0,
         height: height as i32,
         width: width as i32,
-        buf: BitmapBuffer::RGB(buf),
+        buffer: BitmapBuffer::RGB(buffer),
     }
 }
 
 /// Return a custom block cursor character.
 pub fn get_block_cursor_glyph(height: usize, width: usize) -> RasterizedGlyph {
     // Create a completely filled glyph.
-    let buf = vec![255u8; width * height * 3];
+    let buffer = BitmapBuffer::RGB(vec![255u8; width * height * 3]);
 
     // Create a custom glyph with the rectangle data attached to it.
     RasterizedGlyph {
-        c: ' ',
+        character: ' ',
         top: height as i32,
         left: 0,
         height: height as i32,
         width: width as i32,
-        buf: BitmapBuffer::RGB(buf),
+        buffer,
     }
 }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1378,7 +1378,7 @@ impl Atlas {
                 BitmapBuffer::RGB(buffer) => {
                     multicolor = false;
                     (gl::RGB, buffer)
-                }
+                },
                 BitmapBuffer::RGBA(buffer) => {
                     multicolor = true;
                     (gl::RGBA, buffer)

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -187,9 +187,8 @@ impl GlyphCache {
 
     fn load_glyphs_for_font<L: LoadGlyph>(&mut self, font: FontKey, loader: &mut L) {
         let size = self.font_size;
-        for character in 32u8..=126u8 {
-            let character = character as char;
-            self.get(GlyphKey { font_key: font, character, size }, loader);
+        for i in 32u8..=126u8 {
+            self.get(GlyphKey { font_key: font, character: i as char, size }, loader);
         }
     }
 
@@ -312,7 +311,11 @@ impl GlyphCache {
         let (regular, bold, italic, bold_italic) =
             Self::compute_font_keys(font, &mut self.rasterizer)?;
 
-        self.rasterizer.get_glyph(GlyphKey { font_key: regular, character: 'm', size: font.size() })?;
+        self.rasterizer.get_glyph(GlyphKey {
+            font_key: regular,
+            character: 'm',
+            size: font.size(),
+        })?;
         let metrics = self.rasterizer.metrics(regular, font.size())?;
 
         info!("Font size changed to {:?} with DPR of {}", font.size(), dpr);


### PR DESCRIPTION
This should prevent missing glyph symbols from zerowidth characters
obscuring normal glyphs.