### PR TITLE
Reset the cursor style when leaving the alt grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Alacritty failing to start on X11 with invalid DPI reported by XRandr
 - Text selected after search without any match
 - Incorrect vi cursor position after leaving search
+- Reset cursor style when leaving alt grid
 
 ### Removed
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -531,7 +531,9 @@ impl<T> Term<T> {
 
     /// Swap primary and alternate screen buffer.
     pub fn swap_alt(&mut self) {
-        if !self.mode.contains(TermMode::ALT_SCREEN) {
+        if self.mode.contains(TermMode::ALT_SCREEN) {
+            self.cursor_style = None;
+        } else {
             // Set alt screen cursor to the current primary screen cursor.
             self.inactive_grid.cursor = self.grid.cursor.clone();
 


### PR DESCRIPTION
According to invisible-island's docs for `CSI 1049 Pm l`, we should be
resetting the cursor style in addition to changing back to the normal
buffer.

fixes #4868
fixes #4505