### PR TITLE
Remove .agignore

### DIFF
--- a/.agignore
+++ b/.agignore
@@ -1,1 +1,0 @@
-tests/ref


### PR DESCRIPTION
This file is a configuration file for The Silver Searcher which is useful but not related to Alacritty and the development directly.

Also this file has no effect in practice because the ignored target no longer exists in current repository. So nobody is affects by this removing.