### PR TITLE
Add option to apply opacity to all background colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.10.0-dev
 
+### Added
+
+- Option `colors.transparent_background_colors` to allow applying opacity to all background colors
+
 ### Changed
 
 - `ExpandSelection` is now a configurable mouse binding action
+
+### Removed
+
+- Config option `background_opacity`, you should use `window.opacity` instead
 
 ## 0.9.0
 
@@ -21,7 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Support for `ipfs`/`ipns` URLs
 - Mode field for regex hint bindings
-- Option `colors.opaque_background_colors` to allow applying opacity to all background colors
 
 ### Fixed
 
@@ -41,10 +48,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Broken bitmap font rendering with FreeType 2.11+
 - Crash with non-utf8 font paths on Linux
 - Newly installed fonts not rendering until Alacritty restart
-
-### Removed
-
-- Config option `background_opacity`, you should use `window.background_opacity` instead
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Support for `ipfs`/`ipns` URLs
 - Mode field for regex hint bindings
+- Option `colors.opaque_background_colors` to allow applying opacity to all background colors
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash with non-utf8 font paths on Linux
 - Newly installed fonts not rendering until Alacritty restart
 
+### Removed
+
+- Config option `background_opacity`, you should use `window.background_opacity` instead
+
 ## 0.8.0
 
 ### Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - `ExpandSelection` is now a configurable mouse binding action
-
-### Removed
-
 - Config option `background_opacity`, you should use `window.opacity` instead
 
 ## 0.9.0

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -63,6 +63,13 @@
   #     - buttonless: Title bar, transparent background and no title bar buttons
   #decorations: full
 
+  # Background opacity
+  #
+  # Window opacity as a floating point number from `0.0` to `1.0`.
+  # The value `0.0` is completely transparent and `1.0` is opaque.
+  #background_opacity: 1.0
+
+
   # Startup Mode (changes require restart)
   #
   # Values for `startup_mode`:
@@ -359,12 +366,6 @@
   #     args: ["Hello, World!"]
   #
   #command: None
-
-# Background opacity
-#
-# Window opacity as a floating point number from `0.0` to `1.0`.
-# The value `0.0` is completely transparent and `1.0` is opaque.
-#background_opacity: 1.0
 
 #selection:
   # This string contains all characters that are used as separators for

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -69,7 +69,6 @@
   # The value `0.0` is completely transparent and `1.0` is opaque.
   #opacity: 1.0
 
-
   # Startup Mode (changes require restart)
   #
   # Values for `startup_mode`:

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -67,7 +67,7 @@
   #
   # Window opacity as a floating point number from `0.0` to `1.0`.
   # The value `0.0` is completely transparent and `1.0` is opaque.
-  #background_opacity: 1.0
+  #opacity: 1.0
 
 
   # Startup Mode (changes require restart)
@@ -319,12 +319,12 @@
   #
   #indexed_colors: []
 
-  # Opaque backgrounds with transparency enabled
+  # Transparent backgrounds with transparency enabled
   #
-  # Whether or not `background_opacity` applies to all backgrounds or only to the
+  # Whether or not `window.opacity` applies to all backgrounds or only to the
   # default background. When set to `false` all cells will be transparent
   # regardless of their background color.
-  #opaque_background_colors: true
+  #transparent_background_colors: false
 
 # Bell
 #

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -319,10 +319,10 @@
   #
   #indexed_colors: []
 
-  # Transparent backgrounds with transparency enabled
+  # Transparent cell backgrounds
   #
-  # Whether or not `window.opacity` applies to all backgrounds or only to the
-  # default background. When set to `false` all cells will be transparent
+  # Whether or not `window.opacity` applies to all cell backgrounds or only to
+  # the default background. When set to `true` all cells will be transparent
   # regardless of their background color.
   #transparent_background_colors: false
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -312,6 +312,13 @@
   #
   #indexed_colors: []
 
+  # Opaque backgrounds with transparency enabled
+  #
+  # Whether or not `background_opacity` applies to all backgrounds or only to the
+  # default background. When set to `false` all cells will be transparent
+  # regardless of their background color.
+  #opaque_background_colors: true
+
 # Bell
 #
 # The bell is rung every time the BEL control character is received.

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -18,7 +18,7 @@ void main() {
         }
 
         alphaMask = vec4(1.0);
