### PR TITLE
Update vi-mode `Open` Config Docs for Hints

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -228,7 +228,7 @@
     #  background: '#c5c8c6'
     #  foreground: '#1d1f21'
 
-  # Keyboard hints
+  # Keyboard regex hints
   #hints:
     # Fist character in the hint label
     #
@@ -592,8 +592,8 @@
 # - Vi mode exclusive actions:
 #
 #   - Open
-#       Open URLs at the cursor location with the launcher configured in
-#       `url.launcher`.
+#       Perform the action of the first matching hint under the vi mode cursor
+#       with `mouse.enabled` set to `true`.
 #   - ToggleNormalSelection
 #   - ToggleLineSelection
 #   - ToggleBlockSelection

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -165,7 +165,7 @@ impl HintState {
 }
 
 /// Hint match which was selected by the user.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HintMatch {
     /// Action for handling the text.
     pub action: HintAction,


### PR DESCRIPTION
Fixes #5005

I'm not sure I love how the `Open` action for vi-mode is dependent on a configuration named `mouse.enabled`, but I'm also not sure what might make more sense. Fundamentally there are regex matches, which can be either A) highlighted by the mouse and activated with this `Open` command, and B) activated without highlighting by keyboard hint prefix input. To me, B is what really lines up with "hints", and A could be a more general matching feature. Still, I don't know if thinking of things like this would help.

Perhaps a better way to clear up some potential confusion would be to rename `Open` to `Click`, thus making it more clear how this works.

@chrisduerr thoughts?