### PR TITLE
Remove incorrect changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Alacritty failing to start on X11 with invalid DPI reported by XRandr
 - Text selected after search without any match
 - Incorrect vi cursor position after leaving search
-- Hollow block cursor being drawn when the cursor is hidden for unfocused window
 
 ### Removed
 


### PR DESCRIPTION
Since the bug was not present in the 0.7.2 release, there is no need to
add a changelog entry for this fix.