### PR TITLE
Remove live-shader-reload feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     * `--no-live-config-reload`
     * `--dimensions`
     * `--position`
+- `live-shader-reload` feature
 
 ## 0.6.0
 

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -59,7 +59,5 @@ default = ["wayland", "x11"]
 x11 = ["copypasta/x11", "glutin/x11", "x11-dl", "image"]
 wayland = ["copypasta/wayland", "glutin/wayland", "wayland-client"]
 winpty = ["alacritty_terminal/winpty"]
-# Enabling this feature makes shaders automatically reload when changed
-live-shader-reload = []
 nightly = []
 bench = []

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -197,8 +197,6 @@ impl RenderLines {
 }
 
 /// Shader sources for rect rendering program.
-pub static RECT_SHADER_F_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/res/rect.f.glsl");
-pub static RECT_SHADER_V_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/res/rect.v.glsl");
 static RECT_SHADER_F: &str = include_str!("../../res/rect.f.glsl");
 static RECT_SHADER_V: &str = include_str!("../../res/rect.v.glsl");
 
@@ -228,11 +226,6 @@ pub struct RectRenderer {
 }
 
 impl RectRenderer {
-    /// Update program when doing live-shader-reload.
-    pub fn set_program(&mut self, program: RectShaderProgram) {
-        self.program = program;
-    }
-
     pub fn new() -> Result<Self, renderer::Error> {
         let mut vao: GLuint = 0;
         let mut vbo: GLuint = 0;
@@ -359,15 +352,8 @@ pub struct RectShaderProgram {
 
 impl RectShaderProgram {
     pub fn new() -> Result<Self, renderer::ShaderCreationError> {
-        let (vertex_src, fragment_src) = if cfg!(feature = "live-shader-reload") {
-            (None, None)
-        } else {
-            (Some(RECT_SHADER_V), Some(RECT_SHADER_F))
-        };
-        let vertex_shader =
-            renderer::create_shader(RECT_SHADER_V_PATH, gl::VERTEX_SHADER, vertex_src)?;
-        let fragment_shader =
-            renderer::create_shader(RECT_SHADER_F_PATH, gl::FRAGMENT_SHADER, fragment_src)?;
+        let vertex_shader = renderer::create_shader(gl::VERTEX_SHADER, RECT_SHADER_V)?;
+        let fragment_shader = renderer::create_shader(gl::FRAGMENT_SHADER, RECT_SHADER_F)?;
         let program = renderer::create_program(vertex_shader, fragment_shader)?;
 
         unsafe {


### PR DESCRIPTION
Since live-shader-reload is generally unused and unmaintained, and could
only be used for debugging purposes, since it refers relative paths,
this feature was removed for the sake of simplicity.
