### PR TITLE
Allow for Commands to take visible or all text as input (Revived)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - History for search mode, bound to ^P/^N/Up/Down by default
 - Default binding to cancel search on Ctrl+C
 - History position indicator for search and vi mode
+- Option for commands to receive text from the terminal on their stdin
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "miow 0.3.6",
  "nix 0.19.1",
  "parking_lot",
+ "quote",
  "regex-automata",
  "serde",
  "serde_json",

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -681,9 +681,16 @@
 #
 # - `command`: Fork and execute a specified command plus arguments
 #
-#    The `command` field must be a map containing a `program` string and an
-#    `args` array of command line parameter strings. For example:
-#       `{ program: "alacritty", args: ["-e", "vttest"] }`
+#    The `command` field can be either only a string specifying the program, or
+#    a map of:
+#
+#    - `program` (required), string specifying the program
+#    - `args` (optional), array of command line parameter strings
+#    - `input` (optional), either VisibleText or AllText. If specified, then
+#      respectively either the visible text in the terminal or all the text
+#      including the scrollback is piped to the command's stdin.
+#
+#    For example: `{ program: "alacritty", args: ["-e", "vttest"] }`
 #
 # And optionally:
 #

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -183,7 +183,7 @@ impl Options {
             // `Arg::min_values(1)` is set.
             let program = String::from(args.next().unwrap());
             let args = args.map(String::from).collect();
-            options.command = Some(Program::WithArgs { program, args });
+            options.command = Some(Program::WithArgs { program, args, input: None });
         }
 
         if matches.is_present("hold") {

--- a/alacritty/src/config/mouse.rs
+++ b/alacritty/src/config/mouse.rs
@@ -41,6 +41,7 @@ impl Default for Url {
             launcher: Some(Program::WithArgs {
                 program: String::from("cmd"),
                 args: vec!["/c".to_string(), "start".to_string(), "".to_string()],
+                input: None,
             }),
             modifiers: Default::default(),
         }

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -1,11 +1,11 @@
 use std::ffi::OsStr;
 use std::fmt::Debug;
-use std::io;
+use std::io::{self, Write};
 #[cfg(not(windows))]
 use std::os::unix::process::CommandExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 
 use log::{debug, warn};
 
@@ -13,19 +13,27 @@ use log::{debug, warn};
 use winapi::um::winbase::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
 /// Start the daemon and log error on failure.
-pub fn start_daemon<I, S>(program: &str, args: I)
+pub fn start_daemon<I, S>(program: &str, args: I, input: Option<&str>)
 where
     I: IntoIterator<Item = S> + Debug + Copy,
     S: AsRef<OsStr>,
 {
-    match spawn_daemon(program, args) {
+    match spawn_daemon(program, args, input) {
         Ok(_) => debug!("Launched {} with args {:?}", program, args),
         Err(_) => warn!("Unable to launch {} with args {:?}", program, args),
     }
 }
 
+fn write_input(child: &mut Child, input: Option<&str>) -> io::Result<()> {
+    if let Some(s) = input {
+        let stdin = child.stdin.as_mut().unwrap();
+        stdin.write_all(s.as_bytes())?;
+    }
+    Ok(())
+}
+
 #[cfg(windows)]
-fn spawn_daemon<I, S>(program: &str, args: I) -> io::Result<()>
+fn spawn_daemon<I, S>(program: &str, args: I, input: Option<&str>) -> io::Result<()>
 where
     I: IntoIterator<Item = S> + Copy,
     S: AsRef<OsStr>,
@@ -34,26 +42,26 @@ where
     // CREATE_NEW_PROCESS_GROUP and CREATE_NO_WINDOW has the effect
     // that console applications will run without opening a new
     // console window.
-    Command::new(program)
+    let mut child = Command::new(program)
         .args(args)
-        .stdin(Stdio::null())
+        .stdin(if input.is_some() { Stdio::piped() } else { Stdio::null() })
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW)
-        .spawn()
-        .map(|_| ())
+        .spawn()?;
+    write_input(&mut child, input)
 }
 
 #[cfg(not(windows))]
