### PR TITLE
Fix no text selection clear when leave vi mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Incorrect vi cursor position after invoking `ScrollPage*` action
 - Slow PTY read performance with extremely dense grids
 - Crash when resizing during vi mode
+- No text selection clear when leave vi mode
 
 ## 0.8.0
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -694,10 +694,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     /// Toggle the vi mode status.
     #[inline]
     fn toggle_vi_mode(&mut self) {
-        if !self.terminal.mode().contains(TermMode::VI) {
-            self.clear_selection();
-        }
-
+        self.clear_selection();
         self.cancel_search();
         self.terminal.toggle_vi_mode();
 


### PR DESCRIPTION
This bug comes from 530de00049c2afcc562d36ccdb3e6afa2fe396a5. This causes unintentional text selection expansion and highlight from left end of the selection to bottom of viewport.

An sample video which is show the bug

https://user-images.githubusercontent.com/12132068/124625853-23733180-deb9-11eb-813d-2ec04bba8f17.mp4

Reproduction steps (with default keybinding)

1. Enter vi mode (by `Ctrl+Shift+Space`).
2. Move vi mode cursor arbitrarily or don't move.
3. Start text selection (by `v`).
4. Move vi mode cursor arbitrarily or don't move.
5. Leave vi mode (by `Ctrl+Shift+Space`).
6. Go to step `1.`.