### PR TITLE
Fix mouse reports

### DIFF
--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -421,7 +421,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let point = self.ctx.mouse().point(&self.ctx.size_info(), display_offset);
 
         // Assure the mouse point is not in the scrollback.
-        if point.line >= 0 {
+        if point.line < 0 {
             return;
         }
 


### PR DESCRIPTION
The patch 9cb5562 has introduced a regression which would abort if a
mouse report's line was bigger than zero, which is the exact opposite of
when a mouse report is required.

Fixes #4980.