### PR TITLE
Fix regex search regression

### DIFF
--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -800,4 +800,29 @@ mod tests {
         let mut iter = RegexIter::new(start, end, Direction::Right, &term, &dfas);
         assert_eq!(iter.next(), None);
     }
+
+    #[test]
+    fn wrap_around_to_another_end() {
+        #[rustfmt::skip]
+        let term = mock_term("\
+            abc\r\n\
+            def\
+        ");
+
+        // bottom to top
+        let dfas = RegexSearch::new("abc").unwrap();
+        let start = Point::new(Line(1), Column(0));
+        let end = Point::new(Line(0), Column(2));
+        let match_start = Point::new(Line(0), Column(0));
+        let match_end = Point::new(Line(0), Column(2));
+        assert_eq!(term.regex_search_right(&dfas, start, end), Some(match_start..=match_end));
+
+        // top to bottom
+        let dfas = RegexSearch::new("def").unwrap();
+        let start = Point::new(Line(0), Column(2));
+        let end = Point::new(Line(1), Column(0));
+        let match_start = Point::new(Line(1), Column(0));
+        let match_end = Point::new(Line(1), Column(2));
+        assert_eq!(term.regex_search_left(&dfas, start, end), Some(match_start..=match_end));
+    }
 }

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -809,7 +809,7 @@ mod tests {
             def\
         ");
 
-        // bottom to top
+        // Bottom to top.
         let dfas = RegexSearch::new("abc").unwrap();
         let start = Point::new(Line(1), Column(0));
         let end = Point::new(Line(0), Column(2));
@@ -817,7 +817,7 @@ mod tests {
         let match_end = Point::new(Line(0), Column(2));
         assert_eq!(term.regex_search_right(&dfas, start, end), Some(match_start..=match_end));
 
-        // top to bottom
+        // Top to bottom.
         let dfas = RegexSearch::new("def").unwrap();
         let start = Point::new(Line(0), Column(2));
         let end = Point::new(Line(1), Column(0));

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -239,12 +239,7 @@ impl<T> Term<T> {
             }
 
             // Stop once we've reached the target point.
-            //
-            // We check beyond the point itself to account for skipped characters after wide chars
-            // without spacer.
-            if (direction == Direction::Right && point >= end)
-                || (direction == Direction::Left && point <= end)
-            {
+            if point == end {
                 break;
             }
 
@@ -291,6 +286,13 @@ impl<T> Term<T> {
         match direction {
             Direction::Right if cell.flags.contains(Flags::WIDE_CHAR) => {
                 iter.next();
+
+                // If iterates `iter` when finds a wide character without wide character spacer,
+                // one character is skipped unintentionally. So returns `iter` to one previous
+                // position.
+                if !iter.cell().flags.contains(Flags::WIDE_CHAR_SPACER) {
+                    iter.prev();
+                }
             },
             Direction::Right if cell.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER) => {
                 if let Some(Indexed { cell: new_cell, .. }) = iter.next() {

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -284,16 +284,14 @@ impl<T> Term<T> {
         direction: Direction,
     ) {
         match direction {
-            Direction::Right if cell.flags.contains(Flags::WIDE_CHAR) => {
+            // In the alternate screen buffer there might not be a wide char spacer after a wide
+            // char, so we only advance the iterator when the wide char is not in the last column.
+            Direction::Right
+                if cell.flags.contains(Flags::WIDE_CHAR)
+                    && iter.point().column < self.last_column() =>
+            {
                 iter.next();
-
-                // If iterates `iter` when finds a wide character without wide character spacer,
-                // one character is skipped unintentionally. So returns `iter` to one previous
-                // position.
-                if !iter.cell().flags.contains(Flags::WIDE_CHAR_SPACER) {
-                    iter.prev();
-                }
-            },
+            }
             Direction::Right if cell.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER) => {
                 if let Some(Indexed { cell: new_cell, .. }) = iter.next() {
                     *cell = new_cell;


### PR DESCRIPTION
The regression is that vi cursor doesn't jump to match in almost cases when invokes SearchNext/SearchPrevious actions. (The exception is that vi cursor is on topmost line of scrollback buffer or on bottompost and rightmost point of one.)

The original problem of this regression is that the regex searching skips one character follows wide character without wide character spacer unintentionally.

This pr is an alternative approach of #5227 which has already been closed.