### PR TITLE
install.md: Suggest `nix develop`, too

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -176,10 +176,13 @@ eopkg install fontconfig-devel
 #### NixOS/Nixpkgs
 
 The following command can be used to get a shell with all development
-dependencies on [NixOS](https://nixos.org).
+dependencies using [Nix](https://nixos.org).
 
 ```sh
 nix-shell -A alacritty '<nixpkgs>'
+
+# or, if you're using Nix Flakes:
+nix develop nixpkgs#alacritty
 ```
 
 #### Gentoo


### PR DESCRIPTION
Newer versions of Nix deprecate `nix-shell`, providing in its place a new command called `nix develop`.

I've also s/NixOS/Nix, as using `nix-shell` / `nix develop` doesn't actually require NixOS (e.g. both should work fine on Ubuntu + Nix).
