### PR TITLE
Respond to XTVERSION

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1010,6 +1010,13 @@ impl<T: EventListener> Handler for Term<T> {
     }
 
     #[inline]
+    fn xtversion(&mut self) {
+        trace!("Reporting XTVERSION");
+        let text = format!("\x1b[>Alacritty({})\x1b\\", env!("CARGO_PKG_VERSION"));
+        self.event_proxy.send_event(Event::PtyWrite(text));
+    }
+
+    #[inline]
     fn device_status(&mut self, arg: usize) {
         trace!("Reporting device status: {}", arg);
         match arg {

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -68,6 +68,7 @@ brevity.
 | `CSI m`    | PARTIAL     | Only singular straight underlines are supported   |
 | `CSI n`    | IMPLEMENTED |                                                   |
 | `CSI P`    | IMPLEMENTED |                                                   |
+| `CSI > q`  | IMPLEMENTED |                                                   |
 | `CSI SP q` | IMPLEMENTED |                                                   |
 | `CSI r`    | IMPLEMENTED |                                                   |
 | `CSI S`    | IMPLEMENTED |                                                   |


### PR DESCRIPTION
XTVERSION requests take the form of CSI > [0] q, and are responded to with a freeform string. Differentiate between XTVERSION and DECSCUSR (CSI n SP q), and reject any XTVERSION that specifies a Ps other than 0 (admit an absent Ps as 0, per the spec). Respond to XTVERSION with Alacritty and the Cargo package version of alacritty_terminal (it's this core that's relevant for determining capabilities).
    
This is necessary for Notcurses to unambiguously identify Alacritty (i.e. as opposed to relying on TERM), and is implemented by many other terminal emulators.

Closes #5273.