### PR TITLE
Add copy/paste hint actions

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -478,8 +478,18 @@
 
   # List with all available hints
   #
+  # Each hint takes a `regex`, `binding` and either a `command` or an `action`.
+  #
   # The fields `command`, `binding.key` and `binding.mods` accept the same
   # values as they do in the `key_bindings` section.
+  #
+  # Values for `action`:
+  #   - Copy
+  #       Copy the hint's text to the clipboard.
+  #   - Paste
+  #       Paste the hint's text to the terminal or search.
+  #   - Select
+  #       Select the hint's text.
   #
   # Example
   #

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -250,7 +250,7 @@ impl<'de> Deserialize<'de> for HintsAlphabet {
 pub enum HintInternalAction {
     /// Copy the text to the clipboard.
     Copy,
-    /// Write the text to the PTY.
+    /// Write the text to the PTY/search.
     Paste,
     /// Select the text matching the hint.
     Select,
@@ -271,7 +271,7 @@ pub enum HintAction {
 /// Hint configuration.
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Hint {
-    /// Action when this hint is triggered.
+    /// Action executed when this hint is triggered.
     #[serde(flatten)]
     pub action: HintAction,
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use log::error;
 use serde::de::Error as SerdeError;
-use serde::{Deserialize, Deserializer};
+use serde::{self, Deserialize, Deserializer};
 use unicode_width::UnicodeWidthChar;
 
 use alacritty_config_derive::ConfigDeserialize;
@@ -245,11 +245,33 @@ impl<'de> Deserialize<'de> for HintsAlphabet {
     }
 }
 
+/// Built-in actions for hint mode.
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
+pub enum HintInternalAction {
+    /// Copy the text to the clipboard.
+    Copy,
+    /// Write the text to the PTY.
+    Paste,
+}
+
+/// Actions for hint bindings.
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum HintAction {
+    /// Built-in hint action.
+    #[serde(rename = "action")]
+    Action(HintInternalAction),
+
+    /// Command the text will be piped to.
+    #[serde(rename = "command")]
+    Command(Program),
+}
+
 /// Hint configuration.
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Hint {
-    /// Command the text will be piped to.
-    pub command: Program,
+    /// Action when this hint is triggered.
+    #[serde(flatten)]
+    pub action: HintAction,
 
     /// Regex for finding matches.
     pub regex: LazyRegex,

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -252,6 +252,8 @@ pub enum HintInternalAction {
     Copy,
     /// Write the text to the PTY.
     Paste,
+    /// Select the text matching the hint.
+    Select,
 }
 
 /// Actions for hint bindings.

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -1,3 +1,4 @@
+use alacritty_terminal::term::search::Match;
 use alacritty_terminal::term::Term;
 
 use crate::config::ui_config::{Hint, HintAction};
@@ -109,15 +110,12 @@ impl HintState {
 
         // Check if the selected label is fully matched.
         if label.len() == 1 {
-            // Get text for the hint's regex match.
-            let hint_match = &self.matches[index];
-            let text = term.bounds_to_string(*hint_match.start(), *hint_match.end());
-
+            let bounds = self.matches[index].clone();
             let action = hint.action.clone();
 
             self.stop();
 
-            Some(HintMatch { text, action })
+            Some(HintMatch { action, bounds })
         } else {
             // Store character to preserve the selection.
             self.keys.push(c);
@@ -150,8 +148,8 @@ pub struct HintMatch {
     /// Action for handling the text.
     pub action: HintAction,
 
-    /// Hint match text.
-    pub text: String,
+    /// Terminal range matching the hint.
+    pub bounds: Match,
 }
 
 /// Generator for creating new hint labels.

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -1,7 +1,6 @@
 use alacritty_terminal::term::Term;
 
-use crate::config::ui_config::Hint;
-use crate::daemon::start_daemon;
+use crate::config::ui_config::{Hint, HintAction};
 use crate::display::content::RegexMatches;
 
 /// Percentage of characters in the hints alphabet used for the last character.
@@ -88,7 +87,7 @@ impl HintState {
     }
 
     /// Handle keyboard input during hint selection.
-    pub fn keyboard_input<T>(&mut self, term: &Term<T>, c: char) {
+    pub fn keyboard_input<T>(&mut self, term: &Term<T>, c: char) -> Option<HintMatch> {
         match c {
             // Use backspace to remove the last character pressed.
             '\x08' | '\x1f' => {
@@ -102,17 +101,11 @@ impl HintState {
         // Update the visible matches.
         self.update_matches(term);
 
-        let hint = match self.hint.as_ref() {
-            Some(hint) => hint,
-            None => return,
-        };
+        let hint = self.hint.as_ref()?;
 
         // Find the last label starting with the input character.
         let mut labels = self.labels.iter().enumerate().rev();
-        let (index, label) = match labels.find(|(_, label)| !label.is_empty() && label[0] == c) {
-            Some(last) => last,
-            None => return,
-        };
+        let (index, label) = labels.find(|(_, label)| !label.is_empty() && label[0] == c)?;
 
         // Check if the selected label is fully matched.
         if label.len() == 1 {
@@ -120,16 +113,16 @@ impl HintState {
             let hint_match = &self.matches[index];
             let text = term.bounds_to_string(*hint_match.start(), *hint_match.end());
 
-            // Append text as last argument and launch command.
-            let program = hint.command.program();
-            let mut args = hint.command.args().to_vec();
-            args.push(text);
-            start_daemon(program, &args);
+            let action = hint.action.clone();
 
             self.stop();
+
+            Some(HintMatch { text, action })
         } else {
             // Store character to preserve the selection.
             self.keys.push(c);
+
+            None
         }
     }
 
@@ -150,6 +143,15 @@ impl HintState {
             self.keys.clear();
         }
     }
+}
+
+/// Hint match which was selected by the user.
+pub struct HintMatch {
+    /// Action for handling the text.
+    pub action: HintAction,
+
+    /// Hint match text.
+    pub text: String,
 }
 
 /// Generator for creating new hint labels.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -672,7 +672,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
                 let text = self.terminal.bounds_to_string(*bounds.start(), *bounds.end());
                 self.clipboard.store(ClipboardType::Clipboard, text);
             },
-            // Write the text to the PTY.
+            // Write the text to the PTY/search.
             HintAction::Action(HintInternalAction::Paste) => {
                 let text = self.terminal.bounds_to_string(*bounds.start(), *bounds.end());
                 self.paste(&text);

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -661,7 +661,6 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         }
 
         self.ctx.scheduler_mut().unschedule(TimerId::SelectionScrolling);
-        self.copy_selection();
     }
 
     pub fn mouse_wheel_input(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
@@ -944,14 +943,6 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         } else {
             Some(MouseState::MessageBar)
         }
-    }
-
-    /// Copy text selection.
-    fn copy_selection(&mut self) {
-        if self.ctx.config().selection.save_to_clipboard {
-            self.ctx.copy_selection(ClipboardType::Clipboard);
-        }
-        self.ctx.copy_selection(ClipboardType::Selection);
     }
 
     /// Trigger redraw when URL highlight changed.

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -60,7 +60,7 @@ pub struct Processor<T: EventListener, A: ActionContext<T>> {
 }
 
 pub trait ActionContext<T: EventListener> {
-    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, _data: B) {}
+    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&self, _data: B) {}
     fn mark_dirty(&mut self) {}
     fn size_info(&self) -> SizeInfo;
     fn copy_selection(&mut self, _ty: ClipboardType) {}

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -70,7 +70,7 @@ pub trait Notify {
     /// Notify that an escape sequence should be written to the PTY.
     ///
     /// TODO this needs to be able to error somehow.
-    fn notify<B: Into<Cow<'static, [u8]>>>(&mut self, _: B);
+    fn notify<B: Into<Cow<'static, [u8]>>>(&self, _: B);
 }
 
 /// Types that are interested in when the display is resized.

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -62,7 +62,7 @@ struct Writing {
 pub struct Notifier(pub Sender<Msg>);
 
 impl event::Notify for Notifier {
-    fn notify<B>(&mut self, bytes: B)
+    fn notify<B>(&self, bytes: B)
     where
         B: Into<Cow<'static, [u8]>>,
     {

--- a/docs/features.md
+++ b/docs/features.md
@@ -58,7 +58,8 @@ stays selected, allowing you to easily copy it.
 
 Terminal hints allow easily interacting with visible text without having to
 start vi mode. They consist of a regex that detects these text elements and then
-feeds them to an external application.
+either feeds them to an external application or triggers one of Alacritty's
+built-in actions.
 
 Hints can be configured in the `hints` and `colors.hints` sections in the
 Alacritty configuration file.


### PR DESCRIPTION
This adds some built-in actions for handling hint selections without
having to spawn external applications.

The new actions are `Copy` and `Paste`, which allow writing the text to
the clipboard or the PTY.