### PR TITLE
Implement just_frame visual bell mode

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -346,6 +346,9 @@
   #   - Linear
   #animation: EaseOutExpo
 
+  # Whether the visual bell should flash the entire window, or just the outer edges.
+  #just_frame: false
+
   # Duration of the visual bell flash in milliseconds. A `duration` of `0` will
   # disable the visual bell animation.
   #duration: 0

--- a/alacritty/src/config/bell.rs
+++ b/alacritty/src/config/bell.rs
@@ -10,6 +10,9 @@ pub struct BellConfig {
     /// Visual bell animation function.
     pub animation: BellAnimation,
 
+    /// Flash entire window, or just the outer frame.
+    pub just_frame: bool,
+
     /// Command to run on bell.
     pub command: Option<Program>,
 
@@ -25,6 +28,7 @@ impl Default for BellConfig {
         Self {
             color: Rgb { r: 255, g: 255, b: 255 },
             animation: Default::default(),
+            just_frame: Default::default(),
             command: Default::default(),
             duration: Default::default(),
         }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -567,15 +567,51 @@ impl Display {
         // Push visual bell after url/underline/strikeout rects.
         let visual_bell_intensity = self.visual_bell.intensity();
         if visual_bell_intensity != 0. {
-            let visual_bell_rect = RenderRect::new(
-                0.,
-                0.,
-                size_info.width(),
-                size_info.height(),
-                config.ui_config.bell.color,
-                visual_bell_intensity as f32,
-            );
-            rects.push(visual_bell_rect);
+            if config.ui_config.bell.just_frame {
+                rects.extend_from_slice(&[
+                    RenderRect::new(
+                        0.,
+                        0.,
+                        size_info.cell_width(),
+                        size_info.height(),
+                        config.ui_config.bell.color,
+                        visual_bell_intensity as f32,
+                    ),
+                    RenderRect::new(
+                        size_info.width() - size_info.cell_width(),
+                        0.,
+                        size_info.cell_width(),
+                        size_info.height(),
+                        config.ui_config.bell.color,
+                        visual_bell_intensity as f32,
+                    ),
+                    RenderRect::new(
+                        size_info.cell_width(),
+                        0.,
+                        size_info.width() - size_info.cell_width() * 2.0,
+                        size_info.cell_height(),
+                        config.ui_config.bell.color,
+                        visual_bell_intensity as f32,
+                    ),
+                    RenderRect::new(
+                        size_info.cell_width(),
+                        size_info.height() - size_info.cell_height(),
+                        size_info.width() - size_info.cell_width() * 2.0,
+                        size_info.cell_height(),
+                        config.ui_config.bell.color,
+                        visual_bell_intensity as f32,
+                    ),
+                ]);
+            } else {
+                rects.push(RenderRect::new(
+                    0.,
+                    0.,
+                    size_info.width(),
+                    size_info.height(),
+                    config.ui_config.bell.color,
+                    visual_bell_intensity as f32,
+                ));
+            }
         }
 
         if let Some(message) = message_buffer.message() {


### PR DESCRIPTION
Having the entire screen flash for the visual bell can be very distracting, but clearly tells the user when a bell event occurs. I think flashing the outermost ring of characters gets the best of both worlds, being both clear and not nearly as visually distracting.