### PR TITLE
Add Ctrl+c for exiting hint mode.

### DIFF
--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -117,6 +117,8 @@ impl HintState {
             },
             // Cancel hint highlighting on ESC.
             '\x1b' => self.stop(),
+            // Do the same but with Ctrl+c
+            '\x3' => self.stop(),
             _ => (),
         }
 

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -116,9 +116,7 @@ impl HintState {
                 self.keys.pop();
             },
             // Cancel hint highlighting on ESC/Ctrl+c.
-            '\x1b' | '\x03' => {
-                self.stop();
-            },
+            '\x1b' | '\x03' => self.stop(),
             _ => (),
         }
 

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -115,10 +115,10 @@ impl HintState {
             '\x08' | '\x1f' => {
                 self.keys.pop();
             },
-            // Cancel hint highlighting on ESC.
-            '\x1b' => self.stop(),
-            // Do the same but with Ctrl+c
-            '\x3' => self.stop(),
+            // Cancel hint highlighting on ESC/Ctrl+c.
+            '\x1b' | '\x03' => {
+                self.stop();
+            },
             _ => (),
         }
 


### PR DESCRIPTION
Previously only ESC was used for quitting hint mode, but now Ctrl+c should work too.