### PR TITLE
Fix selection flooding Wayland connection

### DIFF
--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -634,6 +634,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         self.ctx.display().highlighted_hint = hint;
 
         self.ctx.scheduler_mut().unschedule(TimerId::SelectionScrolling);
+
+        // Copy selection on release, to prevent flooding the display server.
+        self.ctx.copy_selection(ClipboardType::Selection);
     }
 
     pub fn mouse_wheel_input(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {


### PR DESCRIPTION
This resolves an issue where an excessive clipboard update frequency
would cause the Wayland display server to ignore necessary selection
updates.

Instead of copying the selection to the clipboard during the selection
process, it is now only copied once the mouse button is released.

Fixes #4953