### PR TITLE
Fix default URL binding

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -118,8 +118,7 @@ pub fn load(options: &Options) -> Config {
             config
         });
 
-    // Override config with CLI options.
-    options.override_config(&mut config);
+    after_loading(&mut config, options);
 
     config
 }
@@ -130,10 +129,18 @@ pub fn reload(config_path: &Path, options: &Options) -> Result<Config> {
     let config_options = options.config_options().clone();
     let mut config = load_from(config_path, config_options)?;
 
-    // Override config with CLI options.
-    options.override_config(&mut config);
+    after_loading(&mut config, options);
 
     Ok(config)
+}
+
+/// Modifications after the `Config` object is created.
+fn after_loading(config: &mut Config, options: &Options) {
+    // Override config with CLI options.
+    options.override_config(config);
+
+    // Create key bindings for regex hints.
+    config.ui_config.generate_hint_bindings();
 }
 
 /// Load configuration file and log errors.
@@ -158,9 +165,6 @@ fn read_config(path: &Path, cli_config: Value) -> Result<Config> {
     // Deserialize to concrete type.
     let mut config = Config::deserialize(config_value)?;
     config.ui_config.config_paths = config_paths;
-
-    // Create key bindings for regex hints.
-    config.ui_config.generate_hint_bindings();
 
     Ok(config)
 }

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use glutin::event::{ModifiersState, VirtualKeyCode};
 use log::error;
 use serde::de::Error as SerdeError;
 use serde::{self, Deserialize, Deserializer};
@@ -238,7 +239,10 @@ impl Default for Hints {
                 action,
                 post_processing: true,
                 mouse: Some(HintMouse { enabled: true, mods: Default::default() }),
-                binding: Default::default(),
+                binding: Some(HintBinding {
+                    key: Key::Keycode(VirtualKeyCode::U),
+                    mods: ModsWrapper(ModifiersState::SHIFT | ModifiersState::CTRL),
+                }),
             }],
             alphabet: Default::default(),
         }


### PR DESCRIPTION
The default binding for launching the URL hints was documented as
Ctrl+Shift+U, but never actually set. This adds this binding as the
default instead of having URLs only launchable using the mouse.