### PR TITLE
Change order of checks in `.builds` files

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -19,6 +19,10 @@ environment:
 tasks:
   - rustup: |
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+  - clippy: |
+      cd alacritty
+      rustup component add clippy
+      cargo clippy --all-targets
   - test: |
       cd alacritty
       cargo test
@@ -27,10 +31,6 @@ tasks:
       rustup toolchain install --profile minimal 1.46.0
       rustup default 1.46.0
       cargo test
-  - clippy: |
-      cd alacritty
-      rustup component add clippy
-      cargo clippy --all-targets
   - feature-wayland: |
       cd alacritty/alacritty
       cargo test --no-default-features --features=wayland

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -18,22 +18,22 @@ environment:
 tasks:
   - rustup: |
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
-  - test: |
-      cd alacritty
-      cargo test
   - rustfmt: |
       cd alacritty
       rustup toolchain install nightly -c rustfmt
       cargo +nightly fmt -- --check
+  - clippy: |
+      cd alacritty
+      rustup component add clippy
+      cargo clippy --all-targets
+  - test: |
+      cd alacritty
+      cargo test
   - oldstable: |
       cd alacritty
       rustup toolchain install --profile minimal 1.46.0
       rustup default 1.46.0
       cargo test
-  - clippy: |
-      cd alacritty
-      rustup component add clippy
-      cargo clippy --all-targets
   - feature-wayland: |
       cd alacritty/alacritty
       cargo test --no-default-features --features=wayland


### PR DESCRIPTION
This is a really minor thing, it's ok if you disagree with my reasoning for it!

When I submitted a PR, I used the stable version of rustfmt instead of nightly, which cause the rustfmt check to fail. Since rustfmt was after the main `cargo test`, it took a long time to fail. If rustfmt was first, I'd have noticed much sooner and it would have saved a bit of time! The formatting checks are really fast, too, so it passes quickly and doesn't make much of a difference to the time until the later tests are run.