### PR TITLE
Downgrade glutin version

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -25,7 +25,7 @@ fnv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1"
-glutin = { version = "0.27.0", default-features = false, features = ["serde"] }
+glutin = { version = "0.26.0", default-features = false, features = ["serde"] }
 notify = "4"
 parking_lot = "0.11.0"
 crossfont = { version = "0.3.0", features = ["force_system_fontconfig"] }


### PR DESCRIPTION
The glutin version bump to 0.27.0 has introduced a lot of new issues and
crashes to Alacritty due to the connected winit update. Since it doesn't
solve any major issues downgrading glutin temporarily should improve
Alacritty's reliability.