### PR TITLE
fix: remove invalid --dimensions flag from bash completion

### DIFF
--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -35,7 +35,7 @@ _alacritty()
             compopt -o filenames
             COMPREPLY=( $(compgen -f -- "${cur}") )
             return 0;;
-        --dimensions | -d | --class | --title | -t)
+        --class | --title | -t)
             # Don't complete here
             return 0;;
         --working-directory)


### PR DESCRIPTION
A first pass at updating the completion files for zsh, bash, and fish
was made in commit 34435ed776988e765d9327dcedfe909e440e6bf8. This patch
completes this work by updating the completion scripts to remove flags
that no longer exist.