### PR TITLE
Use ConfigDeserialize for all config enums

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -252,7 +252,7 @@ pub enum ViAction {
 }
 
 /// Search mode specific actions.
-#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SearchAction {
     /// Move the focus to the next search match.
     SearchFocusNext,

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -7,6 +7,8 @@ use log::{debug, trace};
 use serde::{Deserialize, Serialize};
 use vte::{Params, ParamsIter};
 
+use alacritty_config_derive::ConfigDeserialize;
+
 use crate::index::{Column, Line};
 use crate::term::color::Rgb;
 
@@ -332,14 +334,14 @@ pub trait Handler {
 }
 
 /// Terminal cursor configuration.
-#[derive(Deserialize, Default, Debug, Eq, PartialEq, Copy, Clone, Hash)]
+#[derive(ConfigDeserialize, Default, Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct CursorStyle {
     pub shape: CursorShape,
     pub blinking: bool,
 }
 
 /// Terminal cursor shape.
-#[derive(Deserialize, Debug, Eq, PartialEq, Copy, Clone, Hash)]
+#[derive(ConfigDeserialize, Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum CursorShape {
     /// Cursor is a block like `▒`.
     Block,
@@ -351,11 +353,11 @@ pub enum CursorShape {
     Beam,
 
     /// Cursor is a box like `☐`.
-    #[serde(skip)]
+    #[config(skip)]
     HollowBlock,
 
     /// Invisible cursor.
-    #[serde(skip)]
+    #[config(skip)]
     Hidden,
 }
 
@@ -509,7 +511,7 @@ pub enum TabulationClearMode {
 ///
 /// The order here matters since the enum should be castable to a `usize` for
 /// indexing a color list.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum NamedColor {
     /// Black.
     Black = 0,
@@ -621,7 +623,7 @@ impl NamedColor {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Color {
     Named(NamedColor),
     Spec(Rgb),

--- a/alacritty_terminal/src/config/colors.rs
+++ b/alacritty_terminal/src/config/colors.rs
@@ -178,7 +178,7 @@ impl Default for BrightColors {
     }
 }
 
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DimColors {
     pub black: Rgb,
     pub red: Rgb,
@@ -188,4 +188,19 @@ pub struct DimColors {
     pub magenta: Rgb,
     pub cyan: Rgb,
     pub white: Rgb,
+}
+
+impl Default for DimColors {
+    fn default() -> Self {
+        DimColors {
+            black: Rgb { r: 0x13, g: 0x14, b: 0x15 },
+            red: Rgb { r: 0x86, g: 0x43, b: 0x43 },
+            green: Rgb { r: 0x77, g: 0x7c, b: 0x44 },
+            yellow: Rgb { r: 0x9e, g: 0x82, b: 0x4c },
+            blue: Rgb { r: 0x55, g: 0x6a, b: 0x7d },
+            magenta: Rgb { r: 0x75, g: 0x61, b: 0x7b },
+            cyan: Rgb { r: 0x5b, g: 0x7d, b: 0x78 },
+            white: Rgb { r: 0x82, g: 0x84, b: 0x82 },
+        }
+    }
 }

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -126,7 +126,7 @@ impl IndexMut<CharsetIndex> for Charsets {
 ///                           ^
 ///                          cols
 /// ```
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Grid<T> {
     /// Current cursor for writing data.
     #[serde(skip)]

--- a/alacritty_terminal/src/grid/row.rs
+++ b/alacritty_terminal/src/grid/row.rs
@@ -13,7 +13,7 @@ use crate::index::Column;
 use crate::term::cell::ResetDiscriminant;
 
 /// A row in the grid.
-#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct Row<T> {
     inner: Vec<T>,
 

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -26,7 +26,7 @@ const MAX_CACHE_SIZE: usize = 1_000;
 /// [`slice::rotate_left`]: https://doc.rust-lang.org/std/primitive.slice.html#method.rotate_left
 /// [`Deref`]: std::ops::Deref
 /// [`zero`]: #structfield.zero
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Storage<T> {
     inner: Vec<Row<T>>,
 

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -45,7 +45,7 @@ pub enum Boundary {
 }
 
 /// Index in the grid using row, column notation.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub struct Point<L = Line> {
     pub line: L,
     pub col: Column,
@@ -199,7 +199,7 @@ impl From<&RenderableCell> for Point<Line> {
 /// A line.
 ///
 /// Newtype to avoid passing values incorrectly.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd)]
 pub struct Line(pub usize);
 
 impl fmt::Display for Line {
@@ -211,7 +211,7 @@ impl fmt::Display for Line {
 /// A column.
 ///
 /// Newtype to avoid passing values incorrectly.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd)]
 pub struct Column(pub usize);
 
 impl fmt::Display for Column {

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -1,6 +1,6 @@
 use std::cmp::{max, min};
 
-use serde::Deserialize;
+use alacritty_config_derive::ConfigDeserialize;
 
 use crate::event::EventListener;
 use crate::grid::{Dimensions, GridCell};
@@ -9,7 +9,7 @@ use crate::term::cell::Flags;
 use crate::term::Term;
 
 /// Possible vi mode motion movements.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ViMotion {
     /// Move up.
     Up,


### PR DESCRIPTION
This fixes up all of the remaining enums which are used in the
configuration file to make sure they all support fully case insensitive
deserialization.

Fixes #4611.
