### PR TITLE
chore(deps): force usage of serde_yaml >= 0.8.4

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -23,7 +23,7 @@ log = { version = "0.4", features = ["std", "serde"] }
 time = "0.1.40"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.8"
+serde_yaml = "0.8.4"
 serde_json = "1"
 glutin = { version = "0.26.0", default-features = false, features = ["serde"] }
 notify = "4"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2"
 bitflags = "1"
 parking_lot = "0.11.0"
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.8"
+serde_yaml = "0.8.4"
 vte = { version = "0.10.0", default-features = false }
 mio = "0.6.20"
 mio-extras = "2"


### PR DESCRIPTION
Upgrade serde_yaml to >= 0.8.4. Nothing really changes, just for https://deps.rs.

NOTE: cargo parses `0.8.4` as `^0.8.4`, so nothing *should* have been flagged by deps.rs in the first place, but this just really settles it.