### PR TITLE
add Windows version requirements to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Since Alacritty uses OpenGL to render the terminal content on all platforms, it
 is currently not possible to run it without support for at least OpenGL 3.3.
 
 On Windows, a native PTY API was only introduced [in 2018](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/).
-As Alacritty has adopted this API exclusively, Windows 10 version 1903 or greater
+As Alacritty has adopted this API exclusively, Windows 10 version 1809 or greater
 is now required.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ For everyone else, the detailed instructions to install Alacritty can be found
 Since Alacritty uses OpenGL to render the terminal content on all platforms, it
 is currently not possible to run it without support for at least OpenGL 3.3.
 
+On Windows, a native PTY API was only introduced [in 2018](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/).
+As Alacritty has adopted this API exclusively, Windows 10 version 1903 or greater
+is now required.
+
 ## Configuration
 
 You can find the default configuration file with documentation for all available

--- a/README.md
+++ b/README.md
@@ -47,12 +47,9 @@ Prebuilt binaries for macOS and Windows can also be downloaded from the
 For everyone else, the detailed instructions to install Alacritty can be found
 [here](INSTALL.md).
 
-Since Alacritty uses OpenGL to render the terminal content on all platforms, it
-is currently not possible to run it without support for at least OpenGL 3.3.
-
-On Windows, a native PTY API was only introduced [in 2018](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/).
-As Alacritty has adopted this API exclusively, Windows 10 version 1809 or greater
-is now required.
+### Requirements
+- OpenGL 3.3 or higher
+- [Windows] ConPTY support (Windows 10 version 1809 or higher)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ For everyone else, the detailed instructions to install Alacritty can be found
 [here](INSTALL.md).
 
 ### Requirements
+
 - OpenGL 3.3 or higher
 - [Windows] ConPTY support (Windows 10 version 1809 or higher)
 


### PR DESCRIPTION
Addresses #4846 by documenting the Windows version requirement now that
ConPTY is the only backend.