### PR TITLE
Keep viewport in place when resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Incorrect vi cursor position after leaving search
 - Clicking on URLs on Windows incorrectly opens File Explorer
 - Incorrect underline cursor thickness on wide cell
+- Viewport moving around when resizing while scrolled into history
 
 ### Removed
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -502,7 +502,7 @@ pub trait Dimensions {
     /// Number of invisible lines part of the scrollback history.
     #[inline]
     fn history_size(&self) -> usize {
-        self.total_lines() - self.screen_lines()
+        self.total_lines().saturating_sub(self.screen_lines())
     }
 }
 

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -187,7 +187,7 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
 
                 cursor_line_delta += line_delta.0 as usize;
             } else if row.is_clear() {
-                if i + reversed.len() >= self.lines {
+                if i <= self.display_offset {
                     // Since we removed a line, rotate down the viewport.
                     self.display_offset = self.display_offset.saturating_sub(1);
                 }
@@ -354,6 +354,11 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
                         wrapped.resize_with(columns, T::default);
                     }
                     row = Row::from_vec(wrapped, occ);
+
+                    if i <= self.display_offset {
+                        // Since we added a new line, rotate up the viewport.
+                        self.display_offset += 1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #4879

First of all, I'd like to thank you for maintaining the most awesome terminal emulator out there. Keep it up :)

My code anchors the viewport at the last visible line. This corresponds to my intuition of how terminal emulators should work. If you want it anchored at the first visible line or have another approach at this issue feel free to leave a comment.

Your feedback is appreciated.