### PR TITLE
Add modes to regex hint bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for `ipfs`/`ipns` URLs
+- Mode field for regex hint bindings
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -458,8 +458,8 @@
   # Each hint must have a `regex` and either an `action` or a `command` field.
   # The fields `mouse`, `binding` and `post_processing` are optional.
   #
-  # The fields `command`, `binding.key`, `binding.mods` and `mouse.mods` accept
-  # the same values as they do in the `key_bindings` section.
+  # The fields `command`, `binding.key`, `binding.mods`, `binding.mode` and 
+  # `mouse.mods` accept the same values as they do in the `key_bindings` section.
   #
   # The `mouse.enabled` field controls if the hint should be underlined while
   # the mouse with all `mouse.mods` keys held or the vi mode cursor is above it.

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -726,7 +726,8 @@ impl<'a> Deserialize<'a> for Key {
     }
 }
 
-struct ModeWrapper {
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ModeWrapper {
     pub mode: BindingMode,
     pub not_mode: BindingMode,
 }
@@ -751,6 +752,12 @@ impl BindingMode {
         binding_mode.set(BindingMode::VI, mode.contains(TermMode::VI));
         binding_mode.set(BindingMode::SEARCH, search);
         binding_mode
+    }
+}
+
+impl Default for ModeWrapper {
+    fn default() -> Self {
+        Self { mode: BindingMode::empty(), not_mode: BindingMode::empty() }
     }
 }
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -14,7 +14,7 @@ use alacritty_terminal::term::search::RegexSearch;
 
 use crate::config::bell::BellConfig;
 use crate::config::bindings::{
-    self, Action, Binding, BindingMode, Key, KeyBinding, ModsWrapper, MouseBinding,
+    self, Action, Binding, Key, KeyBinding, ModeWrapper, ModsWrapper, MouseBinding,
 };
 use crate::config::color::Colors;
 use crate::config::debug::Debug;
@@ -105,8 +105,8 @@ impl UiConfig {
             let binding = KeyBinding {
                 trigger: binding.key,
                 mods: binding.mods.0,
-                mode: BindingMode::empty(),
-                notmode: BindingMode::empty(),
+                mode: binding.mode.mode,
+                notmode: binding.mode.not_mode,
                 action: Action::Hint(hint.clone()),
             };
 
@@ -242,6 +242,7 @@ impl Default for Hints {
                 binding: Some(HintBinding {
                     key: Key::Keycode(VirtualKeyCode::U),
                     mods: ModsWrapper(ModifiersState::SHIFT | ModifiersState::CTRL),
+                    mode: Default::default(),
                 }),
             }],
             alphabet: Default::default(),
@@ -340,6 +341,8 @@ pub struct HintBinding {
     pub key: Key,
     #[serde(default)]
     pub mods: ModsWrapper,
+    #[serde(default)]
+    pub mode: ModeWrapper,
 }
 
 /// Hint mouse highlighting.


### PR DESCRIPTION
Closes #5154

Adds ModeWrapper to the HintBinding struct to allow users to specify which modes to allow/disallow for their hint binding.
Also implements the Default trait for ModeWrapper to allow users to omit the mode field like ModsWrapper ~~and adds the "None" pattern match for the deserialize implementation to make the mode field consistent with the mods field for the config~~.