### PR TITLE
Fix cursor inversion logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Line indicator obstructing vi mode cursor when scrolled into history
 - Vi mode search starting in the line below the vi cursor
+- Invisible cursor with matching foreground/background colors
 
 ## 0.9.0
 


### PR DESCRIPTION
The existing cursor inversion logic was causing more problems than it
solved, without solving the problem of invisible cursor when inverting a
cell with matching foreground and background colors.

This patch reworks this logic and only inverts the cursor when the
foreground and background colors of the cursor are similar and the
cursor colors aren't set to fixed RGB values.

Fixes #4564.
Fixes #5550.