### PR TITLE
Add reference to alacritty.yml file in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ following locations:
 3. `$HOME/.config/alacritty/alacritty.yml`
 4. `$HOME/.alacritty.yml`
 
+Would you like to know more? Check project's [alacritty.yml](alacritty.yml).
+
 ### Windows
 
 On Windows, the config file should be located at:


### PR DESCRIPTION
Hello,

During my migration to Alacritty (thanks a lot for this project folks) I scratched my head uselessly about "Where is the configuration doc".

Now I know, but worth to avoid this for the next me :) 