### PR TITLE
Add buffer for PTY reads during terminal lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Regression in rendering performance with dense grids since 0.6.0
 - Crash/Freezes with partially visible fullwidth characters due to alt screen resize
 - Incorrect vi cursor position after invoking `ScrollPageHalfUp` action
+- Slow PTY read performance with extremely dense grids
 
 ## 0.8.0
 

--- a/alacritty_terminal/src/sync.rs
+++ b/alacritty_terminal/src/sync.rs
@@ -21,11 +21,29 @@ impl<T> FairMutex<T> {
         FairMutex { data: Mutex::new(data), next: Mutex::new(()) }
     }
 
+    /// Acquire a lease to reserve the mutex lock.
+    ///
+    /// This will prevent others from acquiring a terminal lock, but block if anyone else is
+    /// already holding a lease.
+    pub fn lease(&self) -> MutexGuard<'_, ()> {
+        self.next.lock()
+    }
+
     /// Lock the mutex.
     pub fn lock(&self) -> MutexGuard<'_, T> {
         // Must bind to a temporary or the lock will be freed before going
         // into data.lock().
         let _next = self.next.lock();
         self.data.lock()
+    }
+
+    /// Unfairly lock the mutex.
+    pub fn lock_unfair(&self) -> MutexGuard<'_, T> {
+        self.data.lock()
+    }
+
+    /// Unfairly try to lock the mutex.
+    pub fn try_lock_unfair(&self) -> Option<MutexGuard<'_, T>> {
+        self.data.try_lock()
     }
 }


### PR DESCRIPTION
Before this patch, Alacritty's PTY reader would always try to read the
PTY into a buffer and then wait for the acquisition of the terminal lock
to process this data. Since locking for the terminal could take some
time, the PTY could fill up with the thread idling while doing so.

As a solution, this patch keeps reading to a buffer while the terminal
is locked in the renderer and starts processing all buffered data as
soon as the lock is released.

This has halfed the runtime of a simple `cat` benchmark from ~9 to ~4
seconds when the font size is set to `1`. Running this patch with
"normal" grid densities does not appear to make any significant
performance differences in either direction.

One possible memory optimization for the future would be to use this
buffer for synchronized updates, but since this currently uses a dynamic
buffer and would be a bit more cluttered, it has not been implemented in
this patch.