### PR TITLE
Fix cursor reports with mouse outside of window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Compilation when targetting aarch64-apple-darwin
 - Window not being completely opaque on Windows
 - Window being always on top during alt-tab on Windows
-- No live config update when starting Alacritty with a broken configuration file
 - Cursor position not reported to apps when mouse is moved with button held outside of window
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Compilation when targetting aarch64-apple-darwin
 - Window not being completely opaque on Windows
 - Window being always on top during alt-tab on Windows
+- No live config update when starting Alacritty with a broken configuration file
+- Cursor position not reported to apps when mouse is moved with button held outside of window
 
 ### Removed
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -403,8 +403,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
         if (lmb_pressed || rmb_pressed) && (self.ctx.modifiers().shift() || !self.ctx.mouse_mode())
         {
             self.ctx.update_selection(point, cell_side);
-        } else if inside_text_area
-            && cell_changed
+        } else if cell_changed
             && point.line < self.ctx.terminal().screen_lines()
             && self.ctx.terminal().mode().intersects(TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG)
         {


### PR DESCRIPTION
Previously Alacritty would not report cursor escapes to the application
when a mouse button was held down and the mouse was moved. This prevents
applications like tmux from updating their selection.

Similarly to how windowing libraries keep reporting mouse events when
the left mouse button is held down over the window, the escape sequences
are now clamped to within the grid and reported to applications.

Fixes #4566.