### PR TITLE
Add libxkbcommon-dev to debian/ubuntu install documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,7 +81,7 @@ to build Alacritty. Here's an apt command that should install all of them. If
 something is still found to be missing, please open an issue.
 
 ```sh
-apt-get install cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev python3
+apt-get install cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
 ```
 
 #### Arch Linux


### PR DESCRIPTION
## Issue

* Ubuntu 20.04.2 requires `xkbcommon`

```
$ cargo install alacritty
Updating crates.io index
Installing alacritty v0.8.0
...
...
Compiling glutin v0.26.0
error: linking with `cc` failed: exit code: 1
...
  = note: /usr/bin/ld: cannot find -lxkbcommon
          collect2: error: ld returned 1 exit status

error: aborting due to previous error
error: failed to compile `alacritty v0.8.0`, intermediate artifacts can be found at `/tmp/cargo-installebzMuk`
```

## Fix

```shell
$ sudo apt install libxkbcommon-dev
...
$ cargo install alacritty
Updating crates.io index
Installing alacritty v0.8.0
...
...
Installed package `alacritty v0.8.0` (executable `alacritty`)
```

## System Info

Ubuntu 20.04.2 - Mate

```shell
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.2 LTS"
```

```shell
$ cargo --version
cargo 1.51.0 (43b129a20 2021-03-16)
```