### PR TITLE
Fix cursor expansion across wide chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clicking on URLs on Windows incorrectly opens File Explorer
 - Incorrect underline cursor thickness on wide cell
 - Viewport moving around when resizing while scrolled into history
+- Block cursor not expanding across fullwidth characters when on the right side of it
 
 ### Removed
 

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -102,14 +102,6 @@ impl<'a> RenderableContent<'a> {
             return None;
         }
 
-        // Expand across wide cell when inside wide char or spacer.
-        let is_wide = if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-            self.terminal_cursor.point.column -= 1;
-            true
-        } else {
-            cell.flags.contains(Flags::WIDE_CHAR)
-        };
-
         // Cursor colors.
         let color = if self.terminal_content.mode.contains(TermMode::VI) {
             self.config.ui_config.colors.vi_mode_cursor
@@ -139,10 +131,10 @@ impl<'a> RenderableContent<'a> {
         let point = display::point_to_viewport(display_offset, cursor_point).unwrap();
 
         Some(RenderableCursor {
+            is_wide: cell.flags.contains(Flags::WIDE_CHAR),
             shape: self.terminal_cursor.shape,
             cursor_color,
             text_color,
-            is_wide,
             point,
         })
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1786,7 +1786,10 @@ impl RenderableCursor {
     fn new<T>(term: &Term<T>) -> Self {
         // Cursor position.
         let vi_mode = term.mode().contains(TermMode::VI);
-        let point = if vi_mode { term.vi_mode_cursor.point } else { term.grid.cursor.point };
+        let mut point = if vi_mode { term.vi_mode_cursor.point } else { term.grid.cursor.point };
+        if term.grid[point].flags.contains(Flags::WIDE_CHAR_SPACER) {
+            point.column -= 1;
+        }
 
         // Cursor shape.
         let shape = if !vi_mode && !term.mode().contains(TermMode::SHOW_CURSOR) {


### PR DESCRIPTION
This fixes a regression introduced in 0.7.0 where the block cursor would
not expand across both cells anymore when on top of a wide char spacer
cell.

The logic to always move the cursor on the wide char instead of the
spacer has been moved to the alacritty_terminal crate, making sure it is
always performed before any processing in the UI.