### PR TITLE
change windows default url_launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Alacritty failing to start on X11 with invalid DPI reported by XRandr
 - Text selected after search without any match
 - Incorrect vi cursor position after leaving search
+- Clicking on URLs on Windows incorrectly opens File Explorer
 
 ### Removed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -456,7 +456,7 @@
     # Default:
     #   - (macOS) open
     #   - (Linux/BSD) xdg-open
-    #   - (Windows) explorer
+    #   - (Windows) cmd /c start ""
     #launcher:
     #  program: xdg-open
     #  args: []

--- a/alacritty/src/config/mouse.rs
+++ b/alacritty/src/config/mouse.rs
@@ -38,7 +38,10 @@ impl Default for Url {
             #[cfg(target_os = "macos")]
             launcher: Some(Program::Just(String::from("open"))),
             #[cfg(windows)]
-            launcher: Some(Program::Just(String::from("explorer"))),
+            launcher: Some(Program::WithArgs {
+                program: String::from("cmd"),
+                args: vec!["/c".to_string(), "start".to_string(), "".to_string()],
+            }),
             modifiers: Default::default(),
         }
     }


### PR DESCRIPTION
When clicking on a link on windows we don't want to launch Explorer.

Using `cmd /c start "" $LINK/$PATH` opens files and protocols with
their default programs.

Fixes #4885.
Fixes #2084.