### PR TITLE
Cross compile macOS app for arm64 and x86_64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
         run: |
           rustup default 1.43.1
           cargo test
-  build-macos-universal:
+  build-macos-apple-silicon:
     runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v2
-      - name: Install targets
-        run: rustup update && rustup target add x86_64-apple-darwin aarch64-apple-darwin
-      - name: Make App
-        run: make universal
+      - name: Install target
+        run: rustup update && rustup target add aarch64-apple-darwin
+      - name: Ensure it builds for Apple Silicon
+        run: MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,11 @@ jobs:
         run: |
           rustup default 1.43.1
           cargo test
+  build-macos-universal:
+    runs-on: macos-11.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install targets
+        run: rustup update && rustup target add x86_64-apple-darwin aarch64-apple-darwin
+      - name: Make App
+        run: make universal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install target
         run: rustup update && rustup target add aarch64-apple-darwin
-      - name: Ensure it builds for Apple Silicon
+      - name: Check build
         run: cargo check --target=aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
         run: |
           rustup default 1.43.1
           cargo test
-  build-macos-apple-silicon:
+  check-macos-apple-silicon:
     runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v2
       - name: Install target
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Ensure it builds for Apple Silicon
-        run: MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin
+        run: cargo check --target=aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           rustup default 1.43.1
           cargo test
-  check-macos-apple-silicon:
+  check-macos-arm:
     runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-11.0
 
     steps:
       - uses: actions/checkout@v2
       - name: Install targets
-        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
+        run: rustup update && rustup target add x86_64-apple-darwin aarch64-apple-darwin
       - name: Test
         run: cargo test --release
       - name: Make App

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test
         run: cargo test --release
       - name: Make App
-        run: make dmg "MULTI_ARCH=x86_64 aarch64"
+        run: make universal
       - name: Upload Application
         run: |
           mv ./target/release/osx/Alacritty.dmg ./Alacritty-${GITHUB_REF##*/}.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test
         run: cargo test --release
       - name: Make App
-        run: make dmg
+        run: make dmg "MULTI_ARCH=x86_64 aarch64"
       - name: Upload Application
         run: |
           mv ./target/release/osx/Alacritty.dmg ./Alacritty-${GITHUB_REF##*/}.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install targets
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
       - name: Test
         run: cargo test --release
       - name: Make App

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test
         run: cargo test --release
       - name: Make App
-        run: make universal
+        run: make dmg-universal
       - name: Upload Application
         run: |
           mv ./target/release/osx/Alacritty.dmg ./Alacritty-${GITHUB_REF##*/}.dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Packaging
 
 - Updated shell completions
+- Build universal DMG package for arm64 and x86\_64 on macOS
 
 ## 0.7.1
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -243,10 +243,21 @@ If all goes well, this should place a binary at `target/release/alacritty`.
 
 ### macOS
 
+For macOS you can build and install the app as follows:
+
 ```sh
 make app
 cp -r target/release/osx/Alacritty.app /Applications/
 ```
+
+If you want to build cross-compile a universal .dmg file, you can run the following:
+
+```sh
+rustup update && rustup target add x86_64-apple-darwin aarch64-apple-darwin
+make dmg-universal
+```
+
+You will then find `Alacritty.dmg` in `target/release/osx`.
 
 ## Post Build
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ $(APP_NAME)-%: $(TARGET)-%
 	@echo "Created '$(APP_NAME)' in '$(APP_DIR)'"
 
 dmg: | $(DMG_NAME)-native ## Pack Alacritty.app into .dmg
+dmg-universal: $(DMG_NAME)-universal ## Build universal Alacritty.app and package into .dmg
 $(DMG_NAME)-%: $(APP_NAME)-%
 	@echo "Packing disk image..."
 	@ln -sf /Applications $(DMG_DIR)/Applications
@@ -62,8 +63,6 @@ $(DMG_NAME)-%: $(APP_NAME)-%
 		-srcfolder $(APP_DIR) \
 		-ov -format UDZO
 	@echo "Packed '$(DMG_NAME)' in '$(APP_DIR)'"
-
-universal: $(DMG_NAME)-universal ## Build universal Alacritty.app and package into .dmg
 
 install: $(DMG_NAME) ## Mount disk image
 	@open $(DMG_DIR)/$(DMG_NAME)

--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ install: $(DMG_NAME) ## Mount disk image
 .PHONY: app binary clean dmg install $(TARGET)-native $(TARGET)-universal
 
 clean: ## Remove all artifacts
-	-rm -rf target
+	cargo clean


### PR DESCRIPTION
Here I'm adding cross compilation for arm64 and x86_64, and combining them into a [universal binary](https://developer.apple.com/documentation/xcode/building_a_universal_macos_binary) with lipo.

I also added installation of the targets in the release workflow. With these changes the app will run natively on both Intel and M1 Macs.