### PR TITLE
Allow forcing vsync on or off using the config

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -93,6 +93,9 @@
   # and `light`. Set this to `None` to use the default theme variant.
   #gtk_theme_variant: None
 
+  # Force window vsync on or off
+  #vsync: true
+
 #scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -45,6 +45,9 @@ pub struct WindowConfig {
     /// Window class.
     pub class: Class,
 
+    /// Window vsync
+    pub vsync: Option<bool>,
+
     /// Pixel padding.
     padding: Delta<u8>,
 
@@ -64,6 +67,7 @@ impl Default for WindowConfig {
             gtk_theme_variant: Default::default(),
             dynamic_padding: Default::default(),
             class: Default::default(),
+            vsync: Default::default(),
             padding: Default::default(),
             dimensions: Default::default(),
         }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -185,10 +185,12 @@ impl Window {
         #[cfg(any(not(feature = "wayland"), target_os = "macos", windows))]
         let is_wayland = false;
 
+        let enable_vsync = window_config.vsync.unwrap_or(!is_wayland);
+
         let windowed_context =
-            create_gl_window(window_builder.clone(), &event_loop, false, !is_wayland, size)
+            create_gl_window(window_builder.clone(), &event_loop, false, enable_vsync, size)
                 .or_else(|_| {
-                    create_gl_window(window_builder, &event_loop, true, !is_wayland, size)
+                    create_gl_window(window_builder, &event_loop, true, enable_vsync, size)
                 })?;
 
         // Text cursor.


### PR DESCRIPTION
Disabling vsync vastly improves resizing performance on tiled window managers. So I've added the option to force it off if the user so desires.

There was some discussion about it on: https://github.com/alacritty/alacritty/issues/4381