### PR TITLE
Pass current working directory to Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reload configuration files when their symbolic link is replaced
 - Strip trailing whitespaces when yanking from a block selection
 - Display area keeps history position when viewport is cleared
+- Commands spawn from the current directory of the parent alacritty instance in Unix-like systems
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reload configuration files when their symbolic link is replaced
 - Strip trailing whitespaces when yanking from a block selection
 - Display area keeps history position when viewport is cleared
-- Commands spawn from the current directory of the parent alacritty instance in Unix-like systems
+- Commands spawn from the current directory of the foreground shell in Unix-like systems
 
 ### Fixed
 

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -1,6 +1,4 @@
 #[cfg(not(windows))]
-use alacritty_terminal::tty;
-#[cfg(not(windows))]
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt::Debug;
@@ -17,6 +15,12 @@ use std::process::{Command, Stdio};
 use log::{debug, warn};
 #[cfg(windows)]
 use winapi::um::winbase::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
+
+#[cfg(not(windows))]
+use alacritty_terminal::tty;
+
+#[cfg(target_os = "macos")]
+use crate::macos;
 
 /// Start the daemon and log error on failure.
 pub fn start_daemon<I, S>(program: &str, args: I)

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -2,9 +2,9 @@
 use alacritty_terminal::tty;
 use std::ffi::OsStr;
 use std::fmt::Debug;
-use std::io;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::fs;
+use std::io;
 #[cfg(not(windows))]
 use std::os::unix::process::CommandExt;
 #[cfg(windows)]

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -1,5 +1,6 @@
 #[cfg(not(windows))]
 use alacritty_terminal::tty;
