### PR TITLE
Unix: Hide TTY close EIO in Rust 1.55+

### DIFF
--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -394,7 +394,7 @@ where
                                     // This sucks, but checking the process is either racy or
                                     // blocking.
                                     #[cfg(target_os = "linux")]
-                                    if err.kind() == ErrorKind::Other {
+                                    if err.raw_os_error() == Some(libc::EIO) {
                                         continue;
                                     }
 


### PR DESCRIPTION
`ErrorKind::Other` no longer includes `EIO` since Rust 1.55:

    https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#stdioerrorkind-variants-updated

It was not precise enough from the very beginning, as the comment says
that only EIO should be hidden, while the code was any uncategorised
errors.