-fn spawn_daemon<I, S>(program: &str, args: I) -> io::Result<()>
+fn spawn_daemon<I, S>(program: &str, args: I, input: Option<&str>) -> io::Result<()>
 where
     I: IntoIterator<Item = S> + Copy,
     S: AsRef<OsStr>,
 {
     unsafe {
-        Command::new(program)
+        let mut child = Command::new(program)
             .args(args)
-            .stdin(Stdio::null())
+            .stdin(if input.is_some() { Stdio::piped() } else { Stdio::null() })
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .pre_exec(|| {
@@ -69,8 +77,8 @@ where
 
                 Ok(())
             })
-            .spawn()?
-            .wait()
-            .map(|_| ())
+            .spawn()?;
+        write_input(&mut child, input)?;
+        child.wait().map(|_| ())
     }
 }

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -118,13 +118,14 @@ impl HintState {
         if label.len() == 1 {
             // Get text for the hint's regex match.
             let hint_match = &self.matches[index];
-            let text = term.bounds_to_string(*hint_match.start(), *hint_match.end());
+            let mut text = String::new();
+            term.write_bounds_to_string(&mut text, *hint_match.start(), *hint_match.end());
 
             // Append text as last argument and launch command.
             let program = hint.command.program();
             let mut args = hint.command.args().to_vec();
             args.push(text);
-            start_daemon(program, &args);
+            start_daemon(program, &args, None);
 
             self.stop();
         } else {

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -41,3 +41,6 @@ mio-anonymous-pipes = "0.1"
 
 [dev-dependencies]
 serde_json = "1.0.0"
+
+[build-dependencies]
+quote = "1.0.7"

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -174,6 +174,12 @@ impl From<CursorBlinking> for bool {
     }
 }
 
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CommandInput {
+    VisibleText,
+    AllText,
+}
+
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum Program {
@@ -182,6 +188,8 @@ pub enum Program {
         program: String,
         #[serde(default)]
         args: Vec<String>,
+        #[serde(default)]
+        input: Option<CommandInput>,
     },
 }
 
@@ -197,6 +205,13 @@ impl Program {
         match self {
             Program::Just(_) => &[],
             Program::WithArgs { args, .. } => args,
+        }
+    }
+
+    pub fn input(&self) -> Option<CommandInput> {
+        match self {
+            Program::Just(_) => None,
+            Program::WithArgs { input, .. } => *input,
         }
     }
 }

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -79,7 +79,7 @@ pub trait OnResize {
 }
 
 /// Event Loop for notifying the renderer about terminal events.
-pub trait EventListener {
+pub trait EventListener: Send + 'static {
     fn send_event(&self, _event: Event) {}
 }
 

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -157,9 +157,7 @@ impl LineLength for grid::Row<Cell> {
         }
 
         for (index, cell) in self[..].iter().rev().enumerate() {
-            if cell.c != ' '
-                || cell.extra.as_ref().map(|extra| extra.zerowidth.is_empty()) == Some(false)
-            {
+            if !cell.is_empty() {
                 length = Column(self.len() - index);
                 break;
             }

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -144,7 +144,7 @@ fn default_shell(pw: &Passwd<'_>) -> Program {
     let shell_name = pw.shell.rsplit('/').next().unwrap();
     let argv = vec![String::from("-c"), format!("exec -a -{} {}", shell_name, pw.shell)];
 
-    Program::WithArgs { program: "/bin/bash".to_owned(), args: argv }
+    Program::WithArgs { program: "/bin/bash".to_owned(), args: argv, input: None }
 }
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
Fixes #1615.
See also #3709.

I adapted the original PR to avoid merge conflicts.
I also added basic parallelization using rayon as suggested by Chris [here](https://github.com/alacritty/alacritty/pull/3709#issuecomment-671103599). After that, I documented the code and made sure that the tests still pass.