### PR TITLE
feat(env): add TERM_PROGRAM as env var, to be able to find out in wha…

### DIFF
--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -67,6 +67,9 @@ pub fn setup_env<C>(config: &Config<C>) {
     let terminfo = if terminfo_exists("alacritty") { "alacritty" } else { "xterm-256color" };
     env::set_var("TERM", terminfo);
 
+    // TERM_PROGRAM is used on macOS and like commonly used
+    env::set_var("TERM_PROGRAM", "alacritty");
+
     // Advertise 24-bit color support.
     env::set_var("COLORTERM", "truecolor");
 


### PR DESCRIPTION
…t terminal things are running

this PR adds the provisioning of the env var `TERM_PROGRAM` as it is used and sometimes needed by other programs on macOS.

I going to need this in order to stream line the window id identification used for [t-rec-rs](https://github.com/sassman/t-rec-rs).

Also I found other cases where this sort of thing was added like [this one e.g. on vscode](https://github.com/microsoft/vscode/commit/9c82ae899c79de07413af7cdbe262dbe4550abd0)