### PR TITLE
Add more funky unicode chars to the default URL regex

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -486,7 +486,7 @@
   #       Move the vi mode cursor to the beginning of the hint.
   #enabled:
   # - regex: "(ipfs:|ipns:|magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
-  #           [^\u0000-\u001F\u007F-\u009F<>\"\\s{-}\\^⟨⟩`]+"
+  #           [^\u0000-\u001F\u007F-\u009F<>\"\\s{-}\\^⟨⟩❮❯‹›←→◀▶│¬↲↪␣¤‡§·•★…`]+"
   #   command: xdg-open
   #   post_processing: true
   #   mouse:

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -25,7 +25,7 @@ use crate::config::window::WindowConfig;
 /// Regex used for the default URL hint.
 #[rustfmt::skip]
 const URL_REGEX: &str = "(ipfs:|ipns:|magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
-                         [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+";
+                         [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩❮❯‹›←→◀▶│¬↲↪␣¤‡§·•★…`]+";
 
 #[derive(ConfigDeserialize, Debug, PartialEq)]
 pub struct UiConfig {


### PR DESCRIPTION
These are often used for [vim listchars](https://www.reddit.com/r/vim/comments/4hoa6e/what_do_you_use_for_your_listchars/) and similar, so any time a URL would be shown in an editor with e.g. a line break after it, that character would be caught in the regex…