### PR TITLE
Add python3 dep to freebsd install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,7 +148,7 @@ command that should install all of them. If something is still found to be
 missing, please open an issue.
 
 ```sh
-pkg install cmake freetype2 fontconfig pkgconf
+pkg install cmake freetype2 fontconfig pkgconf python3
 ```
 
 #### OpenBSD


### PR DESCRIPTION
python3 was required for my install:

```
Caused by:
  process didn't exit successfully: `/root/git/alacritty/target/release/build/xcb-c67f7bb2ddda9300/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Unable to find build dependency python3: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/xcb-0.9.0/build.rs:75:22
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```