### PR TITLE
Update INSTALL.md with instructions for ls color

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -361,3 +361,16 @@ To install the completions for fish, run
 mkdir -p $fish_complete_path[1]
 cp extra/completions/alacritty.fish $fish_complete_path[1]/alacritty.fish
 ```
+
+### When you're not seeing color in the output of `ls` commands
+
+On some distributions, such as Fedora Linux, you may notice an absence of color in directory listings when you run `ls` commands in an Alacritty shell.
+
+If you notice this, you can enable color in `ls` output in Alacritty as follows:
+
+```
+cp /etc/DIR_COLORS ~/.dir_colors
+echo "TERM alacritty" >> ~/.dir_colors
+```
+
+After running these commands, close all Alacritty windows, reopen a new one and try running `ls` again. You should now get output in color.


### PR DESCRIPTION
Based on information I found at https://www.reddit.com/r/Gentoo/comments/kd588m/alacritty_show_ls_without_colors/ and https://github.com/alacritty/alacritty/issues/2210. Listing these instructions here might save a lot of people time troubleshooting this.