### PR TITLE
Fix hollow block cursor being drawn for hidden cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Alacritty failing to start on X11 with invalid DPI reported by XRandr
 - Text selected after search without any match
 - Incorrect vi cursor position after leaving search
+- Hollow block cursor being drawn when the cursor is hidden for unfocused window
 
 ### Removed
 

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -48,7 +48,7 @@ impl<'a> RenderableContent<'a> {
 
         // Copy the cursor and override its shape if necessary.
         let mut terminal_cursor = terminal_content.cursor;
-        if !show_cursor {
+        if !show_cursor || terminal_cursor.shape == CursorShape::Hidden {
             terminal_cursor.shape = CursorShape::Hidden;
         } else if !term.is_focused && config.cursor.unfocused_hollow {
             terminal_cursor.shape = CursorShape::HollowBlock;


### PR DESCRIPTION
Commit 530de00 refactored large chunk of Alacritty's internal handling
of renderable cells, cursors, and such, those it introduced a
regression when hollow block cursor was drawn for unfocused window
with hidden cursor, e.g. in (neo)mutt. This commit fixes it.