-        color = vec4(bg.rgb, 1.0);
+        color = vec4(bg.rgb, bg.a);
     } else if ((int(fg.a) & COLORED) != 0) {
         // Color glyphs, like emojis.
         vec4 glyphColor = texture(mask, TexCoords);

--- a/alacritty/res/text.v.glsl
+++ b/alacritty/res/text.v.glsl
@@ -65,6 +65,6 @@ void main() {
         TexCoords = uvOffset + position * uvSize;
     }
 
-    bg = vec4(backgroundColor.rgb / 255.0, backgroundColor.a);
+    bg = backgroundColor / 255.0;
     fg = vec4(textColor.rgb / 255.0, textColor.a);
 }

--- a/alacritty/src/config/color.rs
+++ b/alacritty/src/config/color.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer};
 use alacritty_config_derive::ConfigDeserialize;
 use alacritty_terminal::term::color::{CellRgb, Rgb};
 
-#[derive(ConfigDeserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Colors {
     pub primary: PrimaryColors,
     pub cursor: InvertedCellColors,
@@ -17,6 +17,7 @@ pub struct Colors {
     pub search: SearchColors,
     pub line_indicator: LineIndicatorColors,
     pub hints: HintColors,
+    pub opaque_background_colors: bool,
 }
 
 impl Colors {
@@ -26,6 +27,25 @@ impl Colors {
 
     pub fn search_bar_background(&self) -> Rgb {
         self.search.bar.background.unwrap_or(self.primary.foreground)
+    }
+}
+
+impl Default for Colors {
+    fn default() -> Self {
+        Self {
+            primary: Default::default(),
+            cursor: Default::default(),
+            vi_mode_cursor: Default::default(),
+            selection: Default::default(),
+            normal: Default::default(),
+            bright: Default::default(),
+            dim: Default::default(),
+            indexed_colors: Default::default(),
+            search: Default::default(),
+            line_indicator: Default::default(),
+            hints: Default::default(),
+            opaque_background_colors: true,
+        }
     }
 }
 

--- a/alacritty/src/config/color.rs
+++ b/alacritty/src/config/color.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer};
 use alacritty_config_derive::ConfigDeserialize;
 use alacritty_terminal::term::color::{CellRgb, Rgb};
 
-#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Colors {
     pub primary: PrimaryColors,
     pub cursor: InvertedCellColors,
