### PR TITLE
Fix ScrollHalfPageUp action's regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Regression in rendering performance with dense grids since 0.6.0
 - Crash/Freezes with partially visible fullwidth characters due to alt screen resize
 - Incorrect vi cursor position after invoking `ScrollPageHalfUp` action
-   when it is on near topmost scrollback buffer
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Regression in rendering performance with dense grids since 0.6.0
 - Crash/Freezes with partially visible fullwidth characters due to alt screen resize
+- Incorrect vi cursor position after invoking `ScrollPageHalfUp` action
+   when it is on near topmost scrollback buffer
 
 ## 0.8.0
 

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -170,7 +170,7 @@ impl ViModeCursor {
         };
 
         // Clamp movement to within visible region.
-        let line = (self.point.line - overscroll).grid_clamp(term, Boundary::Cursor);
+        let line = (self.point.line - overscroll).grid_clamp(term, Boundary::Grid);
 
         // Find the first occupied cell after scrolling has been performed.
         let target_line = (self.point.line - lines).grid_clamp(term, Boundary::Grid);


### PR DESCRIPTION
The regression is that cursor doesn't move to topmost on scrollback buffer and keep it near bottommost when invokes ScrollHalfPageUp action of vi mode even if repeats it. Also it is happen even if vi mode cursor is on above bottommost when in topmost viewport. So looks like that the cursor moves to bottommost line on topmost viewport even though try to move cursor to upper line.

This regression is came from 3bd5ac2 which introduces unified index type. The reason why is that old index type for viewport minimum index is zero, but new index type minimum one is zero or minus value. So vi mode cursor scrolling for new index type need to consider the new rule.  So use `Boundary::Grid`, which is range of entire grid, as cursor point clamping instead of `Boundary::Cursor`, which is range of viewport.

Following movie shows a situation of this regression.

In this movie, I do some steps like below.
(And with default Alacritty keybinding configs.)

Steps
1. Enter vi-mode.
2. Invoke ScrollHalfPageUp action by `Ctrl-U` repeatedly until rearch topmost of scrollback buffer.
3. Move vi mode cursor to a little upper line by `K` repeatedly.
4. Back to `2.`.

https://user-images.githubusercontent.com/12132068/121816736-3cbcff80-ccb8-11eb-9e93-4a122f0a6ac1.mp4