### PR TITLE
Fixed IME position being little earlier one in X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Alacritty failing to start on X11 with invalid DPI reported by XRandr
 - Text selected after search without any match
 - Incorrect vi cursor position after leaving search
+- IME position being little earlier one on X11
 
 ### Removed
 


### PR DESCRIPTION
This fixes that IME position being little earlier one in X11.

I tested on X11 gnome (3.36.4-1ubuntu1~20.04.2) and mozc (2.23.2815.102+dfsg-8ubuntu1) on Ubuntu.

https://user-images.githubusercontent.com/16546008/111015999-c5dd4580-83ee-11eb-9f9f-001454a0a173.mp4