### PR TITLE
Allow logging from dependencies at trace level

### DIFF
--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use glutin::event_loop::EventLoopProxy;
-use log::{self, Level};
+use log::{self, Level, LevelFilter};
 
 use crate::cli::Options;
 use crate::event::Event;
@@ -103,7 +103,7 @@ impl log::Log for Logger {
         let target = &record.target()[..index];
 
         // Only log our own crates.
-        if !self.enabled(record.metadata()) || !ALLOWED_TARGETS.contains(&target) {
+        if !self.enabled(record.metadata()) || !is_allowed_target(record.level(), target) {
             return;
         }
 
@@ -147,6 +147,16 @@ fn create_log_message(record: &log::Record<'_>, target: &str) -> String {
     // Drop extra trailing alignment.
     message.truncate(message.len() - alignment);
     message
+}
+
+fn is_allowed_target(level: Level, target: &str) -> bool {
+    use Level::{Error, Warn};
+    use LevelFilter::Trace;
+
+    match (level, log::max_level()) {
+        (Error, Trace) | (Warn, Trace) => true,
+        _ => ALLOWED_TARGETS.contains(&target),
+    }
 }
 
 struct OnDemandLogFile {

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -152,7 +152,7 @@ fn create_log_message(record: &log::Record<'_>, target: &str) -> String {
 /// Check if log messages from a crate should be logged.
 fn is_allowed_target(level: Level, target: &str) -> bool {
     match (level, log::max_level()) {
-        (Level::Error | Level::Warn, LevelFilter::Trace) => true,
+        (Level::Error, LevelFilter::Trace) | (Level::Warn, LevelFilter::Trace) => true,
         _ => ALLOWED_TARGETS.contains(&target),
     }
 }

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -102,7 +102,7 @@ impl log::Log for Logger {
         let index = record.target().find(':').unwrap_or_else(|| record.target().len());
         let target = &record.target()[..index];
 
-        // Only log our own crates.
+        // Only log our own crates (except when logging at Level::Trace).
         if !self.enabled(record.metadata()) || !is_allowed_target(record.level(), target) {
             return;
         }
@@ -149,12 +149,10 @@ fn create_log_message(record: &log::Record<'_>, target: &str) -> String {
     message
 }
 
+/// Check if log messages from a crate should be logged.
 fn is_allowed_target(level: Level, target: &str) -> bool {
-    use Level::{Error, Warn};
-    use LevelFilter::Trace;
-
     match (level, log::max_level()) {
-        (Error, Trace) | (Warn, Trace) => true,
+        (Level::Error, LevelFilter::Trace) | (Level::Warn, LevelFilter::Trace) => true,
         _ => ALLOWED_TARGETS.contains(&target),
     }
 }

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -102,7 +102,7 @@ impl log::Log for Logger {
         let index = record.target().find(':').unwrap_or_else(|| record.target().len());
         let target = &record.target()[..index];
 
-        // Only log our own crates (except when logging at Level::Trace).
+        // Only log our own crates, except when logging at Level::Trace.
         if !self.enabled(record.metadata()) || !is_allowed_target(record.level(), target) {
             return;
         }
@@ -152,7 +152,7 @@ fn create_log_message(record: &log::Record<'_>, target: &str) -> String {
 /// Check if log messages from a crate should be logged.
 fn is_allowed_target(level: Level, target: &str) -> bool {
     match (level, log::max_level()) {
-        (Level::Error, LevelFilter::Trace) | (Level::Warn, LevelFilter::Trace) => true,
+        (Level::Error | Level::Warn, LevelFilter::Trace) => true,
         _ => ALLOWED_TARGETS.contains(&target),
     }
 }


### PR DESCRIPTION
This change allows the logging of Error and Warn level messages from dependencies when
the overall logging level is set to Trace (though the "-vvv" option).

Fixes: #5387﻿
