### PR TITLE
Add terminal size popup when resizing the window

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -80,6 +80,10 @@
   # Allow terminal applications to change Alacritty's window title.
   #dynamic_title: true
 
+  # Duration of window resize popup in milliseconds.
+  # Specifying '0' will disable the popup.
+  #resize_popup_duration: 500
+
   # Window class (Linux/BSD only):
   #class:
     # Application instance name

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Formatter};
+use std::time::Duration;
 use std::os::raw::c_ulong;
 
 use glutin::window::Fullscreen;
@@ -14,6 +15,9 @@ use crate::config::ui_config::Delta;
 
 /// Default Alacritty name, used for window title and class.
 pub const DEFAULT_NAME: &str = "Alacritty";
+
+/// Default window resize popup duration (in milliseconds).
+const DEFAULT_RESIZE_POPUP_DURATION: i32 = 500;
 
 #[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct WindowConfig {
@@ -50,6 +54,9 @@ pub struct WindowConfig {
 
     /// Initial dimensions.
     dimensions: Dimensions,
+
+    /// Window resize popup duration.
+    resize_popup_duration: i32,
 }
 
 impl Default for WindowConfig {
@@ -66,6 +73,7 @@ impl Default for WindowConfig {
             class: Default::default(),
             padding: Default::default(),
             dimensions: Default::default(),
+            resize_popup_duration: DEFAULT_RESIZE_POPUP_DURATION,
         }
     }
 }
@@ -102,6 +110,15 @@ impl WindowConfig {
     #[inline]
     pub fn maximized(&self) -> bool {
         self.startup_mode == StartupMode::Maximized
+    }
+
+    #[inline]
+    pub fn resize_popup_duration(&self) -> Option<Duration> {
+        if self.resize_popup_duration != 0 {
+            Some(Duration::from_millis(self.resize_popup_duration as u64))
+        } else {
+            None
+        }
     }
 }
 

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -15,6 +15,7 @@ pub enum TimerId {
     SelectionScrolling,
     DelayedSearch,
     BlinkCursor,
+    ResizePopup,
 }
 
 /// Event scheduled to be emitted at a specific time.


### PR DESCRIPTION
Shows a small popup with the window dimensions (columns x lines) in the center of the window when resizing, similar Ubuntu terminal.

# Changes
- Draw popup in the center of the display when a `WindowEvent::Resized` is received. The popup persists for `resize_popup_duration` after the user stops resizing.
- `resize_popup_duration` config under `window` specifying the duration of the popup (setting to 0 will disable the popup).

# Questions
- Should the popup be enabled/disabled by default? (currently set to enabled/500 ms)
- Any specific colors to use? (currently uses primary foreground/background swapped)

# Example

https://user-images.githubusercontent.com/26666500/116330083-99547180-a781-11eb-96e5-e2c22cb92cc3.mov