### PR TITLE
Fix background_opacity deprecation

### DIFF
--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -70,7 +70,7 @@ pub struct UiConfig {
 
     /// Background opacity from 0.0 to 1.0.
     #[config(deprecated = "use window.opacity instead")]
-    window_opacity: Option<Percentage>,
+    background_opacity: Option<Percentage>,
 }
 
 impl Default for UiConfig {
@@ -85,7 +85,7 @@ impl Default for UiConfig {
             config_paths: Default::default(),
             key_bindings: Default::default(),
             mouse_bindings: Default::default(),
-            window_opacity: Default::default(),
+            background_opacity: Default::default(),
             bell: Default::default(),
             colors: Default::default(),
             draw_bold_text_with_bright_colors: Default::default(),
@@ -117,7 +117,7 @@ impl UiConfig {
 
     #[inline]
     pub fn window_opacity(&self) -> f32 {
-        self.window_opacity.unwrap_or(self.window.opacity).as_f32()
+        self.background_opacity.unwrap_or(self.window.opacity).as_f32()
     }
 
     #[inline]


### PR DESCRIPTION
During the deprecation of the background_opacity field, it was
incorrectly renamed to window_opacity. This changes that back to ensure
the old field still works and a warning is emitted accordingly.

See the original regression here:
https://github.com/alacritty/alacritty/commit/c24d7dfd0d2d8849f0398d7cb1a65d6562ee7a0d#diff-f92f0b1ad70a7b75b7266f3c9e569025e023d186814aa88c2b690800850ccb78L72-R73