### PR TITLE
Set dirty flag on keypress

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1226,6 +1226,7 @@ impl<N: Notify + OnResize> Processor<N> {
                     },
                     WindowEvent::KeyboardInput { input, is_synthetic: false, .. } => {
                         processor.key_input(input);
+                        processor.ctx.dirty = true;
                     },
                     WindowEvent::ModifiersChanged(modifiers) => {
                         processor.modifiers_input(modifiers)


### PR DESCRIPTION
This fixes a one-keypress input feedback delay when running on Wayland.
Without setting the dirty flag (and forcing a draw() call), the old
buffer was being committed rather than the buffer holding the new glyph.