### PR TITLE
Fix invalid repetition operator in help target regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ vpath $(DMG_NAME) $(APP_DIR)
 all: help
 
 help: ## Print this help message
-	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z._-]+:.*?## .*$$/{printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 binary: $(TAGET)-native ## Build a release binary
 binary-universal: $(TAGET)-universal ## Build a universal release binary


### PR DESCRIPTION
When using gmake 4.3 with grep 0.9 on OpenBSD 6.9, running `gmake help` results in the following error: `grep: repetition-operator operand invalid`.

Use of grep(1) can be omitted by use of an pattern-action in awk(1).

This change was also tested on macos 11.6

