### PR TITLE
Update signal-hook to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "signal-hook",
+ "signal-hook-mio",
  "unicode-width",
  "vte",
  "winapi 0.3.9",
@@ -1014,6 +1015,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,13 +1497,24 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
 dependencies = [
  "libc",
  "mio",
- "signal-hook-registry",
+ "mio-uds",
+ "signal-hook",
 ]
 
 [[package]]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -29,7 +29,8 @@ dirs = "3.0.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.22.0"
-signal-hook = { version = "0.1", features = ["mio-support"] }
+signal-hook = "0.3.10"
+signal-hook-mio = { version = "0.2.1", features = ["support-v0_6"] }
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.3"

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -18,8 +18,8 @@ use mio::unix::EventedFd;
 use nix::pty::openpty;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use nix::sys::termios::{self, InputFlags, SetArg};
-use signal_hook as sighook;
-use signal_hook::iterator::Signals;
+use signal_hook::consts as sigconsts;
+use signal_hook_mio::v0_6::Signals;
 
 use crate::config::{Config, Program};
 use crate::event::OnResize;
@@ -218,7 +218,7 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, window_id: Option<usize>) -> 
     }
 
     // Prepare signal handling before spawning child.
-    let signals = Signals::new(&[sighook::SIGCHLD]).expect("error preparing signal handling");
+    let signals = Signals::new(&[sigconsts::SIGCHLD]).expect("error preparing signal handling");
 
     match builder.spawn() {
         Ok(child) => {
@@ -328,7 +328,7 @@ impl EventedPty for Pty {
     #[inline]
     fn next_child_event(&mut self) -> Option<ChildEvent> {
         self.signals.pending().next().and_then(|signal| {
-            if signal != sighook::SIGCHLD {
+            if signal != sigconsts::SIGCHLD {
                 return None;
             }
 


### PR DESCRIPTION
This adds an additional dependency on signal-hook-mio, since signal-hook has split it into a separate crate.

---
My impetus for creating this PR is to aid in Debian's packaging of alacritty.  We've recently bumped from futures 0.1 to 0.3 which, bubbling up through various dependencies, requires updating signal-hook to a newer version.