### PR TITLE
Add ExpandSelection as a configurable binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for `ipfs`/`ipns` URLs
 - Mode field for regex hint bindings
 
+### Changed
+
+- `ExpandSelection` is now a configurable mouse binding action
+
 ### Fixed
 
 - Regression in rendering performance with dense grids since 0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.10.0-dev
 
+### Changed
+
+- `ExpandSelection` is now a configurable mouse binding action
+
 ## 0.9.0
 
 ### Packaging
@@ -17,10 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Support for `ipfs`/`ipns` URLs
 - Mode field for regex hint bindings
-
-### Changed
-
-- `ExpandSelection` is now a configurable mouse binding action
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -507,13 +507,19 @@
 #   - Right
 #   - Numeric identifier such as `5`
 #
-# - `action` (see key bindings)
+# - `action` (see key bindings for most of the action)
+#
+# - Mouse exclusive actions:
+#
+#   - ExpandSelection
+#       Expand the selection to the current mouse location
 #
 # And optionally:
 #
 # - `mods` (see key bindings)
 #mouse_bindings:
-#  - { mouse: Middle, action: PasteSelection }
+#  - { mouse: Right,             action: ExpandSelection }
+#  - { mouse: Middle, mode: ~Vi, action: PasteSelection  }
 
 # Key bindings
 #

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -507,12 +507,12 @@
 #   - Right
 #   - Numeric identifier such as `5`
 #
-# - `action` (see key bindings for most of the action)
+# - `action` (see key bindings for actions not exclusive to mouse mode)
 #
 # - Mouse exclusive actions:
 #
 #   - ExpandSelection
-#       Expand the selection to the current mouse location
+#       Expand the selection to the current mouse cursor location.
 #
 # And optionally:
 #

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -109,7 +109,7 @@ pub enum Action {
     #[config(skip)]
     Search(SearchAction),
 
-    /// Perform mouse action.
+    /// Perform mouse binding exclusive action.
     #[config(skip)]
     Mouse(MouseAction),
 
@@ -294,11 +294,10 @@ pub enum SearchAction {
     SearchHistoryNext,
 }
 
-/// Mouse specific actions.
-#[allow(clippy::enum_variant_names)]
+/// Mouse binding specific actions.
 #[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MouseAction {
-    /// Expand the selection to the current mouse position.
+    /// Expand the selection to the current mouse cursor position.
     ExpandSelection,
 }
 
