### PR TITLE
Add check for CARGO_CFG_TARGET_OS, rustc-link-search for OpenBSD [ close #5422 ]

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -15,6 +15,17 @@ fn main() {
         .write_bindings(GlobalGenerator, &mut file)
         .unwrap();
 
+    let target_os = env::var("CARGO_CFG_TARGET_OS");
+    match target_os.as_ref().map(|x| &**x) {
+        Ok("linux") | Ok("freebsd") => {},
+        Ok("openbsd") => {
+            println!(r"cargo:rustc-link-search=/usr/local/lib")
+        },
+        Ok("windows") => {},
+        _ => {}
+    }
+
+
     #[cfg(windows)]
     embed_resource::compile("./windows/windows.rc");
 }


### PR DESCRIPTION
OpenBSD has libxkbcommon in /usr/local/lib which is not pointed from
rust. I've followed the following blog post for the CARGO_CFG_TARGE_OS.

https://kazlauskas.me/entries/writing-proper-buildrs-scripts.html