### PR TITLE
Fix Void Linux link in the install guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -131,7 +131,7 @@ Compiles out of the box for 14.2
 
 #### Void Linux
 
-On [Void Linux](https://voidlinux.eu), install following packages before
+On [Void Linux](https://voidlinux.org), install following packages before
 compiling Alacritty:
 
 ```sh


### PR DESCRIPTION
While skimming the install docs I followed the Void Linux link but ended up at a blog with an expired certificate. Checking on [Distro Watch](https://distrowatch.com/table.php?distribution=void) shows that https://voidlinux.org is the correct link for Void Linux.