### PR TITLE
Add default binding to cancel search on Ctrl+C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Urgency support on Windows
 - Customizable keybindings for search
 - History for search mode, bound to ^P/^N/Up/Down by default
+- Default binding to cancel search on Ctrl+C
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -742,6 +742,7 @@
   # Search Mode
   #- { key: Return,                mode: Search|Vi,  action: SearchConfirm         }
   #- { key: Escape,                mode: Search,     action: SearchCancel          }
+  #- { key: C,      mods: Control, mode: Search,     action: SearchCancel          }
   #- { key: U,      mods: Control, mode: Search,     action: SearchClear           }
   #- { key: W,      mods: Control, mode: Search,     action: SearchDeleteWord      }
   #- { key: P,      mods: Control, mode: Search,     action: SearchHistoryPrevious }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -507,6 +507,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         Return,                        +BindingMode::SEARCH, +BindingMode::VI;
             SearchAction::SearchConfirm;
         Escape,                        +BindingMode::SEARCH; SearchAction::SearchCancel;
+        C,      ModifiersState::CTRL,  +BindingMode::SEARCH; SearchAction::SearchCancel;
         U,      ModifiersState::CTRL,  +BindingMode::SEARCH; SearchAction::SearchClear;
         W,      ModifiersState::CTRL,  +BindingMode::SEARCH; SearchAction::SearchDeleteWord;
         P,      ModifiersState::CTRL,  +BindingMode::SEARCH; SearchAction::SearchHistoryPrevious;


### PR DESCRIPTION
Fixes #4612.