### PR TITLE
Fix unnecessary redraws due to hint highlighting

### DIFF
--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -165,7 +165,7 @@ impl HintState {
 }
 
 /// Hint match which was selected by the user.
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct HintMatch {
     /// Action for handling the text.
     pub action: HintAction,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1114,14 +1114,13 @@ impl<N: Notify + OnResize> Processor<N> {
             }
 
             if self.dirty || self.mouse.hint_highlight_dirty {
-                self.display.update_highlighted_hints(
+                self.dirty |= self.display.update_highlighted_hints(
                     &terminal,
                     &self.config,
                     &self.mouse,
                     self.modifiers,
                 );
                 self.mouse.hint_highlight_dirty = false;
-                self.dirty = true;
             }
 
             if self.dirty {


### PR DESCRIPTION
When the mouse cursor is moved by at least one cell, an update to the
highlighted hints is triggered automatically. Previously this would
always update the hints and redraw Alacritty regardless of the actualy
change to the hint highlighting.

By checking if the hint highlighting has actually changed, pointless
redraws can be prevented. This is especially helpful since mouse motions
often generate a lot of hint re-computations.