### PR TITLE
Fix out of order terminal query responses

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1222,6 +1222,7 @@ impl<N: Notify + OnResize> Processor<N> {
                         let text = format(processor.ctx.display.colors[index]);
                         processor.ctx.write_to_pty(text.into_bytes());
                     },
+                    TerminalEvent::PtyWrite(text) => processor.ctx.write_to_pty(text.into_bytes()),
                     TerminalEvent::MouseCursorDirty => processor.reset_mouse_cursor(),
                     TerminalEvent::Exit => (),
                     TerminalEvent::CursorBlinkingChange(_) => {

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -35,6 +35,9 @@ pub enum Event {
     /// expected escape sequence format.
     ColorRequest(usize, Arc<dyn Fn(Rgb) -> String + Sync + Send + 'static>),
 
+    /// Write some text to the PTY.
+    PtyWrite(String),
+
     /// Cursor blinking state has changed.
     CursorBlinkingChange(bool),
 
@@ -57,6 +60,7 @@ impl Debug for Event {
             Event::ClipboardStore(ty, text) => write!(f, "ClipboardStore({:?}, {})", ty, text),
             Event::ClipboardLoad(ty, _) => write!(f, "ClipboardLoad({:?})", ty),
             Event::ColorRequest(index, _) => write!(f, "ColorRequest({})", index),
+            Event::PtyWrite(text) => write!(f, "PtyWrite({})", text),
             Event::Wakeup => write!(f, "Wakeup"),
             Event::Bell => write!(f, "Bell"),
             Event::Exit => write!(f, "Exit"),

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -240,7 +240,7 @@ where
 
                     // Run the parser.
                     for byte in &buf[..got] {
-                        state.parser.advance(&mut **terminal, *byte, &mut self.pty.writer());
+                        state.parser.advance(&mut **terminal, *byte);
                     }
 
                     // Exit if we've processed enough bytes.
@@ -334,7 +334,7 @@ where
 
                 // Handle synchronized update timeout.
                 if events.is_empty() {
-                    state.parser.stop_sync(&mut *self.terminal.lock(), &mut self.pty.writer());
+                    state.parser.stop_sync(&mut *self.terminal.lock());
                     self.event_proxy.send_event(Event::Wakeup);
                     continue;
                 }

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use serde_json as json;
 
 use std::fs::{self, File};
-use std::io::{self, Read};
+use std::io::Read;
 use std::path::Path;
 
 use alacritty_terminal::ansi;
@@ -108,7 +108,7 @@ fn ref_test(dir: &Path) {
     let mut parser = ansi::Processor::new();
 
     for byte in recording {
-        parser.advance(&mut terminal, byte, &mut io::sink());
+        parser.advance(&mut terminal, byte);
     }
 
     // Truncate invisible lines from the grid.


### PR DESCRIPTION
This forces all responses made to the PTY through the indirection of the
UI event loop, making sure that the writes to the PTY are in the same
order as the original requests.

This just delays all escape sequences by forcing them through the event
loop, ideally all responses which are not asynchronous (like a clipboard
read) would be made immediately. However since some escapes require
feedback from the UI to mutable structures like the config (e.g. color
query escapes), this would require additional locking.

Fixes #4872.