### PR TITLE
fix clippy::inconsistent_struct_constructor

### DIFF
--- a/alacritty/src/display/wayland_theme.rs
+++ b/alacritty/src/display/wayland_theme.rs
@@ -8,8 +8,8 @@ const INACTIVE_OPACITY: u8 = 127;
 
 #[derive(Debug, Clone)]
 pub struct AlacrittyWaylandTheme {
-    pub background: ARGBColor,
     pub foreground: ARGBColor,
+    pub background: ARGBColor,
     pub dim_foreground: ARGBColor,
     pub hovered_close_icon: ARGBColor,
     pub hovered_maximize_icon: ARGBColor,
@@ -32,8 +32,8 @@ impl AlacrittyWaylandTheme {
             background,
             dim_foreground,
             hovered_close_icon,
-            hovered_minimize_icon,
             hovered_maximize_icon,
+            hovered_minimize_icon,
         }
     }
 }

--- a/alacritty/src/url.rs
+++ b/alacritty/src/url.rs
@@ -138,7 +138,7 @@ impl Urls {
         if url.lines.last().map(|last| last.color) == Some(color) {
             url.lines.last_mut().unwrap().end = end;
         } else {
-            url.lines.push(RenderLine { color, start, end });
+            url.lines.push(RenderLine { start, end, color });
         }
 
         // Update excluded cells at the end of the URL.


### PR DESCRIPTION
Make sure that struct fields in the instantiation are ordered the same as in the definition.