### PR TITLE
fix assertion on 32-bit arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Assertion failure on 32-bit architectures
+- Crash due to assertion failure on 32-bit architectures
 
 ## 0.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.8.0-dev
 
+### Fixed
+
+- Assertion failure on 32-bit architectures
+
 ## 0.7.1
 
 ### Fixed

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -156,7 +156,7 @@ impl<T> Storage<T> {
     /// instructions. This implementation achieves the swap in only 8 movups
     /// instructions.
     pub fn swap(&mut self, a: usize, b: usize) {
-        debug_assert_eq!(std::mem::size_of::<Row<T>>(), 32);
+        debug_assert_eq!(std::mem::size_of::<Row<T>>(), std::mem::size_of::<usize>() * 4);
 
         let a = self.compute_index(a);
         let b = self.compute_index(b);

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -156,7 +156,7 @@ impl<T> Storage<T> {
     /// instructions. This implementation achieves the swap in only 8 movups
     /// instructions.
     pub fn swap(&mut self, a: usize, b: usize) {
-        debug_assert_eq!(std::mem::size_of::<Row<T>>(), std::mem::size_of::<usize>() * 4);
+        debug_assert_eq!(mem::size_of::<Row<T>>(), mem::size_of::<usize>() * 4);
 
         let a = self.compute_index(a);
         let b = self.compute_index(b);


### PR DESCRIPTION
Closes #4687, uses the actual size of usize rather than a fixed
constant.