### PR TITLE
Limit the maximum DPR on X11 to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Segmentation fault on shutdown with Wayland
 - Incorrect estimated DPR with Wayland
 - Consecutive clipboard stores dropped on Wayland until the application is refocused
+- Alacritty failing to start on X11 with invalid DPI reported by XRandr
 
 ### Removed
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -24,7 +24,6 @@ use {
     std::io::Cursor,
 
     x11_dl::xlib::{Display as XDisplay, PropModeReplace, XErrorEvent, Xlib},
-    glutin::platform::unix::EventLoopWindowTargetExtUnix,
     glutin::window::Icon,
     png::Decoder,
 };
@@ -226,7 +225,7 @@ impl Window {
 
         // Handle winit reporting invalid values due to incorrect XRandr monitor metrics.
         #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
-        if event_loop.is_x11() && dpr > MAX_X11_DPR {
+        if !is_wayland && dpr > MAX_X11_DPR {
             dpr = 1.;
         }
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -60,6 +60,10 @@ use crate::gl;
 #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
 static WINDOW_ICON: &[u8] = include_bytes!("../../alacritty.png");
 
+/// Maximum DPR on X11 before it is assumed that XRandr is reporting incorrect values.
+#[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
+const MAX_X11_DPR: f64 = 10.;
+
 /// This should match the definition of IDI_ICON from `windows.rc`.
 #[cfg(windows)]
 const IDI_ICON: WORD = 0x101;
@@ -216,7 +220,13 @@ impl Window {
             None
         };
 
-        let dpr = windowed_context.window().scale_factor();
+        let mut dpr = windowed_context.window().scale_factor();
+
+        // Handle winit reporting invalid values due to incorrect XRandr monitor metrics.
+        #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
+        if event_loop.is_x11() && dpr > MAX_X11_DPR {
+            dpr = 1.;
+        }
 
         Ok(Self {
             current_mouse_cursor,

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -220,6 +220,7 @@ impl Window {
             None
         };
 
+        #[allow(unused_mut)]
         let mut dpr = windowed_context.window().scale_factor();
 
         // Handle winit reporting invalid values due to incorrect XRandr monitor metrics.

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -24,6 +24,7 @@ use {
     std::io::Cursor,
 
     x11_dl::xlib::{Display as XDisplay, PropModeReplace, XErrorEvent, Xlib},
+    glutin::platform::unix::EventLoopWindowTargetExtUnix,
     glutin::window::Icon,
     png::Decoder,
 };


### PR DESCRIPTION
Since there have a bunch of problems caused by an excessive DPI reported
by XRandr, this limits the maximum DPR on X11 to 10.

These issues would commonly cause problems like long startup times or
crashes, which are hard to troubleshoot for the user. While a limit of
10 might not eliminate all of these issues, it should still make it
possible for Alacritty to start to make troubleshooting simpler.

Fixes #3214.