### PR TITLE
allow copying urls on right click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - IME composition preview not appearing on Windows
+- New `mouse.url.right_click_copy` option to support copying URLs with right click
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -450,6 +450,11 @@
     # binding section.
     #modifiers: None
 
+    # URL right click copy
+    #
+    # If true, right-clicking on a URL will copy it to the clipboard.
+    #right_click_copy: false
+
 # Mouse bindings
 #
 # Mouse bindings are specified as a list of objects, much like the key

--- a/alacritty/src/config/mouse.rs
+++ b/alacritty/src/config/mouse.rs
@@ -22,6 +22,9 @@ pub struct Url {
 
     /// Modifier used to open links.
     modifiers: ModsWrapper,
+
+    /// Whether to copy URL on right click.
+    pub right_click_copy: bool,
 }
 
 impl Url {
@@ -40,6 +43,7 @@ impl Default for Url {
             #[cfg(windows)]
             launcher: Some(Program::Just(String::from("explorer"))),
             modifiers: Default::default(),
+            right_click_copy: false,
         }
     }
 }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -406,6 +406,16 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
     }
 
+    /// Copy URL when right clicking.
+    fn copy_url(&mut self, url: Url) {
+        if self.config.ui_config.mouse.url.right_click_copy {
+            let start = self.terminal.visible_to_buffer(url.start());
+            let end = self.terminal.visible_to_buffer(url.end());
+            self.clipboard
+                .store(ClipboardType::Clipboard, self.terminal.bounds_to_string(start, end));
+        }
+    }
+
     fn highlighted_url(&self) -> Option<&Url> {
         self.display.highlighted_url.as_ref()
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -90,6 +90,7 @@ pub trait ActionContext<T: EventListener> {
     fn event_loop(&self) -> &EventLoopWindowTarget<Event>;
     fn urls(&self) -> &Urls;
     fn launch_url(&self, _url: Url) {}
+    fn copy_url(&mut self, url: Url);
     fn highlighted_url(&self) -> Option<&Url>;
     fn mouse_mode(&self) -> bool;
     fn clipboard_mut(&mut self) -> &mut Clipboard;
@@ -695,6 +696,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return;
         } else if let (MouseButton::Left, MouseState::Url(url)) = (button, self.mouse_state()) {
             self.ctx.launch_url(url);
+        } else if let (MouseButton::Right, MouseState::Url(url)) = (button, self.mouse_state()) {
+            self.ctx.copy_url(url);
         }
 
         self.ctx.scheduler_mut().unschedule(TimerId::SelectionScrolling);
@@ -1220,6 +1223,10 @@ mod tests {
         }
 
         fn highlighted_url(&self) -> Option<&Url> {
+            unimplemented!();
+        }
+
+        fn copy_url(&mut self, _: Url) {
             unimplemented!();
         }
 

--- a/alacritty/src/url.rs
+++ b/alacritty/src/url.rs
@@ -161,7 +161,7 @@ impl Urls {
         }
 
         // Make sure all prerequisites for highlighting are met.
-        if selection
+        if (selection && !config.ui_config.mouse.url.right_click_copy)
             || !mouse.inside_text_area
             || config.ui_config.mouse.url.launcher.is_none()
             || required_mods != mods


### PR DESCRIPTION
Adds support for copying URLs by right mouse click (as suggested
in #4063). Configured with a new url option, right_click_copy, which
defaults to false.

changelog entry

This doesn't address some of the suggestions for further enhancement in that issue, like setting actions for arbitrary sets of modifiers, but it works quite well for me while being fairly unobtrusive.