### PR TITLE
Add install.yml spec file

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -1,0 +1,32 @@
+rinstall: 0.1.0
+pkgs:
+  alacritty:
+    type: rust
+    exe:
+      - alacritty
+    man:
+      - src: extra/alacritty.man
+        dst: alacritty.1
+    completions:
+      bash:
+        - extra/completions/alacritty.bash
+      fish:
+        - extra/completions/alacritty.fish
+      zsh:
+        - extra/completions/_alacritty
+    user-config:
+      - src: alacritty.yml
+        dst: alacritty/
+    docs:
+      - src: alacritty.yml
+        dst: example/
+    appstream-metadata:
+      - extra/linux/io.alacritty.Alacritty.appdata.xml
+    desktop-files:
+      - extra/linux/Alacritty.desktop
+    icons:
+      - src: extra/logo/alacritty-term.svg
+        dst: Alacritty.svg
+        pixmaps: true
+    terminfo:
+      - extra/alacritty.info


### PR DESCRIPTION
Hi there! I am making an effort to improve the current installation phase of rust programs on Linux. As you can see in the [arch linux alacritty package](https://github.com/archlinux/svntogit-community/blob/packages/alacritty/trunk/PKGBUILD#L33), all the files are installed manually. I developed a project called [_rinstall_](https://github.com/danyspin97/rinstall) that replace those lines. My goal is to deduplicate the effort of packagers by adding this `install.yml` file and call _rinstall_ when packaging alacritty.

Feel free to close this issue if you think it is out of scope from this project. Also feel free to raise any concern about _rinstall_ and I'd gladly cover those.

Regardless, thank you from this awesome software that I have been using daily since I've discovered it.