### PR TITLE
Show IME composition preview on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.8.0-dev
 
+### Added
+
+- IME composition preview not appearing on Windows
+
 ### Fixed
 
 - Crash due to assertion failure on 32-bit architectures

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -421,17 +421,12 @@ impl Window {
     }
 
     /// Adjust the IME editor position according to the new location of the cursor.
-    #[cfg(not(windows))]
     pub fn update_ime_position(&mut self, point: Point, size: &SizeInfo) {
         let nspot_x = f64::from(size.padding_x() + point.col.0 as f32 * size.cell_width());
         let nspot_y = f64::from(size.padding_y() + (point.line.0 + 1) as f32 * size.cell_height());
 
         self.window().set_ime_position(PhysicalPosition::new(nspot_x, nspot_y));
     }
-
-    /// No-op, since Windows does not support IME positioning.
-    #[cfg(windows)]
-    pub fn update_ime_position(&mut self, _point: Point, _size_info: &SizeInfo) {}
 
     pub fn swap_buffers(&self) {
         self.windowed_context.swap_buffers().expect("swap buffers");


### PR DESCRIPTION
## Changes
* Fix IME composition preview not appearing on Windows
  * Although the [`set_ime_position`](https://docs.rs/winit/0.24.0/winit/window/struct.Window.html#method.set_ime_position)  is supported on Windows, it was disabled. So, it has been enabled.
<!--
* Add `cursor.ime_offset` option to set the position of IME composition preview
  * Originally, the IME composition position was one line down from the cursor position. As it is quite uncomfortable to input Hangul, a new option to set the offset is added.
-->

## Screenshots
[![Screenshot](https://i.imgur.com/QVUrDCE.png)
(Click here to play)](https://imgur.com/a/AdclGQ3)

## Tested On
* Windows 10 (1809) + (MS Korean Input, Google Japanese Input)
* ArchLinux + X11 + fcitx (Hangul, Mozc)