### PR TITLE
Add alacritty-msg manpage to documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,15 @@ jobs:
       - name: Test
         run: cargo test --release
       - name: Gzip manpage
-        run: gzip -c "./extra/alacritty.man" > "./alacritty.1.gz"
+        run: |
+          gzip -c "./extra/alacritty.man" > "./alacritty.1.gz"
+          gzip -c "./extra/alacritty-msg.man" > "./alacritty-msg.1.gz"
       - name: Upload Assets
         run: |
           mv ./extra/logo/alacritty-term.svg ./Alacritty.svg
           ./.github/workflows/upload_asset.sh ./Alacritty.svg $GITHUB_TOKEN
           ./.github/workflows/upload_asset.sh ./alacritty.1.gz $GITHUB_TOKEN
+          ./.github/workflows/upload_asset.sh ./alacritty-msg.1.gz $GITHUB_TOKEN
           ./.github/workflows/upload_asset.sh ./extra/completions/alacritty.bash $GITHUB_TOKEN
           ./.github/workflows/upload_asset.sh ./extra/completions/alacritty.fish $GITHUB_TOKEN
           ./.github/workflows/upload_asset.sh ./extra/completions/_alacritty $GITHUB_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.10.0-dev
 
+### Packaging
+
+- New `extra/alacritty-msg.man` manpage for the `alacritty msg` subcommand
+
 ### Added
 
 - Option `colors.transparent_background_colors` to allow applying opacity to all background colors

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -310,6 +310,7 @@ Installing the manual page requires the additional dependency `gzip`.
 ```sh
 sudo mkdir -p /usr/local/share/man/man1
 gzip -c extra/alacritty.man | sudo tee /usr/local/share/man/man1/alacritty.1.gz > /dev/null
+gzip -c extra/alacritty-msg.man | sudo tee /usr/local/share/man/man1/alacritty-msg.1.gz > /dev/null
 ```
 
 ### Shell completions

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TARGET = alacritty
 ASSETS_DIR = extra
 RELEASE_DIR = target/release
 MANPAGE = $(ASSETS_DIR)/alacritty.man
+MANPAGE-MSG = $(ASSETS_DIR)/alacritty-msg.man
 TERMINFO = $(ASSETS_DIR)/alacritty.info
 COMPLETIONS_DIR = $(ASSETS_DIR)/completions
 COMPLETIONS = $(COMPLETIONS_DIR)/_alacritty \
@@ -45,6 +46,7 @@ $(APP_NAME)-%: $(TARGET)-%
 	@mkdir -p $(APP_EXTRAS_DIR)
 	@mkdir -p $(APP_COMPLETIONS_DIR)
 	@gzip -c $(MANPAGE) > $(APP_EXTRAS_DIR)/alacritty.1.gz
+	@gzip -c $(MANPAGE-MSG) > $(APP_EXTRAS_DIR)/alacritty-msg.1.gz
 	@tic -xe alacritty,alacritty-direct -o $(APP_EXTRAS_DIR) $(TERMINFO)
 	@cp -fRp $(APP_TEMPLATE) $(APP_DIR)
 	@cp -fp $(APP_BINARY) $(APP_BINARY_DIR)


### PR DESCRIPTION
The original multiwindow PR added a new manpage, however this was not
properly documented or included in our CI. This patch resolves these
issues.