### PR TITLE
Avoid rapidly flashing lights if bell is repeated frequently

### DIFF
--- a/alacritty/src/display/bell.rs
+++ b/alacritty/src/display/bell.rs
@@ -16,9 +16,13 @@ pub struct VisualBell {
 impl VisualBell {
     /// Ring the visual bell, and return its intensity.
     pub fn ring(&mut self) -> f64 {
-        let now = Instant::now();
-        self.start_time = Some(now);
-        self.intensity_at_instant(now)
+        if self.completed() {
+            let now = Instant::now();
+            self.start_time = Some(now);
+            self.intensity_at_instant(now)
+        } else {
+            self.intensity()
+        }
     }
 
     /// Get the currently intensity of the visual bell. The bell's intensity


### PR DESCRIPTION
An example of this is when backspace is held in bash:
![Peek 2021-06-21 17-37](https://user-images.githubusercontent.com/30854646/122712203-a68c6900-d2b7-11eb-94f3-40093c1b675a.gif)