### PR TITLE
Edit icon img src

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img width="200" alt="Alacritty Logo" src="extra/logo/compat/alacritty-term+scanlines.png">
+    <img width="200" alt="Alacritty Logo" src="https://github.com/alacritty/alacritty/blob/master/extra/logo/compat/alacritty-term+scanlines.png">
 </p>
 
 <h1 align="center">Alacritty - A fast, cross-platform, OpenGL terminal emulator</h1>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img width="200" alt="Alacritty Logo" src="https://github.com/alacritty/alacritty/blob/master/extra/logo/compat/alacritty-term+scanlines.png">
+    <img width="200" alt="Alacritty Logo" src="https://raw.githubusercontent.com/alacritty/alacritty/master/extra/logo/compat/alacritty-term%2Bscanlines.png">
 </p>
 
 <h1 align="center">Alacritty - A fast, cross-platform, OpenGL terminal emulator</h1>


### PR DESCRIPTION
Currently the Alacritty icon is not visible in the Readme when viewed from pages other than the main Readme (ex: https://github.com/alacritty/alacritty/tree/master/alacritty or https://crates.io/crates/alacritty). This change should allow the image to load.