### PR TITLE
Fix URL highlighting with unicode whitespace

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -479,7 +479,7 @@
   #       Move the vi mode cursor to the beginning of the hint.
   #enabled:
   # - regex: "(mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
-  #           [^\u0000-\u001F\u007F-\u009F<>\" {-}\\^⟨⟩`]+"
+  #           [^\u0000-\u001F\u007F-\u009F<>\"\\s{-}\\^⟨⟩`]+"
   #   command: xdg-open
   #   post_processing: true
   #   mouse:

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -24,7 +24,7 @@ use crate::config::window::WindowConfig;
 /// Regex used for the default URL hint.
 #[rustfmt::skip]
 const URL_REGEX: &str = "(magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
-                         [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\" {-}\\^⟨⟩`]+";
+                         [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+";
 
 #[derive(ConfigDeserialize, Debug, PartialEq)]
 pub struct UiConfig {


### PR DESCRIPTION
The URL highlighting regex would automatically terminate on an ascii
whitespace, however there are several other forms of whitespace that are
indistinguisable to a user from normal whitespace. To make things a
little more intuitive, all unicode whitespace will now terminate URLs.