### PR TITLE
[WIP] Implement modifyOtherKeys=1

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -773,7 +773,8 @@ impl<'a> Deserialize<'a> for ModeWrapper {
 
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(
-                    "a combination of AppCursor | AppKeypad | Alt | Vi, possibly with negation (~)",
+                    "a combination of appcursor | appkeypad | alt | vi | search, possibly with \
+                     negation (~)",
                 )
             }
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -406,6 +406,12 @@ pub trait Handler {
     /// Unset mode.
     fn unset_mode(&mut self, _: Mode) {}
 
+    /// Enables xterm's `modifyOtherKeys=1` mode.
+    fn set_modify_other_keys1(&mut self) {}
+
+    /// Disables xterm's `modifyOtherKeys=1` mode.
+    fn unset_modify_other_keys1(&mut self) {}
+
     /// DECSTBM - Set the terminal scrolling region.
     fn set_scrolling_region(&mut self, _top: usize, _bottom: Option<usize>) {}
 
@@ -1206,6 +1212,11 @@ where
                         }
                     }
                 }
+            },
+            ('m', [b'>']) => {
+                // https://github.com/ThomasDickey/xterm-snapshots/blob/2f9db53ba911e7bcd7eeb10b37e40b7b7347fda6/ctlseqs.txt#L1115
+                // TODO(pwy) missing feature: unset
+                handler.set_modify_other_keys1();
             },
             ('n', []) => handler.device_status(next_param_or(0) as usize),
             ('P', []) => handler.delete_chars(next_param_or(1) as usize),

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -62,6 +62,7 @@ bitflags! {
         const ALTERNATE_SCROLL    = 0b0000_1000_0000_0000_0000;
         const VI                  = 0b0001_0000_0000_0000_0000;
         const URGENCY_HINTS       = 0b0010_0000_0000_0000_0000;
+        const MODIFY_OTHER_KEYS1  = 0b0100_0000_0000_0000_0000;
         const ANY                 = std::u32::MAX;
     }
 }
@@ -1605,6 +1606,16 @@ impl<T: EventListener> Handler for Term<T> {
                 self.event_proxy.send_event(Event::CursorBlinkingChange(false));
             },
         }
+    }
+
+    fn set_modify_other_keys1(&mut self) {
+        trace!("Enabling xterm's modifyOtherKeys=1");
+        self.mode.insert(TermMode::MODIFY_OTHER_KEYS1);
+    }
+
+    fn unset_modify_other_keys1(&mut self) {
+        trace!("Disabling xterm's modifyOtherKeys=1");
+        self.mode.remove(TermMode::MODIFY_OTHER_KEYS1);
     }
 
     #[inline]


### PR DESCRIPTION
Current implementation's only partial and not thoroughly tested yet; though it already makes Emacs recognize Shift+Enter, which works wonders for my org-mode!

Anyway, I wanted to ask if I'm going the right route - classic: it'd be pity if I were to spend a few nights to hear that something could've been simplified from day zero 🙂 

cc @chrisduerr

---

Closes #3101 