### PR TITLE
Remove custom merge strategy for changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-/CHANGELOG.md merge=union


### PR DESCRIPTION
While the custom merge strategy can make things simpler in some
scenarios, it has repeatedly shown to silently introduce errors that
have to be manually spotted and corrected after the fact.

It's much more reliable and efficient to always manually oversee
potential conflicts, rather than letting them slip through half of the
time and having to contribute follow-up patches.