### PR TITLE
deps: bump smallvec from 1.6.0 to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,9 +1478,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smithay-client-toolkit"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0003.html