### PR TITLE
Fix crashes with cut-off fullwidth characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Regression in rendering performance with dense grids since 0.6.0
+- Crash/Freezes with partially visible fullwidth characters due to alt screen resize
 
 ## 0.8.0
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -699,7 +699,9 @@ impl<T> Term<T> {
                 point.column = Column(1);
                 point.line += 1;
             },
-            Direction::Right if flags.contains(Flags::WIDE_CHAR) => point.column += 1,
+            Direction::Right if flags.contains(Flags::WIDE_CHAR) => {
+                point.column = min(point.column + 1, self.last_column());
+            },
             Direction::Left if flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER) => {
                 if flags.contains(Flags::WIDE_CHAR_SPACER) {
                     point.column -= 1;
@@ -774,7 +776,7 @@ impl<T> Term<T> {
             // Remove wide char and spacer.
             let wide = cursor_cell.flags.contains(Flags::WIDE_CHAR);
             let point = self.grid.cursor.point;
-            if wide {
+            if wide && point.column + 1 < self.columns() {
                 self.grid[point.line][point.column + 1].flags.remove(Flags::WIDE_CHAR_SPACER);
             } else {
                 self.grid[point.line][point.column - 1].clear_wide();


### PR DESCRIPTION
There's a few places in Alacritty where it was assumed that after a
WIDE_CHAR cell, there'd always be a WIDE_CHAR_SPACER. However since
resizes in the alternate screen buffer do not reflow any content, it's
possible to have a WIDE_CHAR without any WIDE_CHAR_SPACER right behind
it.

This patch changes these instances to be more defensive about accepting
potentially unreasonable input data caused by alt screen resizes.

Fixes #5185.
Fixes #5170.