### PR TITLE
Draft: Feature feedoutput (pipeing commandoutput back to the pty in keybindings)

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -183,7 +183,7 @@ impl Options {
             // `Arg::min_values(1)` is set.
             let program = String::from(args.next().unwrap());
             let args = args.map(String::from).collect();
-            options.command = Some(Program::WithArgs { program, args });
+            options.command = Some(Program::WithArgs { program, args, feedoutput: false });
         }
 
         if matches.is_present("hold") {

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -74,3 +74,22 @@ where
             .map(|_| ())
     }
 }
+
+#[cfg(not(windows))]
+pub fn capture_output<I, S>(program: &str, args: I) -> Option<Vec<u8>>
+where
+    I: IntoIterator<Item = S> + Copy,
+    S: AsRef<OsStr>,
+{
+    let output = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output().ok()?;
+
+    if output.status.success() {
+        Some(output.stdout)
+    } else {
+        None
+    }
+}

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -85,7 +85,8 @@ where
         .args(args)
         .stdin(Stdio::null())
         .stderr(Stdio::null())
-        .output().ok()?;
+        .output()
+        .ok()?;
 
     if output.status.success() {
         Some(output.stdout)

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -43,7 +43,7 @@ use crate::cli::Options as CLIOptions;
 use crate::clipboard::Clipboard;
 use crate::config::ui_config::{HintAction, HintInternalAction};
 use crate::config::{self, Config};
-use crate::daemon::{start_daemon,capture_output};
+use crate::daemon::{capture_output, start_daemon};
 use crate::display::hint::HintMatch;
 use crate::display::window::Window;
 use crate::display::{self, Display, DisplayUpdate};

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -30,7 +30,7 @@ use alacritty_terminal::vi_mode::ViMotion;
 
 use crate::clipboard::Clipboard;
 use crate::config::{Action, BindingMode, Config, Key, SearchAction, ViAction};
-use crate::daemon::{start_daemon,capture_output};
+use crate::daemon::{capture_output, start_daemon};
 use crate::display::hint::HintMatch;
 use crate::display::window::Window;
 use crate::display::Display;

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -182,6 +182,8 @@ pub enum Program {
         program: String,
         #[serde(default)]
         args: Vec<String>,
+        #[serde(default)]
+        feedoutput: bool,
     },
 }
 
@@ -197,6 +199,13 @@ impl Program {
         match self {
             Program::Just(_) => &[],
             Program::WithArgs { args, .. } => args,
+        }
+    }
+
+    pub fn feedoutput(&self) -> bool {
+        match self {
+            Program::Just(_) => false,
+            Program::WithArgs { feedoutput, .. } => *feedoutput,
         }
     }
 }


### PR DESCRIPTION
Hey, thank you for alacritty. This PR is mostly intended to scratch a small personal itch of mine with the software. Currently it's in alpha state and only contains the minmum amount of work to obtain a working sample.

What this commit does is to allow `commands` that are attached to keybindings to feed back output from stdout into the running terminal session.

Exemplary usecase/Rational: Due to wayland's gui isolation on linux (and potentially also on platforms such as windows/osx), it is not that easy any more to type in passwords into a given window automatically, at least not in the way it was possible with X11 using xdotools; so my password management solution (build around pass, rofi/dmenu and xdotools) broke. The easiest (and probably only secure) way to fix this is by integrating an "insert-password" funcitonality into the respective applications - such as alacritty - themselves. Currently it looks like this (where [rofi-pass](https://github.com/carnager/rofi-pass) opens a graphical fuzzy finder across my passwords and outputs the respective password on stdout):

```yaml
key_bindings:
  - { key: P,         mods: Control,                    command: { program: "rofi-pass", args: [], feedoutput: true } }
```

What is nice that nearly all functionality is already there, and therefore the additional code, and probably also maintainability burden, are thus quite minimal. As a side effect, with minimal additional code, we could also attach this to `hint`-handles as well, even though I yet do not see immediate usecases for that one:

```yaml
hints:
  enabled:
   - regex: "(ipfs:|ipns:|magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
             [^\u0000-\u001F\u007F-\u009F<>\"\\s{-}\\^⟨⟩`]+"
     # Input the curled sourcecode into the terminal. The integrated way to do "curl | bash" (yes, I'm kidding)
     command:  { program: "curl", args: [], feedoutput: true }
     binding:
       key: U
       mods: Control|Shift
```

Currently, the PR is in draft state, and definitly needs more work (which I'm willing to do, but I would just like some early feedback and guidance to avoid work going into wrong directions). Areas that I will definitely improve when the concept is ironed out:
1. Write documentation for the feature
2. Write tests (if possible, have to look into it)
3. Validate that the option is not present at unsuitable places (e.g.: Bell program)

Additionally, I would value input on:
- naming of the option: You probably know the drill: There are only 2 hard problems in CS: cache-invalidation, naming things, and off-by-one errors. I'm not really happy with `feedoutput`, but all alternatives I came up with (`passthrough`, `typeback`, `feedback`, `redirect`, `to_pty`) did not seem too natural either
- Should it work for hints? Or does it seem out of place?
- Is deamon.rs really the correct place for `capture_output`?
- Is `write_to_pty` the correct function to input into the session?

Thank you for reading this far. As said, I'd be glad to make any changes if you actually consider adding this feature to alacritty.