### PR TITLE
Fix vi cucrsor tracking during scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash when starting a vi mode search from the bottommost line
 - Original scroll position not restored after canceling search
 - Clipboard copy skipping non-empty cells when encountering an interrupted tab character
+- Vi mode cursor moving downward when scrolled in history with active output
 
 ## 0.8.0
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -562,6 +562,12 @@ impl<T> Term<T> {
         self.selection =
             self.selection.take().and_then(|s| s.rotate(self, &region, -(lines as i32)));
 
+        // Scroll vi mode cursor.
+        let line = &mut self.vi_mode_cursor.point.line;
+        if region.start <= *line && region.end > *line {
+            *line = min(*line + lines, region.end - 1);
+        }
+
         // Scroll between origin and bottom
         self.grid.scroll_down(&region, lines);
     }
@@ -580,6 +586,14 @@ impl<T> Term<T> {
 
         // Scroll selection.
         self.selection = self.selection.take().and_then(|s| s.rotate(self, &region, lines as i32));
+
+        // Scroll vi mode cursor.
+        let viewport_top = Line(-(self.grid.display_offset() as i32));
+        let top = if region.start == 0 { viewport_top } else { region.start };
+        let line = &mut self.vi_mode_cursor.point.line;
+        if (top <= *line) && region.end > *line {
+            *line = max(*line - lines, top);
+        }
 
         // Scroll from origin to bottom less number of lines.
         self.grid.scroll_up(&region, lines);


### PR DESCRIPTION
This resolves an issue with the vi mode cursor where it would not keep
track of the content while scrolled up in history but instead slowly
leave the viewport due to its absolute positioning.

While an alternative solution would have been to always keep the vi mode
cursor in the same spot on the viewport, keeping track of the content is
not only more easy to implement but it also makes for a nicer connection
between the vi mode cursor and the content below it.

Fixes #5339.