### PR TITLE
Disable shadows for transparent windows on macOS

### DIFF
--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -254,6 +254,10 @@ impl Display {
         #[cfg(target_os = "macos")]
         crossfont::set_font_smoothing(config.ui_config.font.use_thin_strokes);
 
+        // Disable shadows for transparent windows on macOS.
+        #[cfg(target_os = "macos")]
+        window.set_has_shadows(config.ui_config.background_opacity() >= 1.0);
+
         #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
         let is_x11 = event_loop.is_x11();
         #[cfg(not(any(feature = "x11", target_os = "macos", windows)))]

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -256,7 +256,7 @@ impl Display {
 
         // Disable shadows for transparent windows on macOS.
         #[cfg(target_os = "macos")]
-        window.set_has_shadows(config.ui_config.background_opacity() >= 1.0);
+        window.set_has_shadow(config.ui_config.background_opacity() >= 1.0);
 
         #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
         let is_x11 = event_loop.is_x11();
@@ -613,12 +613,6 @@ impl Display {
         // `commit`, which is done by swap buffers under the hood.
         #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
         self.request_frame(&self.window);
-
-        // Clear window shadows to prevent shadow artifacts on macOS.
-        #[cfg(target_os = "macos")]
-        if config.ui_config.background_opacity() < 1.0 {
-            self.window.set_has_shadow(false);
-        }
 
         self.window.swap_buffers();
 

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -617,7 +617,7 @@ impl Display {
         // Clear window shadows to prevent shadow artifacts on macOS.
         #[cfg(target_os = "macos")]
         if config.ui_config.background_opacity() < 1.0 {
-            self.window.invalidate_shadow();
+            self.window.set_has_shadow(false);
         }
 
         self.window.swap_buffers();

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1279,6 +1279,14 @@ impl<N: Notify + OnResize> Processor<N> {
         #[cfg(target_os = "macos")]
         crossfont::set_font_smoothing(config.ui_config.font.use_thin_strokes);
 
+        // Disable shadows for transparent windows on macOS.
+        #[cfg(target_os = "macos")]
+        if processor.ctx.config.ui_config.background_opacity()
+            != config.ui_config.background_opacity()
+        {
+            processor.ctx.window.set_has_shadows(config.ui_config.background_opacity() >= 1.0);
+        }
+
         *processor.ctx.config = config;
 
         // Update cursor blinking.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1281,11 +1281,7 @@ impl<N: Notify + OnResize> Processor<N> {
 
         // Disable shadows for transparent windows on macOS.
         #[cfg(target_os = "macos")]
-        if processor.ctx.config.ui_config.background_opacity()
-            != config.ui_config.background_opacity()
-        {
-            processor.ctx.window.set_has_shadow(config.ui_config.background_opacity() >= 1.0);
-        }
+        processor.ctx.window.set_has_shadow(config.ui_config.background_opacity() >= 1.0);
 
         *processor.ctx.config = config;
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1284,7 +1284,7 @@ impl<N: Notify + OnResize> Processor<N> {
         if processor.ctx.config.ui_config.background_opacity()
             != config.ui_config.background_opacity()
         {
-            processor.ctx.window.set_has_shadows(config.ui_config.background_opacity() >= 1.0);
+            processor.ctx.window.set_has_shadow(config.ui_config.background_opacity() >= 1.0);
         }
 
         *processor.ctx.config = config;

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -217,15 +217,6 @@ impl Window {
             None
         };
 
-        // Disable window shadows on macOS to prevent artifacts with transparency.
-        #[cfg(target_os = "macos")]
-        if let RawWindowHandle::MacOS(handle) = windowed_context.window().raw_window_handle() {
-            let raw_window = handle.ns_window as id;
-            unsafe {
-                let _: () = msg_send![raw_window, setHasShadow: NO];
-            }
-        }
-
         let dpr = windowed_context.window().scale_factor();
 
         Ok(Self {

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -445,7 +445,7 @@ impl Window {
     ///
     /// This prevents rendering artifacts from showing up when the window is transparent.
     #[cfg(target_os = "macos")]
-    pub fn set_has_shadows(&self, has_shadows: bool) {
+    pub fn set_has_shadow(&self, has_shadows: bool) {
         let raw_window = match self.window().raw_window_handle() {
             RawWindowHandle::MacOS(handle) => handle.ns_window as id,
             _ => return,


### PR DESCRIPTION
Commit 5725f58 introduced a performance regression on macOS due to
excessive calls to the `invalidateShadow` function, however calling this
function only on redraw after a resize was performed does not fix the
underlying problem.

As a solution, window shadows are now disabled completely for all
transparent windows. This makes sure there is no performance impact,
while still solving the problem with text artifacts on resize.

Fixes #4604.