### PR TITLE
Replace tabs with spaces when converting lines to strings

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -400,26 +400,17 @@ impl<T> Term<T> {
             cols.start -= 1;
         }
 
-        let mut tab_mode = false;
         for column in (cols.start.0..line_length.0).map(Column::from) {
             let cell = &grid_line[column];
 
-            // Skip over cells until next tab-stop once a tab was found.
-            if tab_mode {
-                if self.tabs[column] {
-                    tab_mode = false;
-                } else {
-                    continue;
-                }
-            }
-
-            if cell.c == '\t' {
-                tab_mode = true;
-            }
-
             if !cell.flags.intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER) {
-                // Push cells primary character.
-                text.push(cell.c);
+                if cell.c == '\t' {
+                    // Replace tabs with spaces.
+                    text.push(' ');
+                } else {
+                    // Push cells primary character.
+                    text.push(cell.c);
+                }
 
                 // Push zero-width characters.
                 for c in cell.zerowidth().into_iter().flatten() {


### PR DESCRIPTION
Fixes #5084

The `line_to_string()` function used to skip over cells after a tab, but the example in the issue shows that there can be characters is those cells.

By replacing the tab characters with spaces and not skipping over cells, the clipboard value now looks the same as the copied selection.