@@ -17,7 +17,7 @@ pub struct Colors {
     pub search: SearchColors,
     pub line_indicator: LineIndicatorColors,
     pub hints: HintColors,
-    pub opaque_background_colors: bool,
+    pub transparent_background_colors: bool,
 }
 
 impl Colors {
@@ -27,25 +27,6 @@ impl Colors {
 
     pub fn search_bar_background(&self) -> Rgb {
         self.search.bar.background.unwrap_or(self.primary.foreground)
-    }
-}
-
-impl Default for Colors {
-    fn default() -> Self {
-        Self {
-            primary: Default::default(),
-            cursor: Default::default(),
-            vi_mode_cursor: Default::default(),
-            selection: Default::default(),
-            normal: Default::default(),
-            bright: Default::default(),
-            dim: Default::default(),
-            indexed_colors: Default::default(),
-            search: Default::default(),
-            line_indicator: Default::default(),
-            hints: Default::default(),
-            opaque_background_colors: true,
-        }
     }
 }
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -69,7 +69,8 @@ pub struct UiConfig {
     mouse_bindings: MouseBindings,
 
     /// Background opacity from 0.0 to 1.0.
-    background_opacity: Percentage,
+    #[config(deprecated = "use window.background_opacity instead")]
+    background_opacity: Option<Percentage>,
 }
 
 impl Default for UiConfig {
@@ -116,7 +117,7 @@ impl UiConfig {
 
     #[inline]
     pub fn background_opacity(&self) -> f32 {
-        self.background_opacity.as_f32()
+        self.background_opacity.unwrap_or(self.window.background_opacity).as_f32()
     }
 
     #[inline]

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -69,8 +69,8 @@ pub struct UiConfig {
     mouse_bindings: MouseBindings,
 
     /// Background opacity from 0.0 to 1.0.
-    #[config(deprecated = "use window.background_opacity instead")]
-    background_opacity: Option<Percentage>,
+    #[config(deprecated = "use window.opacity instead")]
+    window_opacity: Option<Percentage>,
 }
 
 impl Default for UiConfig {
@@ -85,7 +85,7 @@ impl Default for UiConfig {
             config_paths: Default::default(),
             key_bindings: Default::default(),
             mouse_bindings: Default::default(),
-            background_opacity: Default::default(),
+            window_opacity: Default::default(),
             bell: Default::default(),
             colors: Default::default(),
             draw_bold_text_with_bright_colors: Default::default(),
@@ -116,8 +116,8 @@ impl UiConfig {
     }
 
     #[inline]
-    pub fn background_opacity(&self) -> f32 {
-        self.background_opacity.unwrap_or(self.window.background_opacity).as_f32()
+    pub fn window_opacity(&self) -> f32 {
+        self.window_opacity.unwrap_or(self.window.opacity).as_f32()
     }
 
     #[inline]

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -7,7 +7,7 @@ use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
 use alacritty_config_derive::ConfigDeserialize;
-use alacritty_terminal::config::LOG_TARGET_CONFIG;
+use alacritty_terminal::config::{Percentage, LOG_TARGET_CONFIG};
 use alacritty_terminal::index::Column;
 
 use crate::config::ui_config::Delta;
@@ -15,7 +15,7 @@ use crate::config::ui_config::Delta;
 /// Default Alacritty name, used for window title and class.
 pub const DEFAULT_NAME: &str = "Alacritty";
 
-#[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Clone, PartialEq)]
 pub struct WindowConfig {
     /// Initial position.
     pub position: Option<Delta<i32>>,
@@ -45,6 +45,9 @@ pub struct WindowConfig {
     /// Window class.
     pub class: Class,
 
+    /// Background opacity from 0.0 to 1.0.
+    pub background_opacity: Percentage,
+
     /// Pixel padding.
     padding: Delta<u8>,
 
@@ -64,6 +67,7 @@ impl Default for WindowConfig {
             gtk_theme_variant: Default::default(),
             dynamic_padding: Default::default(),
             class: Default::default(),
+            background_opacity: Default::default(),
             padding: Default::default(),
             dimensions: Default::default(),
         }

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -46,7 +46,7 @@ pub struct WindowConfig {
     pub class: Class,
 
     /// Background opacity from 0.0 to 1.0.
-    pub background_opacity: Percentage,
+    pub opacity: Percentage,
 
     /// Pixel padding.
     padding: Delta<u8>,
@@ -67,7 +67,7 @@ impl Default for WindowConfig {
             gtk_theme_variant: Default::default(),
             dynamic_padding: Default::default(),
             class: Default::default(),
-            background_opacity: Default::default(),
+            opacity: Default::default(),
             padding: Default::default(),
             dimensions: Default::default(),
         }

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -203,7 +203,7 @@ impl RenderableCell {
             mem::swap(&mut fg, &mut bg);
             1.0
         } else {
-            Self::compute_bg_alpha(cell.bg)
+            Self::compute_bg_alpha(content, cell.bg)
         };
 
         let is_selected = content.terminal_content.selection.map_or(false, |selection| {
@@ -350,11 +350,13 @@ impl RenderableCell {
     /// using the named input color, rather than checking the RGB of the background after its color
     /// is computed.
     #[inline]
-    fn compute_bg_alpha(bg: Color) -> f32 {
+    fn compute_bg_alpha(content: &mut RenderableContent<'_>, bg: Color) -> f32 {
         if bg == Color::Named(NamedColor::Background) {
             0.
-        } else {
+        } else if content.config.ui_config.colors.opaque_background_colors {
             1.
+        } else {
+            content.config.ui_config.background_opacity()
         }
     }
 }

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -354,9 +354,9 @@ impl RenderableCell {
         if bg == Color::Named(NamedColor::Background) {
             0.
         } else if config.colors.transparent_background_colors {
-            1.
-        } else {
             config.window_opacity()
+        } else {
+            1.
         }
     }
 }

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -203,7 +203,7 @@ impl RenderableCell {
             mem::swap(&mut fg, &mut bg);
             1.0
         } else {
-            Self::compute_bg_alpha(content, cell.bg)
+            Self::compute_bg_alpha(&content.config.ui_config, cell.bg)
         };
 
         let is_selected = content.terminal_content.selection.map_or(false, |selection| {
@@ -350,13 +350,13 @@ impl RenderableCell {
     /// using the named input color, rather than checking the RGB of the background after its color
     /// is computed.
     #[inline]
-    fn compute_bg_alpha(content: &mut RenderableContent<'_>, bg: Color) -> f32 {
+    fn compute_bg_alpha(config: &UiConfig, bg: Color) -> f32 {
         if bg == Color::Named(NamedColor::Background) {
             0.
-        } else if content.config.ui_config.colors.opaque_background_colors {
+        } else if config.colors.transparent_background_colors {
             1.
         } else {
-            content.config.ui_config.background_opacity()
+            config.window_opacity()
         }
     }
 }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -299,7 +299,7 @@ impl Display {
 
         // Disable shadows for transparent windows on macOS.
         #[cfg(target_os = "macos")]
-        window.set_has_shadow(config.ui_config.background_opacity() >= 1.0);
+        window.set_has_shadow(config.ui_config.window_opacity() >= 1.0);
 
         // On Wayland we can safely ignore this call, since the window isn't visible until you
         // actually draw something into it and commit those changes.

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -484,12 +484,17 @@ impl Display {
         config: &Config,
         search_state: &SearchState,
     ) {
+        let mut grid_cells = {
+            let cols = self.size_info.columns();
+            let lines = self.size_info.screen_lines();
+            Vec::with_capacity(cols * lines)
+        };
         // Collect renderable content before the terminal is dropped.
         let mut content = RenderableContent::new(config, self, &terminal, search_state);
-        let mut grid_cells = Vec::new();
         for cell in &mut content {
             grid_cells.push(cell);
         }
+
         let background_color = content.color(NamedColor::Background as usize);
         let display_offset = content.display_offset();
         let cursor = content.cursor();

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -484,13 +484,9 @@ impl Display {
         config: &Config,
         search_state: &SearchState,
     ) {
-        let mut grid_cells = {
-            let cols = self.size_info.columns();
-            let lines = self.size_info.screen_lines();
-            Vec::with_capacity(cols * lines)
-        };
         // Collect renderable content before the terminal is dropped.
         let mut content = RenderableContent::new(config, self, &terminal, search_state);
+        let mut grid_cells = Vec::new();
         for cell in &mut content {
             grid_cells.push(cell);
         }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -490,7 +490,6 @@ impl Display {
         for cell in &mut content {
             grid_cells.push(cell);
         }
-
         let background_color = content.color(NamedColor::Background as usize);
         let display_offset = content.display_offset();
         let cursor = content.cursor();

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1436,7 +1436,7 @@ impl<N: Notify + OnResize> Processor<N> {
 
         // Disable shadows for transparent windows on macOS.
         #[cfg(target_os = "macos")]
-        processor.ctx.window().set_has_shadow(config.ui_config.background_opacity() >= 1.0);
+        processor.ctx.window().set_has_shadow(config.ui_config.window_opacity() >= 1.0);
 
         // Update hint keys.
         processor.ctx.display.hint_state.update_alphabet(config.ui_config.hints.alphabet());

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -767,7 +767,7 @@ impl Drop for QuadRenderer {
 impl<'a> RenderApi<'a> {
     pub fn clear(&self, color: Rgb) {
         unsafe {
-            let alpha = self.config.background_opacity();
+            let alpha = self.config.window_opacity();
             gl::ClearColor(
                 (f32::from(color.r) / 255.0).min(1.0) * alpha,
                 (f32::from(color.g) / 255.0).min(1.0) * alpha,


### PR DESCRIPTION
In some cases it could be desired to apply 'background_opacity'
to all background colors instead of just 'colors.primary.background',
thus adding an 'colors.opaque_background_colors' option to control that.

Fixes #741.

--
Based on #4196.