### PR TITLE
Display area keeps history position when viewport is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Config option `background_opacity`, you should use `window.opacity` instead
 - Reload configuration files when their symbolic link is replaced
 - Strip trailing whitespaces when yanking from a block selection
+- Display area keeps history position when viewport is cleared
 
 ### Fixed
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -313,9 +313,6 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
         let positions = (iter.point.line.0 + 1) as usize;
         let region = Line(0)..Line(self.lines as i32);
 
-        // Reset display offset.
-        self.display_offset = 0;
-
         // Clear the viewport.
         self.scroll_up(&region, positions);
 


### PR DESCRIPTION
## Overview

This patch resolves a behavior that a vi cursor doesn't keep track of content in a scrollback buffer due to clamping the vi cursor into the viewport when viewport clear is invoked.

This is similar to #5341, but this problem is caused by viewport clear instead of new outputs to the viewport.

## Reproduction steps

Assume to run Alacritty with default configurations.

1. Create scrollback buffer(history).

```sh
$ seq $LINES
```

2. Invoke viewport clear with a little delay.

```sh
$ sleep 5; clear -x
```

3. Activate vi mode by typing `Ctrl+Shift+Space` and go to the topmost of scrollback buffer(history) by typing `g`.

4. Wait until delayed viewport clear is invoked.

Before this fix, vi cursor is clamped into a viewport.

https://user-images.githubusercontent.com/12132068/144743901-b0a78ee9-c944-4cad-bfea-397c1f60909b.mp4

After this fix, vi cursor keeps track of a line in a history.

https://user-images.githubusercontent.com/12132068/144743925-6fc3cf7a-43c9-4eda-9cff-71e058dca039.mp4