### PR TITLE
Fixed hide other windows keybinding on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - IME composition preview not appearing on Windows
 - Synchronized terminal updates using `DCS = 1 s ST`/`DCS = 2 s ST`
 - Regex terminal hints ([see features.md](./docs/features.md#hints))
+- macOS keybinding (cmd+alt+H) hiding all windows other than Alacritty
 
 ### Fixed
 
@@ -25,7 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clicking on URLs on Windows incorrectly opens File Explorer
 - Incorrect underline cursor thickness on wide cell
 - Viewport moving around when resizing while scrolled into history
-- macOS keybinding (cmd+alt+H) hiding all windows except Alacritty
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clicking on URLs on Windows incorrectly opens File Explorer
 - Incorrect underline cursor thickness on wide cell
 - Viewport moving around when resizing while scrolled into history
+- macOS keybinding (cmd+alt+H) hiding all windows except Alacritty
 
 ### Removed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -821,25 +821,26 @@
   #- { key: Return,   mods: Alt,           action: ToggleFullscreen }
 
   # (macOS only)
-  #- { key: K,              mods: Command, mode: ~Vi|~Search, chars: "\x0c"            }
-  #- { key: K,              mods: Command, mode: ~Vi|~Search, action: ClearHistory     }
-  #- { key: Key0,           mods: Command,                    action: ResetFontSize    }
-  #- { key: Equals,         mods: Command,                    action: IncreaseFontSize }
-  #- { key: Plus,           mods: Command,                    action: IncreaseFontSize }
-  #- { key: NumpadAdd,      mods: Command,                    action: IncreaseFontSize }
-  #- { key: Minus,          mods: Command,                    action: DecreaseFontSize }
-  #- { key: NumpadSubtract, mods: Command,                    action: DecreaseFontSize }
-  #- { key: V,              mods: Command,                    action: Paste            }
-  #- { key: C,              mods: Command,                    action: Copy             }
-  #- { key: C,              mods: Command, mode: Vi|~Search,  action: ClearSelection   }
-  #- { key: H,              mods: Command,                    action: Hide             }
-  #- { key: M,              mods: Command,                    action: Minimize         }
-  #- { key: Q,              mods: Command,                    action: Quit             }
-  #- { key: W,              mods: Command,                    action: Quit             }
-  #- { key: N,              mods: Command,                    action: SpawnNewInstance }
-  #- { key: F,              mods: Command|Control,            action: ToggleFullscreen }
-  #- { key: F,              mods: Command, mode: ~Search,     action: SearchForward    }
-  #- { key: B,              mods: Command, mode: ~Search,     action: SearchBackward   }
+  #- { key: K,              mods: Command, mode: ~Vi|~Search, chars: "\x0c"                 }
+  #- { key: K,              mods: Command, mode: ~Vi|~Search, action: ClearHistory          }
+  #- { key: Key0,           mods: Command,                    action: ResetFontSize         }
+  #- { key: Equals,         mods: Command,                    action: IncreaseFontSize      }
+  #- { key: Plus,           mods: Command,                    action: IncreaseFontSize      }
+  #- { key: NumpadAdd,      mods: Command,                    action: IncreaseFontSize      }
+  #- { key: Minus,          mods: Command,                    action: DecreaseFontSize      }
+  #- { key: NumpadSubtract, mods: Command,                    action: DecreaseFontSize      }
+  #- { key: V,              mods: Command,                    action: Paste                 }
+  #- { key: C,              mods: Command,                    action: Copy                  }
+  #- { key: C,              mods: Command, mode: Vi|~Search,  action: ClearSelection        }
+  #- { key: H,              mods: Command,                    action: Hide                  }
+  #- { key: H,              mods: Command|Alt,                action: HideOtherApplications }
+  #- { key: M,              mods: Command,                    action: Minimize              }
+  #- { key: Q,              mods: Command,                    action: Quit                  }
+  #- { key: W,              mods: Command,                    action: Quit                  }
+  #- { key: N,              mods: Command,                    action: SpawnNewInstance      }
+  #- { key: F,              mods: Command|Control,            action: ToggleFullscreen      }
+  #- { key: F,              mods: Command, mode: ~Search,     action: SearchForward         }
+  #- { key: B,              mods: Command, mode: ~Search,     action: SearchBackward        }
 
 #debug:
   # Display the time it takes to redraw each frame.

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -161,7 +161,7 @@ pub enum Action {
     /// Hide the Alacritty window.
     Hide,
 
-    /// Hide all windows except Alacritty on macOS.
+    /// Hide all windows other than Alacritty on macOS.
     #[cfg(target_os = "macos")]
     HideOtherApplications,
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -161,7 +161,8 @@ pub enum Action {
     /// Hide the Alacritty window.
     Hide,
 
-    /// Hide all windows except Alacritty.
+    /// Hide all windows except Alacritty on macOS.
+    #[cfg(target_os = "macos")]
     HideOtherApplications,
 
     /// Minimize the Alacritty window.

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -161,6 +161,9 @@ pub enum Action {
     /// Hide the Alacritty window.
     Hide,
 
+    /// Hide all windows except Alacritty.
+    HideOtherApplications,
+
     /// Minimize the Alacritty window.
     Minimize,
 
@@ -685,6 +688,7 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         C, ModifiersState::LOGO; Action::Copy;
         C, ModifiersState::LOGO, +BindingMode::VI, ~BindingMode::SEARCH; Action::ClearSelection;
         H, ModifiersState::LOGO; Action::Hide;
+        H, ModifiersState::LOGO | ModifiersState::ALT; Action::HideOtherApplications;
         M, ModifiersState::LOGO; Action::Minimize;
         Q, ModifiersState::LOGO; Action::Quit;
         W, ModifiersState::LOGO; Action::Quit;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -255,6 +255,8 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ToggleSimpleFullscreen => ctx.window_mut().toggle_simple_fullscreen(),
             #[cfg(target_os = "macos")]
             Action::Hide => ctx.event_loop().hide_application(),
+            #[cfg(target_os = "macos")]
+            Action::HideOtherApplications => ctx.event_loop().hide_other_applications(),
             #[cfg(not(target_os = "macos"))]
             Action::Hide => ctx.window().set_visible(false),
             Action::Minimize => ctx.window().set_minimized(true),


### PR DESCRIPTION
Fixes https://github.com/alacritty/alacritty/issues/3697

Looks like the change in `winit` has already been implemented.
