### PR TITLE
Fix characters getting swallowed during IME input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Missing glyph symbols not being rendered for missing glyphs on macOS and Windows
 - Underline cursor being obscured by underline
 - Cursor not being rendered with a lot of unicode glyphs visible
+- IME input swallowed after triggering a key binding
 
 ### Removed
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -824,7 +824,7 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
                 *self.ctx.received_count() = 0;
                 self.process_key_bindings(input);
             },
-            ElementState::Released => (),
+            ElementState::Released => *self.ctx.suppress_chars() = false,
         }
     }
 
@@ -853,8 +853,6 @@ impl<'a, T: EventListener, A: ActionContext<T>> Processor<'a, T, A> {
             if search_active && !suppress_chars {
                 self.ctx.search_input(c);
             }
-
-            *self.ctx.suppress_chars() = false;
 
             return;
         }


### PR DESCRIPTION
This reverts 1d00883 since it is not necessary anymore after all search
bindings are now proper key bindings. This fixes a bug which would cause
the first character to be swallowed when using IME after triggering any
key binding which doesn't send any `ReceivedCharacter` event.

Fixes #4588.