+#[cfg(not(windows))]
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt::Debug;
@@ -78,14 +79,13 @@ where
     S: AsRef<OsStr>,
 {
     let mut command = Command::new(program);
-    let mut command_builder = command.args(args);
+    let mut builder = command.args(args);
     if let Ok(cwd) = foreground_process_path() {
-        command_builder.current_dir(cwd);
+        builder.current_dir(cwd);
     }
-    command_builder =
-        command_builder.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    builder = builder.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
     unsafe {
-        command_builder
+        builder
             .pre_exec(|| {
                 match libc::fork() {
                     -1 => return Err(io::Error::last_os_error()),

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -79,13 +79,12 @@ where
     S: AsRef<OsStr>,
 {
     let mut command = Command::new(program);
-    let mut builder = command.args(args);
+    command.args(args).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
     if let Ok(cwd) = foreground_process_path() {
-        builder.current_dir(cwd);
+        command.current_dir(cwd);
     }
-    builder = builder.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
     unsafe {
-        builder
+        command
             .pre_exec(|| {
                 match libc::fork() {
                     -1 => return Err(io::Error::last_os_error()),

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -9,6 +9,7 @@ use std::io;
 use std::os::unix::process::CommandExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
+#[cfg(not(windows))]
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -49,7 +49,7 @@ where
         .map(|_| ())
 }
 
-// get working directory of controlling process
+/// Get working directory of controlling process.
 #[cfg(not(windows))]
 pub fn foreground_process_path() -> Result<PathBuf, Box<dyn Error>> {
     let mut pid = unsafe { libc::tcgetpgrp(tty::master_fd()) };
@@ -65,7 +65,6 @@ pub fn foreground_process_path() -> Result<PathBuf, Box<dyn Error>> {
     #[cfg(not(target_os = "macos"))]
     let cwd = fs::read_link(link_path)?;
 
-    // this might not be a io::Result, so a Boxed dyn Error is needed
     #[cfg(target_os = "macos")]
     let cwd = macos::proc::cwd(pid)?;
 
@@ -79,10 +78,10 @@ where
     S: AsRef<OsStr>,
 {
     let mut command = Command::new(program);
-    let mut command_builder = match foreground_process_path() {
-        Ok(cwd) => command.args(args).current_dir(cwd),
-        _ => command.args(args),
-    };
+    let mut command_builder = command.args(args);
+    if let Ok(cwd) = foreground_process_path() {
+        command_builder.current_dir(cwd);
+    }
     command_builder =
         command_builder.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
     unsafe {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -35,7 +35,9 @@ use crate::cli::{Options as CliOptions, TerminalOptions as TerminalCliOptions};
 use crate::clipboard::Clipboard;
 use crate::config::ui_config::{HintAction, HintInternalAction};
 use crate::config::{self, UiConfig};
-use crate::daemon::{foreground_process_path, start_daemon};
+#[cfg(not(windows))]
+use crate::daemon::foreground_process_path;
+use crate::daemon::start_daemon;
 use crate::display::hint::HintMatch;
 use crate::display::window::Window;
 use crate::display::{self, Display};

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -356,8 +356,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         // Reuse the arguments passed to Alacritty for the new instance.
         while let Some(arg) = env_args.next() {
-            // Drop working directory from existing parameters; start_daemon()
-            // will set it to the parent alacritty instance current directory
+            // On unix, the working directory of the foreground shell is used by `start_daemon`.
             #[cfg(not(windows))]
             if arg == "--working-directory" {
                 let _ = env_args.next();
@@ -654,7 +653,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             HintAction::Command(command) => {
                 let text = self.terminal.bounds_to_string(*hint.bounds.start(), *hint.bounds.end());
                 let mut args = command.args().to_vec();
-
                 args.push(text);
                 start_daemon(command.program(), &args);
             },

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -352,9 +352,10 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         let mut env_args = env::args();
         let alacritty = env_args.next().unwrap();
 
-        let mut args: Vec<PathBuf> = Vec::new();
+        let mut args: Vec<String> = Vec::new();
 
         // Reuse the arguments passed to Alacritty for the new instance.
+        #[allow(clippy::while_let_on_iterator)]
         while let Some(arg) = env_args.next() {
             // On unix, the working directory of the foreground shell is used by `start_daemon`.
             #[cfg(not(windows))]
@@ -363,7 +364,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
                 continue;
             }
 
-            args.push(arg.into());
+            args.push(arg);
         }
 
         start_daemon(&alacritty, &args);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -358,6 +358,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         while let Some(arg) = env_args.next() {
             // Drop working directory from existing parameters; start_daemon()
             // will set it to the parent alacritty instance current directory
+            #[cfg(not(windows))]
             if arg == "--working-directory" {
                 let _ = env_args.next();
                 continue;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -354,12 +354,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         let mut args: Vec<PathBuf> = Vec::new();
 
-        let working_directory_set = !args.is_empty();
-
         // Reuse the arguments passed to Alacritty for the new instance.
         while let Some(arg) = env_args.next() {
-            // Drop working directory from existing parameters.
-            if working_directory_set && arg == "--working-directory" {
+            // Drop working directory from existing parameters; start_daemon()
+            // will set it to the parent alacritty instance current directory
+            if arg == "--working-directory" {
                 let _ = env_args.next();
                 continue;
             }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -42,8 +42,6 @@ use crate::display::hint::HintMatch;
 use crate::display::window::Window;
 use crate::display::{self, Display};
 use crate::input::{self, ActionContext as _, FONT_SIZE_STEP};
-#[cfg(target_os = "macos")]
-use crate::macos;
 use crate::message_bar::{Message, MessageBuffer};
 use crate::scheduler::{Scheduler, TimerId, Topic};
 use crate::window_context::WindowContext;


### PR DESCRIPTION
Would implement #5616 

### Description
Commands are spawned setting the current working directory to the one of the parent alacritty instance.

### Implementation
Pass the current working directory of the running alacritty instance to [Command::current_dir](https://doc.rust-lang.org/std/process/struct.Command.html#method.current_dir). Only works on Unix-like systems.