### PR TITLE
Fix live reload with broken yaml on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Window not being completely opaque on Windows
 - Window being always on top during alt-tab on Windows
 - Cursor position not reported to apps when mouse is moved with button held outside of window
+- No live config update when starting Alacritty with a broken configuration file
 
 ### Removed
 


### PR DESCRIPTION
Since the current behavior would just load the default configuration
file whenever the configuration file couldn't be loaded, the path was
not set to any value. As a result however, the live config reload
feature would not work with a broken yaml (one which cannot be
deserialized, not one with warnings).

If a configuration file has been specified, but the deserialization
still failed, the path is now preserved on the default configuration
file to make it possible to live reload a fix for the issue.

Fixes #4561.
