### PR TITLE
Fix vi cursor scroll to emulate vi/vim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Regression in rendering performance with dense grids since 0.6.0
 - Crash/Freezes with partially visible fullwidth characters due to alt screen resize
-- Incorrect vi cursor position after invoking `ScrollPageHalfUp` action
+- Incorrect vi cursor position after invoking `ScrollPage*` action
 - Slow PTY read performance with extremely dense grids
 - Crash when resizing during vi mode
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1989,33 +1989,6 @@ mod tests {
     }
 
     #[test]
-    fn selection_with_scroll() {
-        let size = SizeInfo::new(5., 3., 1.0, 1.0, 0.0, 0.0, false);
-        let mut term = Term::new(&MockConfig::default(), size, ());
-
-        for _ in 0..2 {
-            term.grid_mut()[Line(2)][Column(0)].c = 'a';
-            term.grid_mut()[Line(2)][Column(1)].c = 'b';
-            term.grid_mut()[Line(2)][Column(2)].c = 'c';
-            term.clear_screen(ansi::ClearMode::All);
-        }
-        term.grid_mut()[Line(0)][Column(0)].c = 'd';
-
-        term.toggle_vi_mode();
-        term.selection =
-            Some(Selection::new(SelectionType::Lines, Point::new(Line(0), Column(0)), Side::Left));
-
-        term.scroll_display(Scroll::PageUp);
-        assert_eq!(term.selection_to_string(), Some(String::from("abc\nd\n")));
-
-        term.scroll_display(Scroll::PageUp);
-        assert_eq!(term.selection_to_string(), Some(String::from("abc\n\n\nabc\nd\n")));
-
-        term.scroll_display(Scroll::PageUp);
-        assert_eq!(term.selection_to_string(), Some(String::from("abc\n\n\nabc\nd\n")));
-    }
-
-    #[test]
     fn semantic_selection_works() {
         let size = SizeInfo::new(5., 3., 1.0, 1.0, 0.0, 0.0, false);
         let mut term = Term::new(&MockConfig::default(), size, ());

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -280,11 +280,6 @@ impl<T> Term<T> {
         self.grid.scroll_display(scroll);
         self.event_proxy.send_event(Event::MouseCursorDirty);
 
-        // Clamp vi mode cursor to the viewport.
-        let viewport_start = -(self.grid.display_offset() as i32);
-        let viewport_end = viewport_start + self.bottommost_line().0;
-        let vi_cursor_line = &mut self.vi_mode_cursor.point.line.0;
-        *vi_cursor_line = min(viewport_end, max(viewport_start, *vi_cursor_line));
         self.vi_mode_recompute_selection();
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1937,22 +1937,25 @@ mod tests {
         let size = SizeInfo::new(5., 10., 1.0, 1.0, 0.0, 0.0, false);
         let mut term = Term::new(&MockConfig::default(), size, ());
 
-        // Create 20 lines of scrollback.
-        for _ in 0..29 {
+        // Create 11 lines of scrollback.
+        for _ in 0..20 {
             term.newline();
         }
 
+        // Scrollable amount to top is 11.
         term.scroll_display(Scroll::PageUp);
         assert_eq!(term.vi_mode_cursor.point, Point::new(Line(-1), Column(0)));
         assert_eq!(term.grid.display_offset(), 10);
 
+        // Scrollable amount to top is 1.
         term.scroll_display(Scroll::PageUp);
-        assert_eq!(term.vi_mode_cursor.point, Point::new(Line(-11), Column(0)));
-        assert_eq!(term.grid.display_offset(), 20);
+        assert_eq!(term.vi_mode_cursor.point, Point::new(Line(-2), Column(0)));
+        assert_eq!(term.grid.display_offset(), 11);
 
+        // Scrollable amount to top is 0.
         term.scroll_display(Scroll::PageUp);
-        assert_eq!(term.vi_mode_cursor.point, Point::new(Line(-11), Column(0)));
-        assert_eq!(term.grid.display_offset(), 20);
+        assert_eq!(term.vi_mode_cursor.point, Point::new(Line(-2), Column(0)));
+        assert_eq!(term.grid.display_offset(), 11);
     }
 
     #[test]
@@ -1960,23 +1963,26 @@ mod tests {
         let size = SizeInfo::new(5., 10., 1.0, 1.0, 0.0, 0.0, false);
         let mut term = Term::new(&MockConfig::default(), size, ());
 
-        // Create 20 lines of scrollback.
-        for _ in 0..29 {
+        // Create 11 lines of scrollback.
+        for _ in 0..20 {
             term.newline();
         }
 
         // Change display_offset to topmost.
         term.grid_mut().scroll_display(Scroll::Top);
-        term.vi_mode_cursor = ViModeCursor::new(Point::new(Line(-20), Column(0)));
+        term.vi_mode_cursor = ViModeCursor::new(Point::new(Line(-11), Column(0)));
 
+        // Scrollable amount to bottom is 11.
         term.scroll_display(Scroll::PageDown);
-        assert_eq!(term.vi_mode_cursor.point, Point::new(Line(-10), Column(0)));
-        assert_eq!(term.grid.display_offset(), 10);
+        assert_eq!(term.vi_mode_cursor.point, Point::new(Line(-1), Column(0)));
+        assert_eq!(term.grid.display_offset(), 1);
 
+        // Scrollable amount to bottom is 1.
         term.scroll_display(Scroll::PageDown);
         assert_eq!(term.vi_mode_cursor.point, Point::new(Line(0), Column(0)));
         assert_eq!(term.grid.display_offset(), 0);
 
+        // Scrollable amount to bottom is 0.
         term.scroll_display(Scroll::PageDown);
         assert_eq!(term.vi_mode_cursor.point, Point::new(Line(0), Column(0)));
         assert_eq!(term.grid.display_offset(), 0);

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -749,12 +749,7 @@ mod tests {
 
     fn history_term() -> Term<()> {
         let mut term = term();
-
-        for i in 0..(term.screen_lines() as i32) {
-            term.grid_mut()[Line(i)][Column(0)].c = 'c';
-        }
         term.grid_mut().clear_viewport();
-
         term
     }
 

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -752,7 +752,7 @@ mod tests {
     fn scroll_simple() {
         let mut term = term();
 
-        // Create 1 lines of scrollback.
+        // Create 1 line of scrollback.
         for _ in 0..20 {
             term.newline();
         }


### PR DESCRIPTION
This is an additional patch for 6f135d7.

This fixes the regression that vi cursor doesn't move to appropriate position to emulate vi/vim after invokes `SearchPage*`.

To emulate vi/vim the cursor should move up/down some lines if the viewport on topmost scrollback buffer or on bottommost one when invokes `SearchPage*` action. Otherwise the cursor should look like no movement relatively on viewport.

They are sample videos about this problem.

Steps in videos

1. Run `cat alacritty.yml`
2. Enter vi mode
3. Invoke `ScrollHalfPageUp` action several times
4. Invoke `Up` action several times
5. Go to `3.` step

Before fixing regression,

https://user-images.githubusercontent.com/12132068/122762915-c2eccd80-d2d8-11eb-8af9-8c6ff90353a9.mp4

After fixing regression,

https://user-images.githubusercontent.com/12132068/122763027-dd26ab80-d2d8-11eb-8fd0-cfaab28cee5c.mp4

BTW in vi,

Steps in the video
1. Open `alacritty.yml` using vi and go to bottom of the file
2. Type `Ctrl+U` several times
3. Type `k` or `j` several times
4. Go to `2.` step


https://user-images.githubusercontent.com/12132068/122763269-19f2a280-d2d9-11eb-9893-d65c2f3ed245.mp4


