### PR TITLE
Add configuration flag for right-click selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for `ipfs`/`ipns` URLs
+- New `selection.right_click_expand` option to disable right-click selection expansion
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -367,6 +367,9 @@
   # When set to `true`, selected text will be copied to the primary clipboard.
   #save_to_clipboard: false
 
+  # When set to `false`, the selection will not be expanded with the right mouse button
+  #right_click_expand: true
+
 #cursor:
   # Cursor style
   #style:

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -544,6 +544,10 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
     /// Handle selection expansion on right click.
     fn on_right_click(&mut self, point: Point) {
+        if !self.ctx.config().selection.right_click_expand {
+            return;
+        }
+
         match self.ctx.mouse().click_state {
             ClickState::Click => {
                 let selection_type = if self.ctx.modifiers().ctrl() {

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -50,6 +50,7 @@ pub struct Config<T> {
 pub struct Selection {
     pub semantic_escape_chars: String,
     pub save_to_clipboard: bool,
+    pub right_click_expand: bool,
 }
 
 impl Default for Selection {
@@ -57,6 +58,7 @@ impl Default for Selection {
         Self {
             semantic_escape_chars: String::from(",│`|:\"' ()[]{}<>\t"),
             save_to_clipboard: Default::default(),
+            right_click_expand: true,
         }
     }
 }


### PR DESCRIPTION
This add a flag to the `selection` section of the configuration file called `right_click_expand` that defaults to `true`.  If it is set to `false`, the right-click behaviour that expands the selection is disabled, allowing other actions to be performed involving the selection without it changing.

Fixes #4132 