### PR TITLE
Fix search freezing Alacritty

### DIFF
--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -469,16 +469,25 @@ impl<'a, T> Iterator for RegexIter<'a, T> {
     type Item = Match;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        // Since the end itself might be a single cell match, we search one more time.
         if self.point == self.end {
             self.done = true;
-        } else if self.done {
-            return None;
         }
 
         let regex_match = self.next_match()?;
 
         self.point = *regex_match.end();
-        self.skip();
+        if self.point == self.end {
+            // Stop when the match terminates right on the end limit.
+            self.done = true;
+        } else {
+            // Move the new search origin past the match.
+            self.skip();
+        }
 
         Some(regex_match)
     }


### PR DESCRIPTION
This resolves a regression introduced in 530de00 where searching would
cause a deadlock when the viewport is at the bottom of the scrollback
and a match ends in the last cell.

Fixes #4800.