### PR TITLE
Add magnet URL support to config docs

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -478,7 +478,7 @@
   #   - MoveViModeCursor
   #       Move the vi mode cursor to the beginning of the hint.
   #enabled:
-  # - regex: "(mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
+  # - regex: "(magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
   #           [^\u0000-\u001F\u007F-\u009F<>\"\\s{-}\\^⟨⟩`]+"
   #   command: xdg-open
   #   post_processing: true


### PR DESCRIPTION
Support for magnet URLs was introduced in 78e0444, however that commit
failed to document things in the alacritty.yml file.