### PR TITLE
Clean up config files loaded log message

### DIFF
--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -235,10 +235,11 @@ fn run(
 }
 
 fn log_config_path(config: &Config) {
-    let mut msg = String::from("Configuration files loaded from:");
-    for path in &config.ui_config.config_paths {
-        msg.push_str(&format!("\n  {:?}", path.display()));
+    if !config.ui_config.config_paths.is_empty() {
+        let mut msg = String::from("Configuration files loaded from:");
+        for path in &config.ui_config.config_paths {
+            msg.push_str(&format!("\n- {}", path.display()));
+        }
+        info!("{}", msg);
     }
-
-    info!("{}", msg);
 }

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -235,11 +235,14 @@ fn run(
 }
 
 fn log_config_path(config: &Config) {
-    if !config.ui_config.config_paths.is_empty() {
-        let mut msg = String::from("Configuration files loaded from:");
-        for path in &config.ui_config.config_paths {
-            msg.push_str(&format!("\n- {}", path.display()));
-        }
-        info!("{}", msg);
+    if config.ui_config.config_paths.is_empty() {
+        return
     }
+
+    let mut msg = String::from("Configuration files loaded from:");
+    for path in &config.ui_config.config_paths {
+        msg.push_str(&format!("\n- {}", path.display()));
+    }
+
+    info!("{}", msg);
 }

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -241,7 +241,7 @@ fn log_config_path(config: &Config) {
 
     let mut msg = String::from("Configuration files loaded from:");
     for path in &config.ui_config.config_paths {
-        msg.push_str(&format!("\n- {}", path.display()));
+        msg.push_str(&format!("\n- {:?}", path.display()));
     }
 
     info!("{}", msg);

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -241,7 +241,7 @@ fn log_config_path(config: &Config) {
 
     let mut msg = String::from("Configuration files loaded from:");
     for path in &config.ui_config.config_paths {
-        msg.push_str(&format!("\n- {:?}", path.display()));
+        msg.push_str(&format!("\n  {:?}", path.display()));
     }
 
     info!("{}", msg);

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -236,7 +236,7 @@ fn run(
 
 fn log_config_path(config: &Config) {
     if config.ui_config.config_paths.is_empty() {
-        return
+        return;
     }
 
     let mut msg = String::from("Configuration files loaded from:");


### PR DESCRIPTION
This is extremely minor, but I'm always a fan of cleaning up log messages to help reading through them. This removes a slightly confusing line in the case a user doesn't have a config file, and the default is used. In this case, another log message will print as follows:

```
[INFO ] [alacritty_config_derive] No config file found; using default
```