### PR TITLE
Fix URL highlight in mouse mode without shift

### DIFF
--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -5,7 +5,7 @@ use glutin::event::ModifiersState;
 use alacritty_terminal::grid::BidirectionalIterator;
 use alacritty_terminal::index::{Boundary, Point};
 use alacritty_terminal::term::search::{Match, RegexSearch};
-use alacritty_terminal::term::Term;
+use alacritty_terminal::term::{Term, TermMode};
 
 use crate::config::ui_config::{Hint, HintAction};
 use crate::config::Config;
@@ -246,9 +246,15 @@ pub fn highlighted_at<T>(
     point: Point,
     mouse_mods: ModifiersState,
 ) -> Option<HintMatch> {
+    let mouse_mode = term.mode().intersects(TermMode::MOUSE_MODE);
+
     config.ui_config.hints.enabled.iter().find_map(|hint| {
         // Check if all required modifiers are pressed.
-        if hint.mouse.map_or(true, |mouse| !mouse.enabled || !mouse_mods.contains(mouse.mods.0)) {
+        if hint.mouse.map_or(true, |mouse| {
+            !mouse.enabled
+                || !mouse_mods.contains(mouse.mods.0)
+                || (mouse_mode && !mouse_mods.contains(ModifiersState::SHIFT))
+        }) {
             return None;
         }
 

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -250,11 +250,12 @@ pub fn highlighted_at<T>(
 
     config.ui_config.hints.enabled.iter().find_map(|hint| {
         // Check if all required modifiers are pressed.
-        if hint.mouse.map_or(true, |mouse| {
-            !mouse.enabled
-                || !mouse_mods.contains(mouse.mods.0)
-                || (mouse_mode && !mouse_mods.contains(ModifiersState::SHIFT))
-        }) {
+        let highlight = hint.mouse.map_or(false, |mouse| {
+            mouse.enabled
+                && mouse_mods.contains(mouse.mods.0)
+                && (!mouse_mode || mouse_mods.contains(ModifiersState::SHIFT))
+        });
+        if !highlight {
             return None;
         }
 


### PR DESCRIPTION
This resolves a regression introduced in 96fc9ec where URLs would get
highlighted on mouse hover while mouse mode is active even when the
shift modifier was not held down.