@@ -1128,7 +1127,7 @@ impl<'a> Deserialize<'a> for RawBinding {
                     (Some(action @ Action::Mouse(_)), None, None) => {
                         if mouse.is_none() {
                             return Err(V::Error::custom(format!(
-                                "action `{}` is only available in mouse binding",
+                                "action `{}` is only available for mouse bindings",
                                 action,
                             )));
                         }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -109,6 +109,10 @@ pub enum Action {
     #[config(skip)]
     Search(SearchAction),
 
+    /// Perform mouse action.
+    #[config(skip)]
+    Mouse(MouseAction),
+
     /// Paste contents of system clipboard.
     Paste,
 
@@ -227,12 +231,19 @@ impl From<SearchAction> for Action {
     }
 }
 
+impl From<MouseAction> for Action {
+    fn from(action: MouseAction) -> Self {
+        Self::Mouse(action)
+    }
+}
+
 /// Display trait used for error logging.
 impl Display for Action {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Action::ViMotion(motion) => motion.fmt(f),
             Action::Vi(action) => action.fmt(f),
+            Action::Mouse(action) => action.fmt(f),
             _ => write!(f, "{:?}", self),
         }
     }
@@ -281,6 +292,14 @@ pub enum SearchAction {
     SearchHistoryPrevious,
     /// Go to the next regex in the search history.
     SearchHistoryNext,
+}
+
+/// Mouse specific actions.
+#[allow(clippy::enum_variant_names)]
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MouseAction {
+    /// Expand the selection to the current mouse position.
+    ExpandSelection,
 }
 
 macro_rules! bindings {
@@ -343,6 +362,7 @@ macro_rules! bindings {
 pub fn default_mouse_bindings() -> Vec<MouseBinding> {
     bindings!(
         MouseBinding;
+        MouseButton::Right;                    MouseAction::ExpandSelection;
         MouseButton::Middle, ~BindingMode::VI; Action::PasteSelection;
     )
 }
@@ -1027,6 +1047,8 @@ impl<'a> Deserialize<'a> for RawBinding {
                                 SearchAction::deserialize(value.clone())
                             {
                                 Some(search_action.into())
+                            } else if let Ok(mouse_action) = MouseAction::deserialize(value.clone()) {
+                                Some(mouse_action.into())
                             } else {
                                 match Action::deserialize(value.clone()).map_err(V::Error::custom) {
                                     Ok(action) => Some(action),
@@ -1097,6 +1119,15 @@ impl<'a> Deserialize<'a> for RawBinding {
                             return Err(V::Error::custom(format!(
                                 "action `{}` is only available in search mode, try adding `mode: \
                                  Search`",
+                                action,
+                            )));
+                        }
+                        action
+                    },
+                    (Some(action @ Action::Mouse(_)), None, None) => {
+                        if !mouse.is_some() {
+                            return Err(V::Error::custom(format!(
+                                "action `{}` is only available in mouse binding",
                                 action,
                             )));
                         }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -1047,7 +1047,8 @@ impl<'a> Deserialize<'a> for RawBinding {
                                 SearchAction::deserialize(value.clone())
                             {
                                 Some(search_action.into())
-                            } else if let Ok(mouse_action) = MouseAction::deserialize(value.clone()) {
+                            } else if let Ok(mouse_action) = MouseAction::deserialize(value.clone())
+                            {
                                 Some(mouse_action.into())
                             } else {
                                 match Action::deserialize(value.clone()).map_err(V::Error::custom) {
@@ -1125,7 +1126,7 @@ impl<'a> Deserialize<'a> for RawBinding {
                         action
                     },
                     (Some(action @ Action::Mouse(_)), None, None) => {
-                        if !mouse.is_some() {
+                        if mouse.is_none() {
                             return Err(V::Error::custom(format!(
                                 "action `{}` is only available in mouse binding",
                                 action,

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -22,7 +22,9 @@ mod bindings;
 mod mouse;
 
 use crate::cli::Options;
-pub use crate::config::bindings::{Action, Binding, BindingMode, Key, MouseAction, SearchAction, ViAction};
+pub use crate::config::bindings::{
+    Action, Binding, BindingMode, Key, MouseAction, SearchAction, ViAction,
+};
 #[cfg(test)]
 pub use crate::config::mouse::{ClickHandler, Mouse};
 use crate::config::ui_config::UiConfig;

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -22,7 +22,7 @@ mod bindings;
 mod mouse;
 
 use crate::cli::Options;
-pub use crate::config::bindings::{Action, Binding, BindingMode, Key, SearchAction, ViAction};
+pub use crate::config::bindings::{Action, Binding, BindingMode, Key, MouseAction, SearchAction, ViAction};
 #[cfg(test)]
 pub use crate::config::mouse::{ClickHandler, Mouse};
 use crate::config::ui_config::UiConfig;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -29,7 +29,7 @@ use alacritty_terminal::term::{ClipboardType, SizeInfo, Term, TermMode};
 use alacritty_terminal::vi_mode::ViMotion;
 
 use crate::clipboard::Clipboard;
-use crate::config::{Action, BindingMode, Config, Key, SearchAction, ViAction};
+use crate::config::{Action, BindingMode, Config, Key, MouseAction, SearchAction, ViAction};
 use crate::daemon::start_daemon;
 use crate::display::hint::HintMatch;
 use crate::display::window::Window;
@@ -231,6 +231,41 @@ impl<T: EventListener> Execute<T> for Action {
             Action::Search(SearchAction::SearchDeleteWord) => ctx.search_pop_word(),
             Action::Search(SearchAction::SearchHistoryPrevious) => ctx.search_history_previous(),
             Action::Search(SearchAction::SearchHistoryNext) => ctx.search_history_next(),
+            Action::Mouse(MouseAction::ExpandSelection) => {
+                let selection_type = match ctx.mouse().click_state {
+                    ClickState::Click => {
+                        if ctx.modifiers().ctrl() {
+                            Some(SelectionType::Block)
+                        } else {
+                            Some(SelectionType::Simple)
+                        }
+                    },
+                    ClickState::DoubleClick => Some(SelectionType::Semantic),
+                    ClickState::TripleClick => Some(SelectionType::Lines),
+                    ClickState::None => None,
+                };
+
+                if let Some(selection_type) = selection_type {
+                    // Load mouse point, treating message bar and padding as the closest cell.
+                    let display_offset = ctx.terminal().grid().display_offset();
+                    let point = ctx.mouse().point(&ctx.size_info(), display_offset);
+
+                    let cell_side = ctx.mouse().cell_side;
+
+                    let selection = match &mut ctx.terminal_mut().selection {
+                        Some(selection) => selection,
+                        None => return,
+                    };
+
+                    selection.ty = selection_type;
+                    ctx.update_selection(point, cell_side);
+
+                    // Move vi mode cursor to mouse click position.
+                    if ctx.terminal().mode().contains(TermMode::VI) && !ctx.search_active() {
+                        ctx.terminal_mut().vi_mode_cursor.point = point;
+                    }
+                }
+            },
             Action::SearchForward => ctx.start_search(Direction::Right),
             Action::SearchBackward => ctx.start_search(Direction::Left),
             Action::Copy => ctx.copy_selection(ClipboardType::Clipboard),
@@ -533,46 +568,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
             match button {
                 MouseButton::Left => self.on_left_click(point),
-                MouseButton::Right => self.on_right_click(point),
                 // Do nothing when using buttons other than LMB.
-                _ => self.ctx.mouse_mut().click_state = ClickState::None,
+                _ => (),
             }
-        }
-    }
-
-    /// Handle selection expansion on right click.
-    fn on_right_click(&mut self, point: Point) {
-        match self.ctx.mouse().click_state {
-            ClickState::Click => {
-                let selection_type = if self.ctx.modifiers().ctrl() {
-                    SelectionType::Block
-                } else {
-                    SelectionType::Simple
-                };
-
-                self.expand_selection(point, selection_type);
-            },
-            ClickState::DoubleClick => self.expand_selection(point, SelectionType::Semantic),
-            ClickState::TripleClick => self.expand_selection(point, SelectionType::Lines),
-            ClickState::None => (),
-        }
-    }
-
-    /// Expand existing selection.
-    fn expand_selection(&mut self, point: Point, selection_type: SelectionType) {
-        let cell_side = self.ctx.mouse().cell_side;
-
-        let selection = match &mut self.ctx.terminal_mut().selection {
-            Some(selection) => selection,
-            None => return,
-        };
-
-        selection.ty = selection_type;
-        self.ctx.update_selection(point, cell_side);
-
-        // Move vi mode cursor to mouse click position.
-        if self.ctx.terminal().mode().contains(TermMode::VI) && !self.ctx.search_active() {
-            self.ctx.terminal_mut().vi_mode_cursor.point = point;
         }
     }
 
@@ -749,8 +747,10 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         } else {
             match state {
                 ElementState::Pressed => {
-                    self.process_mouse_bindings(button);
+                    // process mouse press before bindings to
+                    // correctly set click_state
                     self.on_mouse_press(button);
+                    self.process_mouse_bindings(button);
                 },
                 ElementState::Released => self.on_mouse_release(button),
             }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -566,10 +566,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             let display_offset = self.ctx.terminal().grid().display_offset();
             let point = self.ctx.mouse().point(&self.ctx.size_info(), display_offset);
 
-            match button {
-                MouseButton::Left => self.on_left_click(point),
-                // Do nothing when using buttons other than LMB.
-                _ => (),
+            if let MouseButton::Left = button {
+                self.on_left_click(point)
             }
         }
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1119,6 +1119,7 @@ mod tests {
             initial_button: $initial_button:expr,
             input: $input:expr,
             end_state: $end_state:expr,
+            end_button: $end_button:expr,
         } => {
             #[test]
             fn $name() {
@@ -1138,6 +1139,7 @@ mod tests {
 
                 let mut mouse = Mouse {
                     click_state: $initial_state,
+                    last_click_button: $initial_button,
                     ..Mouse::default()
                 };
 
@@ -1171,6 +1173,7 @@ mod tests {
                 };
 
                 assert_eq!(processor.ctx.mouse.click_state, $end_state);
+                assert_eq!(processor.ctx.mouse.last_click_button, $end_button);
             }
         }
     }
@@ -1208,6 +1211,7 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::Click,
+        end_button: MouseButton::Left,
     }
 
     test_clickstate! {
@@ -1224,6 +1228,7 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::Click,
+        end_button: MouseButton::Right,
     }
 
     test_clickstate! {
@@ -1239,7 +1244,8 @@ mod tests {
             },
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
-        end_state: ClickState::None,
+        end_state: ClickState::Click,
+        end_button: MouseButton::Middle,
     }
 
     test_clickstate! {
@@ -1256,6 +1262,24 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::DoubleClick,
+        end_button: MouseButton::Left,
+    }
+
+    test_clickstate! {
+        name: double_click_right,
+        initial_state: ClickState::Click,
+        initial_button: MouseButton::Right,
+        input: GlutinEvent::WindowEvent {
+            event: WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Right,
+                device_id: unsafe { std::mem::transmute_copy(&0) },
+                modifiers: ModifiersState::default(),
+            },
+            window_id: unsafe { std::mem::transmute_copy(&0) },
+        },
+        end_state: ClickState::DoubleClick,
+        end_button: MouseButton::Right,
     }
 
     test_clickstate! {
@@ -1272,6 +1296,24 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::TripleClick,
+        end_button: MouseButton::Left,
+    }
+
+    test_clickstate! {
+        name: triple_click_middle,
+        initial_state: ClickState::DoubleClick,
+        initial_button: MouseButton::Middle,
+        input: GlutinEvent::WindowEvent {
+            event: WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Middle,
+                device_id: unsafe { std::mem::transmute_copy(&0) },
+                modifiers: ModifiersState::default(),
+            },
+            window_id: unsafe { std::mem::transmute_copy(&0) },
+        },
+        end_state: ClickState::TripleClick,
+        end_button: MouseButton::Middle,
     }
 
     test_clickstate! {
@@ -1288,6 +1330,7 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::Click,
+        end_button: MouseButton::Right,
     }
 
     test_process_binding! {

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1083,7 +1083,6 @@ mod tests {
             initial_button: $initial_button:expr,
             input: $input:expr,
             end_state: $end_state:expr,
-            end_button: $end_button:expr,
         } => {
             #[test]
             fn $name() {
@@ -1137,7 +1136,6 @@ mod tests {
                 };
 
                 assert_eq!(processor.ctx.mouse.click_state, $end_state);
-                assert_eq!(processor.ctx.mouse.last_click_button, $end_button);
             }
         }
     }
@@ -1175,7 +1173,6 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::Click,
-        end_button: MouseButton::Left,
     }
 
     test_clickstate! {
@@ -1192,7 +1189,6 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::Click,
-        end_button: MouseButton::Right,
     }
 
     test_clickstate! {
@@ -1209,7 +1205,6 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::Click,
-        end_button: MouseButton::Middle,
     }
 
     test_clickstate! {
@@ -1226,24 +1221,6 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::DoubleClick,
-        end_button: MouseButton::Left,
-    }
-
-    test_clickstate! {
-        name: double_click_right,
-        initial_state: ClickState::Click,
-        initial_button: MouseButton::Right,
-        input: GlutinEvent::WindowEvent {
-            event: WindowEvent::MouseInput {
-                state: ElementState::Pressed,
-                button: MouseButton::Right,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
-                modifiers: ModifiersState::default(),
-            },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
-        },
-        end_state: ClickState::DoubleClick,
-        end_button: MouseButton::Right,
     }
 
     test_clickstate! {
@@ -1260,24 +1237,6 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::TripleClick,
-        end_button: MouseButton::Left,
-    }
-
-    test_clickstate! {
-        name: triple_click_middle,
-        initial_state: ClickState::DoubleClick,
-        initial_button: MouseButton::Middle,
-        input: GlutinEvent::WindowEvent {
-            event: WindowEvent::MouseInput {
-                state: ElementState::Pressed,
-                button: MouseButton::Middle,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
-                modifiers: ModifiersState::default(),
-            },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
-        },
-        end_state: ClickState::TripleClick,
-        end_button: MouseButton::Middle,
     }
 
     test_clickstate! {
@@ -1294,7 +1253,6 @@ mod tests {
             window_id: unsafe { std::mem::transmute_copy(&0) },
         },
         end_state: ClickState::Click,
-        end_button: MouseButton::Right,
     }
 
     test_process_binding! {


### PR DESCRIPTION
This adds a new action called `ExpandSelection` that by default is bound to the right mouse button. This allows users to chose whether to keep that binding or remove it (or even map it to a different mouse button).

When implementing this, I mirrored `ViAction` in that it is a different `enum` and is only available on mouse bindings similar to how `ViAction`s are only available in vi mode.

I moved the logic from `on_right_click` and `expand_selection` into event listener, but there is one piece I'm not sure about that I'll highlight below.

I had to move `process_mouse_bindings` before `on_mouse_press` as it is responsible for noticing when double- and triple-clicks occur, but I don't think this will have any negative side-effects.

Replaces #5194
Fixes #4132