### PR TITLE
Touch-to-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.10.0-dev
 
+### Added
+
+- Touchscreen support for clicking
+
 ### Changed
 
 - `ExpandSelection` is now a configurable mouse binding action

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -986,13 +986,27 @@ impl Mouse {
 /// State of touch.
 #[derive(Debug)]
 pub struct TouchState {
+    pub start_x: f64,
+    pub start_y: f64,
     pub x: f64,
     pub y: f64,
 }
 
 impl Default for TouchState {
     fn default() -> TouchState {
-        TouchState { x: Default::default(), y: Default::default() }
+        TouchState {
+            start_x: Default::default(),
+            start_y: Default::default(),
+            x: Default::default(),
+            y: Default::default(),
+        }
+    }
+}
+
+impl TouchState {
+    /// Returns square of the distance travelled since the touch began.
+    pub fn dist2(&self) -> f64 {
+        (self.start_x - self.x).powi(2) + (self.start_y - self.y).powi(2)
     }
 }
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1303,6 +1303,9 @@ impl<N: Notify + OnResize> Processor<N> {
                         processor.ctx.window().set_mouse_visible(true);
                         processor.mouse_wheel_input(delta, phase);
                     },
+                    WindowEvent::Touch(touch) => {
+                        processor.touch_input(touch)
+                    },
                     WindowEvent::Focused(is_focused) => {
                         if window_id == processor.ctx.window().window_id() {
                             processor.ctx.terminal.is_focused = is_focused;
@@ -1338,7 +1341,6 @@ impl<N: Notify + OnResize> Processor<N> {
                     | WindowEvent::Destroyed
                     | WindowEvent::ThemeChanged(_)
                     | WindowEvent::HoveredFile(_)
-                    | WindowEvent::Touch(_)
                     | WindowEvent::Moved(_) => (),
                 }
             },
@@ -1364,7 +1366,6 @@ impl<N: Notify + OnResize> Processor<N> {
                     | WindowEvent::HoveredFileCancelled
                     | WindowEvent::Destroyed
                     | WindowEvent::HoveredFile(_)
-                    | WindowEvent::Touch(_)
                     | WindowEvent::Moved(_)
             ),
             GlutinEvent::Suspended { .. }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use glutin::dpi::PhysicalPosition;
 use glutin::event::{
-    ElementState, KeyboardInput, ModifiersState, MouseButton, MouseScrollDelta, TouchPhase,
+    ElementState, KeyboardInput, ModifiersState, MouseButton, MouseScrollDelta, Touch, TouchPhase,
 };
 use glutin::event_loop::EventLoopWindowTarget;
 #[cfg(target_os = "macos")]
@@ -618,6 +618,20 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                     _ => (),
                 }
             },
+        }
+    }
+
+    pub fn touch_input(&mut self, touch: Touch) {
+        match touch.phase {
+            TouchPhase::Started => {}
+            TouchPhase::Moved => {}
+            TouchPhase::Ended => {
+                self.mouse_moved(PhysicalPosition::new(touch.location.x, touch.location.y));
+                self.on_mouse_press(MouseButton::Left);
+                self.process_mouse_bindings(MouseButton::Left);
+                self.on_mouse_release(MouseButton::Left);
+            }
+            TouchPhase::Cancelled => {}
         }
     }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -640,8 +640,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 self.ctx.touch_mut().y = touch.location.y;
             },
             TouchPhase::Ended => {
-                self.mouse_moved(PhysicalPosition::new(self.ctx.touch().x, self.ctx.touch().y));
                 if self.ctx.touch().dist2() < DRAG_MINIMUM_DISTANCE2 {
+                    self.mouse_moved(PhysicalPosition::new(self.ctx.touch().x, self.ctx.touch().y));
                     if self.message_bar_cursor_state() == Some(CursorIcon::Hand) {
                         self.on_message_bar_button_click();
                     } else {

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -643,7 +643,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 self.mouse_moved(PhysicalPosition::new(self.ctx.touch().x, self.ctx.touch().y));
                 if self.ctx.touch().dist2() < DRAG_MINIMUM_DISTANCE2 {
                     if self.message_bar_cursor_state() == Some(CursorIcon::Hand) {
-                        self.on_message_bar_click();
+                        self.on_message_bar_button_click();
                     } else {
                         self.on_mouse_press(MouseButton::Left);
                         self.process_mouse_bindings(MouseButton::Left);
@@ -708,7 +708,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         }
     }
 
-    fn on_message_bar_click(&mut self) {
+    fn on_message_bar_button_click(&mut self) {
         let size = self.ctx.size_info();
 
         let current_lines = self.ctx.message().map(|m| m.text(&size).len()).unwrap_or(0);
@@ -746,7 +746,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         if self.message_bar_cursor_state() == Some(CursorIcon::Hand)
             && state == ElementState::Pressed
         {
-            self.on_message_bar_click();
+            self.on_message_bar_button_click();
         } else {
             match state {
                 ElementState::Pressed => {


### PR DESCRIPTION
This is a baby step towards touch support: tapping will click, but no other touch functionality is available. It does most of what *I* want, but of course I can't vouch for anyone else...

Because of the simplicity of this change, there are a few strange behaviors. None of them seem to be "biting" or potentially harmful, but here's the ones I know of:

- The message bar is not handled correctly. If you tap on the message bar, that gets interpreted as a click behind the message bar.
- Dragging is not detected. That doesn't just mean you can't scroll; it also means that if you drag, it interprets it as a click at the last place your finger was.
- Multitouch is totally ignored. If you put one finger down, then another, then lift the first, it interprets that as a "click". When you lift the second, that's another "click".

Note (as mentioned in the commits) that this code essentially contains a workaround for winit issue 1996. The main part of that workaround is that it necessitates keeping track of a `TouchState` object --- that'll be necessary eventually anyway, so I don't feel guilty.

I have added no tests, expecting that touch behavior will change substantially in the future, and those tests would need to be immediately re-written. Tests have been modified only to keep them compiling (necessary cuz of the additional variable tracking TouchState).

Finally, a question: to detect the difference between a drag (to be ignored, for now) and a tap, it's necessary to have some sort of threshold, probably in distance moved. Is this worthy of adding a configuration option to alacritty.yml? I think the only real alternative is a hidden constant somewhere.

Thanks,
Scott