### PR TITLE
Fix invalid ESC escape sequence parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - No live config update when starting Alacritty with a broken configuration file
 - PTY not drained to the end with the `--hold` flag enabled
 - High CPU usage on BSD with live config reload enabled
+- Alacritty not discarding invalid escape sequences starting with ESC
 
 ### Removed
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1138,6 +1138,7 @@ where
                     [b'*'] => CharsetIndex::G2,
                     [b'+'] => CharsetIndex::G3,
                     _ => {
+                        unhandled!();
                         return;
                     },
                 };
@@ -1147,26 +1148,26 @@ where
 
         match (byte, intermediates) {
             (b'B', intermediates) => configure_charset!(StandardCharset::Ascii, intermediates),
-            (b'D', _) => self.handler.linefeed(),
-            (b'E', _) => {
+            (b'D', []) => self.handler.linefeed(),
+            (b'E', []) => {
                 self.handler.linefeed();
                 self.handler.carriage_return();
             },
-            (b'H', _) => self.handler.set_horizontal_tabstop(),
-            (b'M', _) => self.handler.reverse_index(),
-            (b'Z', _) => self.handler.identify_terminal(self.writer, None),
-            (b'c', _) => self.handler.reset_state(),
+            (b'H', []) => self.handler.set_horizontal_tabstop(),
+            (b'M', []) => self.handler.reverse_index(),
+            (b'Z', []) => self.handler.identify_terminal(self.writer, None),
+            (b'c', []) => self.handler.reset_state(),
             (b'0', intermediates) => {
                 configure_charset!(StandardCharset::SpecialCharacterAndLineDrawing, intermediates)
             },
-            (b'7', _) => self.handler.save_cursor_position(),
+            (b'7', []) => self.handler.save_cursor_position(),
             (b'8', [b'#']) => self.handler.decaln(),
-            (b'8', _) => self.handler.restore_cursor_position(),
-            (b'=', _) => self.handler.set_keypad_application_mode(),
-            (b'>', _) => self.handler.unset_keypad_application_mode(),
+            (b'8', []) => self.handler.restore_cursor_position(),
+            (b'=', []) => self.handler.set_keypad_application_mode(),
+            (b'>', []) => self.handler.unset_keypad_application_mode(),
             // String terminator, do nothing (parser handles as string terminator).
-            (b'\\', _) => (),
-            _ => (),
+            (b'\\', []) => (),
+            _ => unhandled!(),
         }
     }
 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1131,14 +1131,13 @@ where
         }
 
         macro_rules! configure_charset {
-            ($charset:path, $intermediate:expr) => {{
-                let index: CharsetIndex = match $intermediate {
-                    Some(b'(') => CharsetIndex::G0,
-                    Some(b')') => CharsetIndex::G1,
-                    Some(b'*') => CharsetIndex::G2,
-                    Some(b'+') => CharsetIndex::G3,
+            ($charset:path, $intermediates:expr) => {{
+                let index: CharsetIndex = match $intermediates {
+                    [b'('] => CharsetIndex::G0,
+                    [b')'] => CharsetIndex::G1,
+                    [b'*'] => CharsetIndex::G2,
+                    [b'+'] => CharsetIndex::G3,
                     _ => {
-                        unhandled!();
                         return;
                     },
                 };
@@ -1146,28 +1145,28 @@ where
             }};
         }
 
-        match (byte, intermediates.get(0)) {
-            (b'B', intermediate) => configure_charset!(StandardCharset::Ascii, intermediate),
-            (b'D', None) => self.handler.linefeed(),
-            (b'E', None) => {
+        match (byte, intermediates) {
+            (b'B', intermediates) => configure_charset!(StandardCharset::Ascii, intermediates),
+            (b'D', _) => self.handler.linefeed(),
+            (b'E', _) => {
                 self.handler.linefeed();
                 self.handler.carriage_return();
             },
-            (b'H', None) => self.handler.set_horizontal_tabstop(),
-            (b'M', None) => self.handler.reverse_index(),
-            (b'Z', None) => self.handler.identify_terminal(self.writer, None),
-            (b'c', None) => self.handler.reset_state(),
-            (b'0', intermediate) => {
-                configure_charset!(StandardCharset::SpecialCharacterAndLineDrawing, intermediate)
+            (b'H', _) => self.handler.set_horizontal_tabstop(),
+            (b'M', _) => self.handler.reverse_index(),
+            (b'Z', _) => self.handler.identify_terminal(self.writer, None),
+            (b'c', _) => self.handler.reset_state(),
+            (b'0', intermediates) => {
+                configure_charset!(StandardCharset::SpecialCharacterAndLineDrawing, intermediates)
             },
-            (b'7', None) => self.handler.save_cursor_position(),
-            (b'8', Some(b'#')) => self.handler.decaln(),
-            (b'8', None) => self.handler.restore_cursor_position(),
-            (b'=', None) => self.handler.set_keypad_application_mode(),
-            (b'>', None) => self.handler.unset_keypad_application_mode(),
+            (b'7', _) => self.handler.save_cursor_position(),
+            (b'8', [b'#']) => self.handler.decaln(),
+            (b'8', _) => self.handler.restore_cursor_position(),
+            (b'=', _) => self.handler.set_keypad_application_mode(),
+            (b'>', _) => self.handler.unset_keypad_application_mode(),
             // String terminator, do nothing (parser handles as string terminator).
-            (b'\\', None) => (),
-            _ => unhandled!(),
+            (b'\\', _) => (),
+            _ => (),
         }
     }
 }


### PR DESCRIPTION
This strictens the ESC escape sequence parser to prevent invalid
intermediates from being ignored. Previously the parser would just look
at the first intermediate without validating that the rest of them is
empty.

If an escape like `\e(#0` is used now, it will no longer be accepted as
`\e(0` since the intermediate `#` is also present.