### PR TITLE
Fix scrolling variables type documentation

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -102,10 +102,10 @@
 #scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.
-  #history: 10000
+  #history: "10000"
 
   # Scrolling distance multiplier.
-  #multiplier: 3
+  #multiplier: "3"
 
 # Font configuration
 #font:


### PR DESCRIPTION
This fixes the following error when the buffer line is uncommented:
```
    [ERROR] See log at /tmp/Alacritty-79411.log ($ALACRITTY_LOG):
    Config error: env: invalid type: integer `100000`, expected a string
```