### PR TITLE
Fix inefficient search initialization

### DIFF
--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -492,12 +492,11 @@ impl Display {
             self.renderer.with_api(&config.ui_config, &size_info, |mut api| {
                 // Iterate over all non-empty cells in the grid.
                 for mut cell in grid_cells {
-                    // Invert the active match in vi-less search.
-                    let cell_point = Point::new(cell.line, cell.column);
+                    // Invert the active match during search.
                     if cell.is_match
                         && viewport_match
                             .as_ref()
-                            .map_or(false, |viewport_match| viewport_match.contains(&cell_point))
+                            .map_or(false, |viewport_match| viewport_match.contains(&cell.point()))
                     {
                         let colors = config.colors.search.focused_match;
                         let match_fg = colors.foreground.color(cell.fg, cell.bg);

--- a/alacritty_terminal/src/term/render.rs
+++ b/alacritty_terminal/src/term/render.rs
@@ -258,6 +258,11 @@ impl RenderableCell {
         }
     }
 
+    /// Position of the cell.
+    pub fn point(&self) -> Point {
+        Point::new(self.line, self.column)
+    }
+
     /// Check if cell contains any renderable content.
     fn is_empty(&self) -> bool {
         self.bg_alpha == 0.
@@ -370,6 +375,12 @@ struct RenderableSearch<'a> {
 impl<'a> RenderableSearch<'a> {
     /// Create a new renderable search iterator.
     fn new<T>(term: &'a Term<T>) -> Self {
+        // Avoid constructing search if there is none.
+        if term.regex_search.is_none() {
+            let iter: MatchIter<'a> = Box::new(iter::empty());
+            return Self { iter: iter.peekable() };
+        }
+
         let viewport_end = term.grid().display_offset();
         let viewport_start = viewport_end + term.screen_lines().0 - 1;
 


### PR DESCRIPTION
The creation of the renderable search iterator was doing a lot of work
even when absolutely no search is active at the moment. To resolve this
problem, an early return now makes sure that a search is active before
going through the trouble of creating an iterator for it.