### PR TITLE
Increase file watcher delay on BSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cursor position not reported to apps when mouse is moved with button held outside of window
 - No live config update when starting Alacritty with a broken configuration file
 - PTY not drained to the end with the `--hold` flag enabled
+- High CPU usage on BSD with live config reload enabled
 
 ### Removed
 

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -10,6 +10,11 @@ use alacritty_terminal::thread;
 
 use crate::event::{Event, EventProxy};
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+const DEBOUNCE_DELAY: Duration = Duration::from_millis(10);
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+const DEBOUNCE_DELAY: Duration = Duration::from_millis(1000);
+
 pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventProxy) {
     // Canonicalize all paths, filtering out the ones that do not exist.
     paths = paths
@@ -30,7 +35,7 @@ pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventProxy) {
 
     // The Duration argument is a debouncing period.
     let (tx, rx) = mpsc::channel();
-    let mut watcher = match watcher(tx, Duration::from_millis(10)) {
+    let mut watcher = match watcher(tx, DEBOUNCE_DELAY) {
         Ok(watcher) => watcher,
         Err(err) => {
             error!("Unable to watch config file: {}", err);


### PR DESCRIPTION
Since BSD does not support inotify polling in the `notify` crate and
instead relies on manual filesystem polling, this would cause a high CPU
usage at 100 polls a second.

A separate polling rate of once per second is now used for platforms
which do not support filesystem polling, allowing users to still make
use of live config reload on BSD.

Fixes #3871.
