### PR TITLE
Fix #5586: Correct package name for libxkbcommon on openSUSE

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,7 +125,7 @@ a `zypper` command that should install all of them. If something is
 still found to be missing, please open an issue.
 
 ```sh
-zypper install cmake freetype-devel fontconfig-devel libxcb-devel libxkbcommon-dev
+zypper install cmake freetype-devel fontconfig-devel libxcb-devel libxkbcommon-devel
 ```
 
 #### Slackware

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -80,7 +80,7 @@ pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventLoopProxy<Event>) {
                     // Always reload the primary configuration file.
                     let event = Event::new(EventType::ConfigReload(paths[0].clone()), None);
                     let _ = event_proxy.send_event(event);
-                }
+                },
                 _ => (),
             }
         }

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -407,7 +407,7 @@ where
                                     break 'event_loop;
                                 }
                             }
-                        }
+                        },
                         _ => (),
                     }
                 }

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -291,7 +291,7 @@ impl<T> Term<T> {
                     && iter.point().column < self.last_column() =>
             {
                 iter.next();
-            }
+            },
             Direction::Right if cell.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER) => {
                 if let Some(Indexed { cell: new_cell, .. }) = iter.next() {
                     *cell = new_cell;


### PR DESCRIPTION
Fix typo in package name for libxkbcommon (`libxkbcommon-dev` -> `libxkbcommon-devel`)