### PR TITLE
Fix crash when resizing during vi mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash/Freezes with partially visible fullwidth characters due to alt screen resize
 - Incorrect vi cursor position after invoking `ScrollPageHalfUp` action
 - Slow PTY read performance with extremely dense grids
+- Crash when resizing during vi mode
 
 ## 0.8.0
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -512,8 +512,10 @@ impl<T> Term<T> {
 
         // Clamp vi cursor to viewport.
         let vi_point = self.vi_mode_cursor.point;
-        self.vi_mode_cursor.point.column = min(vi_point.column, Column(num_cols - 1));
-        self.vi_mode_cursor.point.line = min(vi_point.line, Line(num_lines as i32 - 1));
+        let viewport_bottom = Line(-(self.grid.display_offset() as i32));
+        let viewport_top = viewport_bottom + self.bottommost_line();
+        self.vi_mode_cursor.point.line = max(min(vi_point.line, viewport_top), viewport_bottom);
+        self.vi_mode_cursor.point.column = min(vi_point.column, self.last_column());
 
         // Reset scrolling region.
         self.scroll_region = Line(0)..Line(self.screen_lines() as i32);


### PR DESCRIPTION
Our resize clamping logic for the vi mode cursor did not correctly clamp
to the viewport after the indexing change. Now it is enforced that the
vi mode cursor cannot leave the visible area after a font or viewport
size change.