### PR TITLE
Added option to clip low line scroll deltas to 1.0

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -107,6 +107,10 @@
   # Scrolling distance multiplier.
   #multiplier: 3
 
+  # If this is `true`, each scroll wheel "step" will scroll at least 1 line.
+  # Useful if a system uses fractional scrolling.
+  #notched_scroll_wheel: false
+
 # Font configuration
 #font:
   # Normal (roman) font face

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -605,7 +605,10 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
     pub fn mouse_wheel_input(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
         match delta {
-            MouseScrollDelta::LineDelta(_columns, lines) => {
+            MouseScrollDelta::LineDelta(_columns, mut lines) => {
+                if self.ctx.config().terminal_config.scrolling.notched_scroll_wheel {
+                    lines = lines.abs().max(1.).copysign(lines);
+                }
                 let new_scroll_px = lines * self.ctx.size_info().cell_height();
                 self.scroll_terminal(f64::from(new_scroll_px));
             },

--- a/alacritty_terminal/src/config/scrolling.rs
+++ b/alacritty_terminal/src/config/scrolling.rs
@@ -10,13 +10,14 @@ const MAX_SCROLLBACK_LINES: u32 = 100_000;
 #[derive(ConfigDeserialize, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Scrolling {
     pub multiplier: u8,
+    pub notched_scroll_wheel: bool,
 
     history: ScrollingHistory,
 }
 
 impl Default for Scrolling {
     fn default() -> Self {
-        Self { multiplier: 3, history: Default::default() }
+        Self { multiplier: 3, notched_scroll_wheel: false, history: Default::default() }
     }
 }
 


### PR DESCRIPTION
I've called this `notched_scroll_wheel` for now, but hopefully a better name will come up.

This option would enable the user to force each "step" from a scroll wheel to scroll the terminal at least one line.

This is useful for machines with fractional line scroll deltas which can sometimes be below 1.0. Although Alacritty already accumulates fractional scrolls, some may prefer to simply coerce low scroll deltas up to a line.

This option approximates the behavior of Terminal.app and iTerm2 on Mac.