### PR TITLE
Note about working around macos signing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Prebuilt binaries for macOS and Windows can also be downloaded from the
 For everyone else, the detailed instructions to install Alacritty can be found
 [here](INSTALL.md).
 
+### MacOS
+
+The Alacritty binary is not signed. To run it on MacOS you'll need disable [this security check](https://support.apple.com/en-us/HT202491) on the binary. You can do this using HomeBrew:
+
+```
+brew upgrade --cask --no-quarantine alacritty
+```
+
 ### Requirements
 
 - OpenGL 3.3 or higher


### PR DESCRIPTION
I've read the [previous](https://github.com/alacritty/alacritty/pull/4758) [discussion](https://github.com/alacritty/alacritty/issues/1896) on this issue and agree that it is absolutely crazy for Apple to require a $99 subscription to distribute free software.

There's a simple workaround available to remove Alacritty from the MacOS security check. This will save MacOS users some time when they are installing Alacritty.

Thanks for the amazing work on this project!