### PR TITLE
Fix wrap around buffer on search

### DIFF
--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -203,7 +203,7 @@ impl<T> Term<T> {
 
         let mut iter = self.grid.iter_from(start);
         let mut state = dfa.start_state();
-        let mut last_wrapped = false;
+        let mut last_line_wrapped = false;
         let mut regex_match = None;
         // Need to wrap around to opposite side of scroll buffer if 'end' point has already been
         // same at 'start' point or been beyond one.
@@ -270,14 +270,14 @@ impl<T> Term<T> {
                 },
             };
             self.skip_fullwidth(&mut iter, &mut cell, direction);
-            let wrapped = cell.flags.contains(Flags::WRAPLINE);
+            let line_wrapped = cell.flags.contains(Flags::WRAPLINE);
             c = cell.c;
 
             let last_point = mem::replace(&mut point, iter.point());
 
             // Handle linebreaks.
-            if (last_point.column == last_column && point.column == Column(0) && !last_wrapped)
-                || (last_point.column == Column(0) && point.column == last_column && !wrapped)
+            if (last_point.column == last_column && point.column == Column(0) && !last_line_wrapped)
+                || (last_point.column == Column(0) && point.column == last_column && !line_wrapped)
             {
                 match regex_match {
                     Some(_) => break,
@@ -285,7 +285,7 @@ impl<T> Term<T> {
                 }
             }
 
-            last_wrapped = wrapped;
+            last_line_wrapped = line_wrapped;
         }
 
         regex_match
@@ -711,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn wrapping() {
+    fn line_wrapping() {
         #[rustfmt::skip]
         let term = mock_term("\
             xxx\r\n\


### PR DESCRIPTION
# SUMMARY

## Problem
SearchNext/SearchPrevious actions doesn't work in almost cases.

## Solution
Stop regex search traversing only if no need to wrap around on scroll buffer and searching target point has already been at same point to end point or been beyond one.

# DETAIL

SearchNext/SearchPrevious actions doesn't work in almost cases. The actions try to search between head point of current line on vi mode cursor to tail point of a line of one level above the line. For example, when a start point is at (3, 0) and an end point position is determined as (2, 119) on a grid(80x120) for a searching, the searching doesn't find anything.

The reason why is that the start point has already been beyond the end point(`(2, 119) <= (3, 0)`). So It is recognized that the search traversing has already been completed and it exits immediately on starting.

So consider whether needs to wrap around to opposite side of scroll buffer at an scroll buffer side or not, in addition to searching start point and the end one, to detect search traversing completion.