### PR TITLE
Replace tabs with spaces if there is text between the tab and the next tab-stop

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -400,26 +400,17 @@ impl<T> Term<T> {
             cols.start -= 1;
         }
 
-        let mut tab_mode = false;
         for column in (cols.start.0..line_length.0).map(Column::from) {
             let cell = &grid_line[column];
 
-            // Skip over cells until next tab-stop once a tab was found.
-            if tab_mode {
-                if self.tabs[column] {
-                    tab_mode = false;
-                } else {
-                    continue;
-                }
-            }
-
-            if cell.c == '\t' {
-                tab_mode = true;
-            }
-
             if !cell.flags.intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER) {
-                // Push cells primary character.
-                text.push(cell.c);
+                if cell.c == '\t' {
+                    // Replace tabs with spaces.
+                    text.push(' ');
+                } else {
+                    // Push cells primary character.
+                    text.push(cell.c);
+                }
 
                 // Push zero-width characters.
                 for c in cell.zerowidth().into_iter().flatten() {


### PR DESCRIPTION
Second attempt at fixing #5084.

Most tabs should still be copied as tabs.
The use of `\r` characters can cause the cells between the tab and the next tab-stop to contain non-whitespace characters. When calling the `line_to_string` method, the `\r` itself is no longer present in the terminal line. Trying to guess where it was and inserting it in the resulting string seems like a bad idea to me. So in this case I think we should replace the tab with a space.