### PR TITLE
Fix alacritty_terminal build on windows

### DIFF
--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -35,7 +35,7 @@ signal-hook = { version = "0.1", features = ["mio-support"] }
 miow = "0.3"
 winapi = { version = "0.3.7", features = [
     "impl-default", "basetsd", "libloaderapi", "minwindef", "ntdef", "processthreadsapi", "winbase",
-    "wincon", "wincontypes", "winerror", "winnt", "winuser",
+    "wincon", "wincontypes", "winerror", "winnt", "winuser", "consoleapi",
 ]}
 mio-anonymous-pipes = "0.2"
 


### PR DESCRIPTION
The "consoleapi" feature in the winapi crate is required when using
things from the `winapi::um::consoleapi` module.

I have to admit I am not at all clear why this wasn't noticed before (since I know alacritty officially supports Windows).  So maybe I'm doing something wrong on my side?

Without this change, I get the following errors when building:

```
PS Z:\devel\alacritty> cargo check -p alacritty_terminal
    Checking alacritty_terminal v0.15.1-dev (Z:\devel\alacritty\alacritty_terminal)
error[E0432]: unresolved import `winapi::um::consoleapi`
  --> alacritty_terminal\src\tty\windows\conpty.rs:12:17
   |
12 | use winapi::um::consoleapi::{ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole};
   |                 ^^^^^^^^^^ could not find `consoleapi` in `um`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `alacritty_terminal`

To learn more, run the command again with --verbose.
```