### PR TITLE
Support for Font Ligatures using harfbuzz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "fnv",
  "gl_generator",
  "glutin",
+ "harfbuzz_rs",
  "libc",
  "log",
  "notify",
@@ -359,9 +360,8 @@ dependencies = [
 
 [[package]]
 name = "crossfont"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1299695a4c6417b7e4a6957bd963478406e148b7b0351e2f2ce31296b0518251"
+version = "0.3.1"
+source = "git+https://github.com/fee1-dead/crossfont#dbf0fc720f75918e56c7d8b14fd42bf40b159ede"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.2",
@@ -573,6 +573,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855"
 
 [[package]]
+name = "freetype"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee38378a9e3db1cc693b4f88d166ae375338a0ff75cb8263e1c601d51f35dc6"
+dependencies = [
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
 name = "freetype-rs"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +731,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5951a1569dbab865c6f2a863efafff193a93caf05538d193e9e3816d21696"
 dependencies = [
  "gl_generator",
+]
+
+[[package]]
+name = "harfbuzz-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8c27ca13930dc4ffe474880040fe9e0f03c2121600dc9c95423624cab3e467"
+dependencies = [
+ "cc",
+ "core-graphics 0.22.3",
+ "core-text",
+ "foreign-types 0.3.2",
+ "freetype",
+ "pkg-config",
+]
+
+[[package]]
+name = "harfbuzz_rs"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c18cfc23920d010f7637b86240a5f8892dfdbcb4f0e60828f8a9dc6ff5521d"
+dependencies = [
+ "bitflags",
+ "harfbuzz-sys",
 ]
 
 [[package]]

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -28,12 +28,13 @@ serde_json = "1"
 glutin = { version = "0.28.0", default-features = false, features = ["serde"] }
 notify = "4"
 parking_lot = "0.11.0"
-crossfont = { version = "0.3.1", features = ["force_system_fontconfig"] }
+crossfont = { git = "https://github.com/fee1-dead/crossfont", features = ["force_system_fontconfig"] }
 copypasta = { version = "0.7.0", default-features = false }
 libc = "0.2"
 unicode-width = "0.1"
 bitflags = "1"
 dirs = "3.0.1"
+harfbuzz_rs = "2.0.1"
 
 [dev-dependencies]
 clap = "2.33.3"

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -14,7 +14,7 @@ use crate::config::ui_config::Delta;
 /// field in this struct. It might be nice in the future to have defaults for
 /// each value independently. Alternatively, maybe erroring when the user
 /// doesn't provide complete config is Ok.
-#[derive(ConfigDeserialize, Default, Debug, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Font {
     /// Extra spacing per character.
     pub offset: Delta<i8>,
@@ -23,6 +23,8 @@ pub struct Font {
     pub glyph_offset: Delta<i8>,
 
     pub use_thin_strokes: bool,
+
+    pub ligatures: bool,
 
     /// Normal font face.
     normal: FontDescription,
@@ -69,6 +71,22 @@ impl Font {
     /// Get bold italic font description.
     pub fn bold_italic(&self) -> FontDescription {
         self.bold_italic.desc(&self.normal)
+    }
+}
+
+impl Default for Font {
+    fn default() -> Self {
+        Self {
+            offset: Default::default(),
+            glyph_offset: Default::default(),
+            use_thin_strokes: false,
+            ligatures: true,
+            normal: Default::default(),
+            bold: Default::default(),
+            italic: Default::default(),
+            bold_italic: Default::default(),
+            size: Default::default(),
+        }
     }
 }
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -45,8 +45,9 @@ use crate::display::meter::Meter;
 use crate::display::window::Window;
 use crate::event::{Mouse, SearchState};
 use crate::message_bar::{MessageBuffer, MessageType};
-use crate::renderer::rects::{RenderLines, RenderRect};
+use crate::renderer::rects::RenderRect;
 use crate::renderer::{self, GlyphCache, QuadRenderer};
+use crate::text_run::{TextRun, TextRunIter};
 
 pub mod content;
 pub mod cursor;
@@ -357,8 +358,8 @@ impl Display {
             info!("Initializing glyph cache...");
             let init_start = Instant::now();
 
-            let cache =
-                renderer.with_loader(|mut api| GlyphCache::new(rasterizer, &font, &mut api))?;
+            let cache = renderer
+                .with_loader(|mut api| GlyphCache::new(rasterizer, &font, &mut api, config))?;
 
             let stop = init_start.elapsed();
             let stop_f = stop.as_secs() as f64 + f64::from(stop.subsec_nanos()) / 1_000_000_000f64;
@@ -479,14 +480,16 @@ impl Display {
         config: &UiConfig,
         search_state: &SearchState,
     ) {
+        let highlighted_hint = self.highlighted_hint.as_ref().map(|m| m.bounds.clone());
+        let vi_highlighted_hint = self.vi_highlighted_hint.as_ref().map(|m| m.bounds.clone());
         // Collect renderable content before the terminal is dropped.
         let mut content = RenderableContent::new(config, self, &terminal, search_state);
-        let mut grid_cells = Vec::new();
-        for cell in &mut content {
-            grid_cells.push(cell);
-        }
         let background_color = content.color(NamedColor::Background as usize);
         let display_offset = content.display_offset();
+        let grid_text_runs: Vec<TextRun> = {
+            TextRunIter::<()>::from_content(&mut content, highlighted_hint, vi_highlighted_hint)
+                .collect()
+        };
         let cursor = content.cursor();
 
         let cursor_point = terminal.grid().cursor.point;
@@ -507,7 +510,7 @@ impl Display {
             api.clear(background_color);
         });
 
-        let mut lines = RenderLines::new();
+        let mut rects: Vec<RenderRect> = Vec::new();
 
         // Draw grid.
         {
@@ -518,29 +521,37 @@ impl Display {
             self.renderer.set_viewport(&size_info);
 
             let glyph_cache = &mut self.glyph_cache;
-            let highlighted_hint = &self.highlighted_hint;
-            let vi_highlighted_hint = &self.vi_highlighted_hint;
+
             self.renderer.with_api(config, &size_info, |mut api| {
-                // Iterate over all non-empty cells in the grid.
-                for mut cell in grid_cells {
-                    // Underline hints hovered by mouse or vi mode cursor.
-                    let point = viewport_to_point(display_offset, cell.point);
-                    if highlighted_hint.as_ref().map_or(false, |h| h.bounds.contains(&point))
-                        || vi_highlighted_hint.as_ref().map_or(false, |h| h.bounds.contains(&point))
-                    {
-                        cell.flags.insert(Flags::UNDERLINE);
+                for text_run in grid_text_runs {
+                    if text_run.flags.contains(Flags::UNDERLINE) {
+                        let underline_metrics = (
+                            metrics.descent,
+                            metrics.underline_position,
+                            metrics.underline_thickness,
+                        );
+                        rects.push(RenderRect::from_text_run(
+                            &text_run,
+                            underline_metrics,
+                            &size_info,
+                        ));
                     }
-
-                    // Update underline/strikeout.
-                    lines.update(&cell);
-
-                    // Draw the cell.
-                    api.render_cell(cell, glyph_cache);
+                    if text_run.flags.contains(Flags::STRIKEOUT) {
+                        let strikeout_metrics = (
+                            metrics.descent,
+                            metrics.strikeout_position,
+                            metrics.strikeout_thickness,
+                        );
+                        rects.push(RenderRect::from_text_run(
+                            &text_run,
+                            strikeout_metrics,
+                            &size_info,
+                        ));
+                    }
+                    api.render_text_run(text_run, glyph_cache);
                 }
             });
         }
-
-        let mut rects = lines.rects(&metrics, &size_info);
 
         if let Some(vi_mode_cursor) = vi_mode_cursor {
             // Indicate vi mode by showing the cursor's position in the top right corner.

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -487,8 +487,13 @@ impl Display {
         let background_color = content.color(NamedColor::Background as usize);
         let display_offset = content.display_offset();
         let grid_text_runs: Vec<TextRun> = {
-            TextRunIter::<()>::from_content(&mut content, highlighted_hint, vi_highlighted_hint)
-                .collect()
+            let mut vec = Vec::with_capacity(terminal.screen_lines() * 2);
+            vec.extend(TextRunIter::from_content(
+                &mut content,
+                highlighted_hint,
+                vi_highlighted_hint,
+            ));
+            vec
         };
         let cursor = content.cursor();
 

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -43,6 +43,7 @@ mod message_bar;
 mod panic;
 mod renderer;
 mod scheduler;
+mod text_run;
 mod window_context;
 
 mod gl {

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -954,8 +954,6 @@ impl<'a> RenderApi<'a> {
     }
 
     pub fn render_text_run(&mut self, text_run: TextRun, glyph_cache: &mut GlyphCache) {
-        let TextRunContent { text, zero_widths } = &text_run.content;
-
         // Get font key for cell
         let font_key = Self::determine_font_key(text_run.flags, glyph_cache);
 
@@ -963,12 +961,15 @@ impl<'a> RenderApi<'a> {
             GlyphIter::Hidden
         } else {
             GlyphIter::Shaped(
-                glyph_cache.shape_run(text, font_key, self).expect("read font").into_iter(),
+                glyph_cache
+                    .shape_run(&text_run.content.text, font_key, self)
+                    .expect("read font")
+                    .into_iter(),
             )
         };
 
         for ((mut cell, glyph), zero_width_chars) in
-            text_run.cells().zip(shaped_glyphs).zip(zero_widths.iter())
+            text_run.cells().zip(shaped_glyphs).zip(text_run.content.zero_widths.iter())
         {
             self.add_render_item(&cell, &glyph);
             // Add empty spacer for full width characters

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 use std::hash::BuildHasherDefault;
@@ -6,10 +7,11 @@ use std::{io, ptr};
 
 use bitflags::bitflags;
 use crossfont::{
-    BitmapBuffer, Error as RasterizerError, FontDesc, FontKey, GlyphKey, Rasterize,
+    BitmapBuffer, Error as RasterizerError, FontDesc, FontKey, GlyphId, GlyphKey, Rasterize,
     RasterizedGlyph, Rasterizer, Size, Slant, Style, Weight,
 };
 use fnv::FnvHasher;
+use harfbuzz_rs::{Feature, Owned, UnicodeBuffer};
 use log::{error, info};
 use unicode_width::UnicodeWidthChar;
 
@@ -24,6 +26,7 @@ use crate::display::content::RenderableCell;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::rects::{RectRenderer, RenderRect};
+use crate::text_run::{TextRun, TextRunContent};
 
 pub mod rects;
 
@@ -91,7 +94,7 @@ pub struct TextShaderProgram {
     u_background: GLint,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Glyph {
     tex_id: GLuint,
     multicolor: bool,
@@ -106,9 +109,6 @@ pub struct Glyph {
 }
 
 /// Naïve glyph cache.
-///
-/// Currently only keyed by `char`, and thus not possible to hold different
-/// representations of the same code point.
 pub struct GlyphCache {
     /// Cache of buffered glyphs.
     cache: HashMap<GlyphKey, Glyph, BuildHasherDefault<FnvHasher>>,
@@ -136,6 +136,11 @@ pub struct GlyphCache {
 
     /// Font metrics.
     metrics: crossfont::Metrics,
+
+    /// A map of FontKey to harfbuzz Font.
+    fonts: HashMap<FontKey, Owned<harfbuzz_rs::Font<'static>>, BuildHasherDefault<FnvHasher>>,
+
+    font_features: Box<[Feature]>,
 }
 
 impl GlyphCache {
@@ -143,6 +148,7 @@ impl GlyphCache {
         mut rasterizer: Rasterizer,
         font: &Font,
         loader: &mut L,
+        config: &UiConfig,
     ) -> Result<GlyphCache, crossfont::Error>
     where
         L: LoadGlyph,
@@ -152,9 +158,19 @@ impl GlyphCache {
         // Need to load at least one glyph for the face before calling metrics.
         // The glyph requested here ('m' at the time of writing) has no special
         // meaning.
-        rasterizer.get_glyph(GlyphKey { font_key: regular, character: 'm', size: font.size() })?;
+        rasterizer.get_glyph(GlyphKey {
+            font_key: regular,
+            id: GlyphId::char('m'),
+            size: font.size(),
+        })?;
 
         let metrics = rasterizer.metrics(regular, font.size())?;
+
+        let features: Box<[Feature]> = if config.font.ligatures {
+            Box::new([Feature::new(b"liga", 1, ..), Feature::new(b"calt", 1, ..)])
+        } else {
+            Box::new([])
+        };
 
         let mut cache = Self {
             cache: HashMap::default(),
@@ -166,6 +182,8 @@ impl GlyphCache {
             bold_italic_key: bold_italic,
             glyph_offset: font.glyph_offset,
             metrics,
+            fonts: HashMap::default(),
+            font_features: features,
         };
 
         cache.load_common_glyphs(loader);
@@ -178,7 +196,7 @@ impl GlyphCache {
 
         // Cache all ascii characters.
         for i in 32u8..=126u8 {
-            self.get(GlyphKey { font_key: font, character: i as char, size }, loader, true);
+            self.get(GlyphKey { font_key: font, id: GlyphId::char(i as char), size }, loader, true);
         }
     }
 
@@ -247,6 +265,46 @@ impl GlyphCache {
         FontDesc::new(desc.family.clone(), style)
     }
 
+    pub fn shape_run<L>(
+        &mut self,
+        text_run: &str,
+        font_key: FontKey,
+        loader: &mut L,
+    ) -> Result<Vec<Glyph>, Box<dyn std::error::Error>>
+    where
+        L: LoadGlyph,
+    {
+        if let Entry::Vacant(v) = self.fonts.entry(font_key) {
+            let path = self.rasterizer.font_path(font_key)?;
+            let face = harfbuzz_rs::Face::from_file(path, 0)?;
+            let font = harfbuzz_rs::Font::new(face);
+            v.insert(font);
+        };
+
+        let font = self.fonts.get(&font_key).unwrap();
+        let buffer = UnicodeBuffer::new().add_str(text_run);
+        let result = harfbuzz_rs::shape(font, buffer, &self.font_features);
+        Ok(result
+            .get_glyph_infos()
+            .iter()
+            .map(move |glyph_info| {
+                let codepoint = glyph_info.codepoint;
+
+                // Codepoint of 0 indicates a missing or undefined glyph
+                let id: crossfont::GlyphId = if codepoint == 0 {
+                    GlyphId::char(
+                        text_run.split_at(glyph_info.cluster as usize).1.chars().next().unwrap(),
+                    )
+                } else {
+                    GlyphId::with_glyph_index(codepoint as u32)
+                };
+
+                let glyph_key = GlyphKey { id, font_key, size: self.font_size };
+                self.get(glyph_key, loader, true)
+            })
+            .collect())
+    }
+
     /// Get a glyph from the font.
     ///
     /// If the glyph has never been loaded before, it will be rasterized and inserted into the
@@ -270,8 +328,7 @@ impl GlyphCache {
             Ok(rasterized) => self.load_glyph(loader, rasterized),
             // Load fallback glyph.
             Err(RasterizerError::MissingGlyph(rasterized)) if show_missing => {
-                // Use `\0` as "missing" glyph to cache it only once.
-                let missing_key = GlyphKey { character: '\0', ..glyph_key };
+                let missing_key = GlyphKey { id: GlyphId::placeholder(), ..glyph_key };
                 if let Some(glyph) = self.cache.get(&missing_key) {
                     *glyph
                 } else {
@@ -306,7 +363,7 @@ impl GlyphCache {
         // right side of the preceding character. Since we render the
         // zero-width characters inside the preceding character, the
         // anchor has been moved to the right by one cell.
-        if glyph.character.width() == Some(0) {
+        if glyph.id.as_char().map(|c| c.width()).flatten() == Some(0) {
             glyph.left += self.metrics.average_advance as i32;
         }
 
@@ -337,7 +394,7 @@ impl GlyphCache {
 
         self.rasterizer.get_glyph(GlyphKey {
             font_key: regular,
-            character: 'm',
+            id: GlyphId::char('m'),
             size: font.size(),
         })?;
         let metrics = self.rasterizer.metrics(regular, font.size())?;
@@ -373,7 +430,11 @@ impl GlyphCache {
         let mut rasterizer = crossfont::Rasterizer::new(dpr as f32, font.use_thin_strokes)?;
         let regular_desc = GlyphCache::make_desc(font.normal(), Slant::Normal, Weight::Normal);
         let regular = Self::load_regular_font(&mut rasterizer, &regular_desc, font.size())?;
-        rasterizer.get_glyph(GlyphKey { font_key: regular, character: 'm', size: font.size() })?;
+        rasterizer.get_glyph(GlyphKey {
+            font_key: regular,
+            id: GlyphId::char('m'),
+            size: font.size(),
+        })?;
 
         rasterizer.metrics(regular, font.size())
     }
@@ -837,23 +898,16 @@ impl<'a> RenderApi<'a> {
         bg: Rgb,
         string: &str,
     ) {
-        let cells = string
-            .chars()
-            .enumerate()
-            .map(|(i, character)| RenderableCell {
-                point: Point::new(point.line, point.column + i),
-                character,
-                zerowidth: None,
-                flags: Flags::empty(),
-                bg_alpha: 1.0,
-                fg,
-                bg,
-            })
-            .collect::<Vec<_>>();
-
-        for cell in cells {
-            self.render_cell(cell, glyph_cache);
-        }
+        let text_run = TextRun {
+            line: point.line,
+            span: (point.column, point.column + string.chars().count() - 1),
+            content: TextRunContent { text: string.to_owned(), zero_widths: Vec::new() },
+            fg,
+            bg,
+            bg_alpha: 1.0,
+            flags: Flags::empty(),
+        };
+        self.render_text_run(text_run, glyph_cache);
     }
 
     #[inline]
@@ -871,35 +925,86 @@ impl<'a> RenderApi<'a> {
         }
     }
 
-    pub fn render_cell(&mut self, mut cell: RenderableCell, glyph_cache: &mut GlyphCache) {
-        // Get font key for cell.
-        let font_key = match cell.flags & Flags::BOLD_ITALIC {
+    fn determine_font_key(flags: Flags, glyph_cache: &GlyphCache) -> FontKey {
+        // FIXME this is super inefficient.
+        match flags & Flags::BOLD_ITALIC {
             Flags::BOLD_ITALIC => glyph_cache.bold_italic_key,
-            Flags::ITALIC => glyph_cache.italic_key,
             Flags::BOLD => glyph_cache.bold_key,
+            Flags::ITALIC => glyph_cache.italic_key,
             _ => glyph_cache.font_key,
+        }
+    }
+
+    fn render_zero_widths<'r, I>(
+        &mut self,
+        zero_width_chars: I,
+        cell: &RenderableCell,
+        font_key: FontKey,
+        glyph_cache: &mut GlyphCache,
+    ) where
+        I: Iterator<Item = &'r char>,
+    {
+        for c in zero_width_chars {
+            let glyph_key =
+                GlyphKey { font_key, size: glyph_cache.font_size, id: GlyphId::char(*c) };
+            let glyph = glyph_cache.get(glyph_key, self, false);
+
+            self.add_render_item(cell, &glyph);
+        }
+    }
+
+    pub fn render_text_run(&mut self, text_run: TextRun, glyph_cache: &mut GlyphCache) {
+        let TextRunContent { text, zero_widths } = &text_run.content;
+
+        // Get font key for cell
+        let font_key = Self::determine_font_key(text_run.flags, glyph_cache);
+
+        let shaped_glyphs = if text_run.flags.contains(Flags::HIDDEN) {
+            GlyphIter::Hidden
+        } else {
+            GlyphIter::Shaped(
+                glyph_cache.shape_run(text, font_key, self).expect("read font").into_iter(),
+            )
         };
 
-        // Ignore hidden cells and render tabs as spaces to prevent font issues.
-        let hidden = cell.flags.contains(Flags::HIDDEN);
-        if cell.character == '\t' || hidden {
-            cell.character = ' ';
-        }
-
-        let mut glyph_key =
-            GlyphKey { font_key, size: glyph_cache.font_size, character: cell.character };
-
-        // Add cell to batch.
-        let glyph = glyph_cache.get(glyph_key, self, true);
-        self.add_render_item(&cell, &glyph);
-
-        // Render visible zero-width characters.
-        if let Some(zerowidth) = cell.zerowidth.take().filter(|_| !hidden) {
-            for character in zerowidth {
-                glyph_key.character = character;
-                let glyph = glyph_cache.get(glyph_key, self, false);
-                self.add_render_item(&cell, &glyph);
+        for ((mut cell, glyph), zero_width_chars) in
+            text_run.cells().zip(shaped_glyphs).zip(zero_widths.iter())
+        {
+            self.add_render_item(&cell, &glyph);
+            // Add empty spacer for full width characters
+            if text_run.flags.contains(Flags::WIDE_CHAR) {
+                cell.point.column += 1;
+                self.add_render_item(&cell, &Glyph::default());
+                cell.point.column -= 1;
             }
+            self.render_zero_widths(
+                zero_width_chars.as_deref().unwrap_or(&[]).iter().filter(|c| **c != ' '),
+                &cell,
+                font_key,
+                glyph_cache,
+            );
+        }
+    }
+}
+
+/// Abstracts iteration over a run of hidden glyphs or shaped glyphs.
+enum GlyphIter<I> {
+    /// Our run was not hidden and our glyphs were shaped
+    Shaped(I),
+    /// Our run is hidden and was not shaped
+    Hidden,
+}
+
+impl<I> Iterator for GlyphIter<I>
+where
+    I: Iterator<Item = Glyph>,
+{
+    type Item = Glyph;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            GlyphIter::Shaped(inner) => inner.next(),
+            GlyphIter::Hidden => Some(Glyph::default()),
         }
     }
 }

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -1,16 +1,10 @@
-use std::collections::HashMap;
 use std::mem;
 
-use crossfont::Metrics;
-
-use alacritty_terminal::grid::Dimensions;
-use alacritty_terminal::index::{Column, Point};
-use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::color::Rgb;
 use alacritty_terminal::term::SizeInfo;
 
-use crate::display::content::RenderableCell;
 use crate::gl::types::*;
+use crate::text_run::TextRun;
 use crate::{gl, renderer};
 
 #[derive(Debug, Copy, Clone)]
@@ -27,173 +21,31 @@ impl RenderRect {
     pub fn new(x: f32, y: f32, width: f32, height: f32, color: Rgb, alpha: f32) -> Self {
         RenderRect { x, y, width, height, color, alpha }
     }
-}
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct RenderLine {
-    pub start: Point<usize>,
-    pub end: Point<usize>,
-    pub color: Rgb,
-}
-
-impl RenderLine {
-    pub fn rects(&self, flag: Flags, metrics: &Metrics, size: &SizeInfo) -> Vec<RenderRect> {
-        let mut rects = Vec::new();
-
-        let mut start = self.start;
-        while start.line < self.end.line {
-            let end = Point::new(start.line, size.last_column());
-            Self::push_rects(&mut rects, metrics, size, flag, start, end, self.color);
-            start = Point::new(start.line + 1, Column(0));
-        }
-        Self::push_rects(&mut rects, metrics, size, flag, start, self.end, self.color);
-
-        rects
-    }
-
-    /// Push all rects required to draw the cell's line.
-    fn push_rects(
-        rects: &mut Vec<RenderRect>,
-        metrics: &Metrics,
+    pub fn from_text_run(
+        text_run: &TextRun,
+        (descent, position, thickness): (f32, f32, f32),
         size: &SizeInfo,
-        flag: Flags,
-        start: Point<usize>,
-        end: Point<usize>,
-        color: Rgb,
-    ) {
-        let (position, thickness) = match flag {
-            Flags::DOUBLE_UNDERLINE => {
-                // Position underlines so each one has 50% of descent available.
-                let top_pos = 0.25 * metrics.descent;
-                let bottom_pos = 0.75 * metrics.descent;
-
-                rects.push(Self::create_rect(
-                    size,
-                    metrics.descent,
-                    start,
-                    end,
-                    top_pos,
-                    metrics.underline_thickness,
-                    color,
-                ));
-
-                (bottom_pos, metrics.underline_thickness)
-            },
-            Flags::UNDERLINE => (metrics.underline_position, metrics.underline_thickness),
-            Flags::STRIKEOUT => (metrics.strikeout_position, metrics.strikeout_thickness),
-            _ => unimplemented!("Invalid flag for cell line drawing specified"),
-        };
-
-        rects.push(Self::create_rect(
-            size,
-            metrics.descent,
-            start,
-            end,
-            position,
-            thickness,
-            color,
-        ));
-    }
-
-    /// Create a line's rect at a position relative to the baseline.
-    fn create_rect(
-        size: &SizeInfo,
-        descent: f32,
-        start: Point<usize>,
-        end: Point<usize>,
-        position: f32,
-        mut thickness: f32,
-        color: Rgb,
-    ) -> RenderRect {
-        let start_x = start.column.0 as f32 * size.cell_width();
-        let end_x = (end.column.0 + 1) as f32 * size.cell_width();
+    ) -> Self {
+        let start_point = text_run.start_point();
+        let start_x = start_point.column.0 as f32 * size.cell_width();
+        let end_x = (text_run.end_point().column.0 + 1) as f32 * size.cell_width();
         let width = end_x - start_x;
-
-        // Make sure lines are always visible.
-        thickness = thickness.max(1.);
-
-        let line_bottom = (start.line as f32 + 1.) * size.cell_height();
+        let line_bottom = (start_point.line as f32 + 1.) * size.cell_height();
         let baseline = line_bottom + descent;
-
-        let mut y = (baseline - position - thickness / 2.).ceil();
-        let max_y = line_bottom - thickness;
-        if y > max_y {
-            y = max_y;
-        }
+        let height = thickness.max(1.);
+        let mut y = baseline - position - height / 2.;
+        let max_y = line_bottom - height;
+        y = y.min(max_y);
 
         RenderRect::new(
             start_x + size.padding_x(),
             y + size.padding_y(),
             width,
-            thickness,
-            color,
+            height,
+            text_run.fg,
             1.,
         )
-    }
-}
-
-/// Lines for underline and strikeout.
-#[derive(Default)]
-pub struct RenderLines {
-    inner: HashMap<Flags, Vec<RenderLine>>,
-}
-
-impl RenderLines {
-    #[inline]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    #[inline]
-    pub fn rects(&self, metrics: &Metrics, size: &SizeInfo) -> Vec<RenderRect> {
-        self.inner
-            .iter()
-            .flat_map(|(flag, lines)| {
-                lines.iter().flat_map(move |line| line.rects(*flag, metrics, size))
-            })
-            .collect()
-    }
-
-    /// Update the stored lines with the next cell info.
-    #[inline]
-    pub fn update(&mut self, cell: &RenderableCell) {
-        self.update_flag(cell, Flags::UNDERLINE);
-        self.update_flag(cell, Flags::DOUBLE_UNDERLINE);
-        self.update_flag(cell, Flags::STRIKEOUT);
-    }
-
-    /// Update the lines for a specific flag.
-    fn update_flag(&mut self, cell: &RenderableCell, flag: Flags) {
-        if !cell.flags.contains(flag) {
-            return;
-        }
-
-        // Include wide char spacer if the current cell is a wide char.
-        let mut end = cell.point;
-        if cell.flags.contains(Flags::WIDE_CHAR) {
-            end.column += 1;
-        }
-
-        // Check if there's an active line.
-        if let Some(line) = self.inner.get_mut(&flag).and_then(|lines| lines.last_mut()) {
-            if cell.fg == line.color
-                && cell.point.column == line.end.column + 1
-                && cell.point.line == line.end.line
-            {
-                // Update the length of the line.
-                line.end = end;
-                return;
-            }
-        }
-
-        // Start new line if there currently is none.
-        let line = RenderLine { start: cell.point, end, color: cell.fg };
-        match self.inner.get_mut(&flag) {
-            Some(lines) => lines.push(line),
-            None => {
-                self.inner.insert(flag, vec![line]);
-            },
-        }
     }
 }
 

--- a/alacritty/src/text_run.rs
+++ b/alacritty/src/text_run.rs
@@ -1,3 +1,5 @@
+use std::mem::replace;
+
 use alacritty_terminal::index::{Column, Line, Point};
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::color::Rgb;
@@ -5,7 +7,7 @@ use alacritty_terminal::term::search::Match;
 
 use crate::display::content::{RenderableCell, RenderableContent};
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy)]
 struct RunStart {
     line: usize,
     column: Column,
@@ -16,14 +18,25 @@ struct RunStart {
 }
 
 impl RunStart {
+    fn new(cell: &RenderableCell) -> Self {
+        Self {
+            line: cell.point.line,
+            column: cell.point.column,
+            fg: cell.fg,
+            bg: cell.bg,
+            bg_alpha: cell.bg_alpha,
+            flags: cell.flags,
+        }
+    }
+
     /// Compare cell and check if it belongs to the same run.
     #[inline]
     fn belongs_to_text_run(&self, render_cell: &RenderableCell) -> bool {
         self.line == render_cell.point.line
             && self.fg == render_cell.fg
-            && self.bg == render_cell.bg
-            && (self.bg_alpha - render_cell.bg_alpha).abs() < std::f32::EPSILON
             && self.flags == render_cell.flags
+            && self.bg == render_cell.bg
+            && (self.bg_alpha - render_cell.bg_alpha).abs() < f32::EPSILON
     }
 }
 
@@ -80,7 +93,7 @@ impl TextRun {
         Point { line: self.line, column: self.span.1 }
     }
 
-    /// Iterates over each RenderableCell in column range [run.0, run.1]
+    /// Iterates over each RenderableCell in column range `[run.0, run.1]`
     pub fn cells(&self) -> impl Iterator<Item = RenderableCell> + '_ {
         let step = if self.flags.contains(Flags::WIDE_CHAR) { 2 } else { 1 };
         let (Column(start), Column(end)) = self.span;
@@ -89,14 +102,24 @@ impl TextRun {
     }
 }
 
-type IsWide = bool;
-type LatestCol = (Column, IsWide);
+#[derive(Default, Clone, Copy)]
+pub struct LatestCol {
+    column: Column,
+    is_wide: bool,
+}
+
+impl LatestCol {
+    #[inline]
+    fn new(cell: &RenderableCell) -> Self {
+        Self { column: cell.point.column, is_wide: cell.flags.contains(Flags::WIDE_CHAR) }
+    }
+}
 
 /// Wraps an Iterator<Item=RenderableCell> and produces TextRuns to represent batches of cells
 pub struct TextRunIter<I> {
     iter: I,
-    run_start: Option<RunStart>,
-    latest_col: Option<LatestCol>,
+    run_start: RunStart,
+    latest_col: LatestCol,
     display_offset: usize,
     hint: Option<Match>,
     vi_hint: Option<Match>,
@@ -107,12 +130,12 @@ pub struct TextRunIter<I> {
 type TextRunIterFromContent<'a, 'c> =
     TextRunIter<std::iter::Filter<&'a mut RenderableContent<'c>, fn(&RenderableCell) -> bool>>;
 
-impl<I> TextRunIter<I> {
-    pub fn from_content<'a, 'c>(
+impl<'a, 'c> TextRunIterFromContent<'a, 'c> {
+    pub fn from_content(
         content: &'a mut RenderableContent<'c>,
         hint: Option<Match>,
         vi_hint: Option<Match>,
-    ) -> TextRunIterFromContent<'a, 'c> {
+    ) -> Self {
         fn check(cell: &RenderableCell) -> bool {
             !cell.flags.contains(Flags::WIDE_CHAR_SPACER)
         }
@@ -130,41 +153,60 @@ where
     I: Iterator<Item = RenderableCell>,
 {
     pub fn new(
-        iter: I,
+        mut iter: I,
         hint: Option<Match>,
         vi_hint: Option<Match>,
         display_offset: usize,
     ) -> Self {
-        TextRunIter {
-            iter,
-            latest_col: None,
-            display_offset,
-            run_start: None,
-            buffer_text: String::new(),
-            buffer_zero_width: Vec::new(),
-            hint,
-            vi_hint,
+        if let Some(cell) = iter.next() {
+            let latest_col = LatestCol::new(&cell);
+            let run_start = RunStart::new(&cell);
+            let buffer_text = cell.character.to_string();
+            let buffer_zero_width = vec![cell.zerowidth];
+
+            TextRunIter {
+                iter,
+                run_start,
+                latest_col,
+                display_offset,
+                hint,
+                vi_hint,
+                buffer_text,
+                buffer_zero_width,
+            }
+        } else {
+            // There are no cells in the grid. This rarely happens.
+            #[cold]
+            #[inline]
+            fn dummy<I>(iter: I) -> TextRunIter<I> {
+                TextRunIter {
+                    iter,
+                    run_start: RunStart::default(),
+                    latest_col: LatestCol::default(),
+                    display_offset: 0,
+                    hint: None,
+                    vi_hint: None,
+                    buffer_text: String::new(),
+                    buffer_zero_width: Vec::new(),
+                }
+            }
+
+            dummy(iter)
         }
     }
 }
 impl<I> TextRunIter<I> {
     /// Check if the cell belongs to this text run. Returns `true` if it does not belong.
     fn cell_does_not_belong_to_run(&self, render_cell: &RenderableCell) -> bool {
-        self.run_start
-            .as_ref()
-            .map(|run_start| !run_start.belongs_to_text_run(render_cell))
-            .unwrap_or_default()
+        !self.run_start.belongs_to_text_run(render_cell)
     }
 
     /// Check if the column is not adjacent to the latest column.
-    fn is_col_not_adjacent(&self, column: Column) -> bool {
-        self.latest_col
-            .as_ref()
-            .map(|&(col, is_wide)| {
-                let width = if is_wide { 2 } else { 1 };
-                col + width != column && column + width != col
-            })
-            .unwrap_or_default()
+    fn is_col_not_adjacent(&self, col: Column) -> bool {
+        let LatestCol { column, is_wide } = self.latest_col;
+
+        let width = if is_wide { 2 } else { 1 };
+        col + width != column && column + width != col
     }
 
     /// Check if current run ends at incoming RenderableCell
@@ -184,7 +226,8 @@ impl<I> TextRunIter<I> {
     /// Empty out pending buffer producing owned collections that can be moved into a TextRun
     fn drain_buffer(&mut self) -> TextRunContent {
         use std::mem::take;
-        let text = take(&mut self.buffer_text);
+        let text = self.buffer_text.clone();
+        self.buffer_text.clear();
         let zero_widths = take(&mut self.buffer_zero_width);
 
         TextRunContent { text, zero_widths }
@@ -204,40 +247,28 @@ impl<I> TextRunIter<I> {
 
     /// Start a new run by setting latest_col, run_start, and buffering content of rc
     /// Returns the previous runs run_start and latest_col data if available.
-    fn start_run(&mut self, render_cell: RenderableCell) -> (Option<RunStart>, Option<LatestCol>) {
-        let latest = self
-            .latest_col
-            .replace((render_cell.point.column, render_cell.flags.contains(Flags::WIDE_CHAR)));
-        let start = self.run_start.replace(RunStart {
-            line: render_cell.point.line,
-            column: render_cell.point.column,
-            fg: render_cell.fg,
-            bg: render_cell.bg,
-            bg_alpha: render_cell.bg_alpha,
-            flags: render_cell.flags,
-        });
+    fn start_run(&mut self, render_cell: RenderableCell) -> (RunStart, LatestCol) {
+        let prev_start = replace(&mut self.run_start, RunStart::new(&render_cell));
+        let prev_latest = replace(&mut self.latest_col, LatestCol::new(&render_cell));
+
         self.buffer_content(render_cell);
-        (start, latest)
+
+        (prev_start, prev_latest)
     }
 
     /// Create a run of chars from the current state of the `TextRunIter`.
     /// This is a destructive operation, the iterator will be in a new run state after it's
     /// completion.
-    fn produce_char_run(&mut self, render_cell: RenderableCell) -> Option<TextRun> {
+    fn produce_char_run(&mut self, render_cell: RenderableCell) -> TextRun {
         let prev_buffer = self.drain_buffer();
-        let (start_opt, latest_col_opt) = self.start_run(render_cell);
-        let start = start_opt?;
-        let latest_col = latest_col_opt?;
-        Some(Self::build_text_run(start, latest_col, prev_buffer))
+        let (start, latest_col) = self.start_run(render_cell);
+
+        Self::build_text_run(start, latest_col, prev_buffer)
     }
 
     /// Build a TextRun instance from passed state of TextRunIter
-    fn build_text_run(
-        start: RunStart,
-        (latest, is_wide): LatestCol,
-        content: TextRunContent,
-    ) -> TextRun {
-        let end_column = if is_wide { latest + 1 } else { latest };
+    fn build_text_run(start: RunStart, latest_col: LatestCol, content: TextRunContent) -> TextRun {
+        let end_column = latest_col.column + latest_col.is_wide as usize;
         TextRun {
             line: start.line,
             span: (start.column, end_column),
@@ -257,46 +288,28 @@ where
     type Item = TextRun;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut output = None;
         while let Some(mut render_cell) = self.iter.next() {
             if self.is_hinted(render_cell.point) {
                 render_cell.flags.insert(Flags::UNDERLINE);
             }
-            if self.latest_col.is_none() || self.run_start.is_none() {
-                // Initial state, this is should only be hit on the first next() call of
-                // iterator
-
-                self.run_start = Some(RunStart {
-                    line: render_cell.point.line,
-                    column: render_cell.point.column,
-                    fg: render_cell.fg,
-                    bg: render_cell.bg,
-                    bg_alpha: render_cell.bg_alpha,
-                    flags: render_cell.flags,
-                });
-            } else if self.is_end_of_run(&render_cell) {
+            if self.is_end_of_run(&render_cell) {
                 // If we find a run break,
                 // return what we have so far and start a new run.
-                output = self.produce_char_run(render_cell);
-                break;
+                return Some(self.produce_char_run(render_cell));
             }
 
             // Build up buffer and track the latest column we've seen
-            self.latest_col =
-                Some((render_cell.point.column, render_cell.flags.contains(Flags::WIDE_CHAR)));
+            self.latest_col = LatestCol::new(&render_cell);
             self.buffer_content(render_cell);
         }
+
         // Check for any remaining buffered content and return it as a text run.
         // This is a destructive operation, it will return None after it excutes once.
-        output.or_else(|| {
-            if !self.buffer_text.is_empty() || !self.buffer_zero_width.is_empty() {
-                let start = self.run_start.take()?;
-                let latest_col = self.latest_col.take()?;
-                // Save leftover buffer and empty it
-                Some(Self::build_text_run(start, latest_col, self.drain_buffer()))
-            } else {
-                None
-            }
-        })
+        if !self.buffer_text.is_empty() || !self.buffer_zero_width.is_empty() {
+            // Save leftover buffer and empty it
+            Some(Self::build_text_run(self.run_start, self.latest_col, self.drain_buffer()))
+        } else {
+            None
+        }
     }
 }

--- a/alacritty/src/text_run.rs
+++ b/alacritty/src/text_run.rs
@@ -1,0 +1,302 @@
+use alacritty_terminal::index::{Column, Line, Point};
+use alacritty_terminal::term::cell::Flags;
+use alacritty_terminal::term::color::Rgb;
+use alacritty_terminal::term::search::Match;
+
+use crate::display::content::{RenderableCell, RenderableContent};
+
+#[derive(Debug)]
+struct RunStart {
+    line: usize,
+    column: Column,
+    fg: Rgb,
+    bg: Rgb,
+    bg_alpha: f32,
+    flags: Flags,
+}
+
+impl RunStart {
+    /// Compare cell and check if it belongs to the same run.
+    #[inline]
+    fn belongs_to_text_run(&self, render_cell: &RenderableCell) -> bool {
+        self.line == render_cell.point.line
+            && self.fg == render_cell.fg
+            && self.bg == render_cell.bg
+            && (self.bg_alpha - render_cell.bg_alpha).abs() < std::f32::EPSILON
+            && self.flags == render_cell.flags
+    }
+}
+
+#[derive(Debug)]
+pub struct TextRunContent {
+    pub text: String,
+    pub zero_widths: Vec<Option<Vec<char>>>,
+}
+
+/// Represents a set of renderable cells that all share the same rendering propreties.
+/// The assumption is that if two cells are in the same TextRun they can be sent off together to
+/// be shaped. This allows for ligatures to be rendered but not when something breaks up a ligature
+/// (e.g. selection hightlight) which is desired behavior.
+#[derive(Debug)]
+pub struct TextRun {
+    /// A run never spans multiple lines.
+    pub line: usize,
+    /// Span of columns the text run covers.
+    pub span: (Column, Column),
+    /// Cursor or sequence of characters.
+    pub content: TextRunContent,
+    /// Foreground color of text run content.
+    pub fg: Rgb,
+    /// Background color of text run content.
+    pub bg: Rgb,
+    /// Background color opacity of the text run
+    pub bg_alpha: f32,
+    /// Attributes of this text run.
+    pub flags: Flags,
+}
+
+impl TextRun {
+    /// Returns dummy RenderableCell containing no content with positioning and color information
+    /// from this TextRun.
+    fn dummy_cell_at(&self, col: Column) -> RenderableCell {
+        RenderableCell {
+            point: Point { line: self.line, column: col },
+            character: ' ',
+            zerowidth: None,
+            fg: self.fg,
+            bg: self.bg,
+            bg_alpha: self.bg_alpha,
+            flags: self.flags,
+        }
+    }
+
+    /// First point covered by this TextRun
+    pub fn start_point(&self) -> Point<usize> {
+        Point { line: self.line, column: self.span.0 }
+    }
+
+    /// End point covered by this TextRun
+    pub fn end_point(&self) -> Point<usize> {
+        Point { line: self.line, column: self.span.1 }
+    }
+
+    /// Iterates over each RenderableCell in column range [run.0, run.1]
+    pub fn cells(&self) -> impl Iterator<Item = RenderableCell> + '_ {
+        let step = if self.flags.contains(Flags::WIDE_CHAR) { 2 } else { 1 };
+        let (Column(start), Column(end)) = self.span;
+        // TODO: impl Step for Column (once Step is stable) to avoid unwrapping then rewrapping.
+        (start..=end).step_by(step).map(move |col| self.dummy_cell_at(Column(col)))
+    }
+}
+
+type IsWide = bool;
+type LatestCol = (Column, IsWide);
+
+/// Wraps an Iterator<Item=RenderableCell> and produces TextRuns to represent batches of cells
+pub struct TextRunIter<I> {
+    iter: I,
+    run_start: Option<RunStart>,
+    latest_col: Option<LatestCol>,
+    display_offset: usize,
+    hint: Option<Match>,
+    vi_hint: Option<Match>,
+    buffer_text: String,
+    buffer_zero_width: Vec<Option<Vec<char>>>,
+}
+
+type TextRunIterFromContent<'a, 'c> =
+    TextRunIter<std::iter::Filter<&'a mut RenderableContent<'c>, fn(&RenderableCell) -> bool>>;
+
+impl<I> TextRunIter<I> {
+    pub fn from_content<'a, 'c>(
+        content: &'a mut RenderableContent<'c>,
+        hint: Option<Match>,
+        vi_hint: Option<Match>,
+    ) -> TextRunIterFromContent<'a, 'c> {
+        fn check(cell: &RenderableCell) -> bool {
+            !cell.flags.contains(Flags::WIDE_CHAR_SPACER)
+        }
+
+        let display_offset = content.display_offset();
+
+        // Logic for WIDE_CHAR is handled internally by TextRun
+        // So we no longer need WIDE_CHAR_SPACER at this point.
+        TextRunIter::new(content.filter(check), hint, vi_hint, display_offset)
+    }
+}
+
+impl<I> TextRunIter<I>
+where
+    I: Iterator<Item = RenderableCell>,
+{
+    pub fn new(
+        iter: I,
+        hint: Option<Match>,
+        vi_hint: Option<Match>,
+        display_offset: usize,
+    ) -> Self {
+        TextRunIter {
+            iter,
+            latest_col: None,
+            display_offset,
+            run_start: None,
+            buffer_text: String::new(),
+            buffer_zero_width: Vec::new(),
+            hint,
+            vi_hint,
+        }
+    }
+}
+impl<I> TextRunIter<I> {
+    /// Check if the cell belongs to this text run. Returns `true` if it does not belong.
+    fn cell_does_not_belong_to_run(&self, render_cell: &RenderableCell) -> bool {
+        self.run_start
+            .as_ref()
+            .map(|run_start| !run_start.belongs_to_text_run(render_cell))
+            .unwrap_or_default()
+    }
+
+    /// Check if the column is not adjacent to the latest column.
+    fn is_col_not_adjacent(&self, column: Column) -> bool {
+        self.latest_col
+            .as_ref()
+            .map(|&(col, is_wide)| {
+                let width = if is_wide { 2 } else { 1 };
+                col + width != column && column + width != col
+            })
+            .unwrap_or_default()
+    }
+
+    /// Check if current run ends at incoming RenderableCell
+    /// Run will not include incoming RenderableCell if it ends
+    fn is_end_of_run(&self, render_cell: &RenderableCell) -> bool {
+        self.cell_does_not_belong_to_run(render_cell)
+            || self.is_col_not_adjacent(render_cell.point.column)
+    }
+
+    /// Add content of cell to pending TextRun buffer
+    fn buffer_content(&mut self, cell: RenderableCell) {
+        // Add to buffer only if the next RenderableCell is a Chars (not a cursor)
+        self.buffer_text.push(cell.character);
+        self.buffer_zero_width.push(cell.zerowidth);
+    }
+
+    /// Empty out pending buffer producing owned collections that can be moved into a TextRun
+    fn drain_buffer(&mut self) -> TextRunContent {
+        use std::mem::take;
+        let text = take(&mut self.buffer_text);
+        let zero_widths = take(&mut self.buffer_zero_width);
+
+        TextRunContent { text, zero_widths }
+    }
+
+    fn is_hinted(&self, point: Point<usize>) -> bool {
+        fn viewport_to_point(display_offset: usize, point: Point<usize>) -> Point {
+            let line = Line(point.line as i32) - display_offset;
+            Point::new(line, point.column)
+        }
+
+        let pt = viewport_to_point(self.display_offset, point);
+
+        self.hint.as_ref().map_or(false, |bounds| bounds.contains(&pt))
+            || self.vi_hint.as_ref().map_or(false, |bounds| bounds.contains(&pt))
+    }
+
+    /// Start a new run by setting latest_col, run_start, and buffering content of rc
+    /// Returns the previous runs run_start and latest_col data if available.
+    fn start_run(&mut self, render_cell: RenderableCell) -> (Option<RunStart>, Option<LatestCol>) {
+        let latest = self
+            .latest_col
+            .replace((render_cell.point.column, render_cell.flags.contains(Flags::WIDE_CHAR)));
+        let start = self.run_start.replace(RunStart {
+            line: render_cell.point.line,
+            column: render_cell.point.column,
+            fg: render_cell.fg,
+            bg: render_cell.bg,
+            bg_alpha: render_cell.bg_alpha,
+            flags: render_cell.flags,
+        });
+        self.buffer_content(render_cell);
+        (start, latest)
+    }
+
+    /// Create a run of chars from the current state of the `TextRunIter`.
+    /// This is a destructive operation, the iterator will be in a new run state after it's
+    /// completion.
+    fn produce_char_run(&mut self, render_cell: RenderableCell) -> Option<TextRun> {
+        let prev_buffer = self.drain_buffer();
+        let (start_opt, latest_col_opt) = self.start_run(render_cell);
+        let start = start_opt?;
+        let latest_col = latest_col_opt?;
+        Some(Self::build_text_run(start, latest_col, prev_buffer))
+    }
+
+    /// Build a TextRun instance from passed state of TextRunIter
+    fn build_text_run(
+        start: RunStart,
+        (latest, is_wide): LatestCol,
+        content: TextRunContent,
+    ) -> TextRun {
+        let end_column = if is_wide { latest + 1 } else { latest };
+        TextRun {
+            line: start.line,
+            span: (start.column, end_column),
+            content,
+            fg: start.fg,
+            bg: start.bg,
+            bg_alpha: start.bg_alpha,
+            flags: start.flags,
+        }
+    }
+}
+
+impl<I> Iterator for TextRunIter<I>
+where
+    I: Iterator<Item = RenderableCell>,
+{
+    type Item = TextRun;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut output = None;
+        while let Some(mut render_cell) = self.iter.next() {
+            if self.is_hinted(render_cell.point) {
+                render_cell.flags.insert(Flags::UNDERLINE);
+            }
+            if self.latest_col.is_none() || self.run_start.is_none() {
+                // Initial state, this is should only be hit on the first next() call of
+                // iterator
+
+                self.run_start = Some(RunStart {
+                    line: render_cell.point.line,
+                    column: render_cell.point.column,
+                    fg: render_cell.fg,
+                    bg: render_cell.bg,
+                    bg_alpha: render_cell.bg_alpha,
+                    flags: render_cell.flags,
+                });
+            } else if self.is_end_of_run(&render_cell) {
+                // If we find a run break,
+                // return what we have so far and start a new run.
+                output = self.produce_char_run(render_cell);
+                break;
+            }
+
+            // Build up buffer and track the latest column we've seen
+            self.latest_col =
+                Some((render_cell.point.column, render_cell.flags.contains(Flags::WIDE_CHAR)));
+            self.buffer_content(render_cell);
+        }
+        // Check for any remaining buffered content and return it as a text run.
+        // This is a destructive operation, it will return None after it excutes once.
+        output.or_else(|| {
+            if !self.buffer_text.is_empty() || !self.buffer_zero_width.is_empty() {
+                let start = self.run_start.take()?;
+                let latest_col = self.latest_col.take()?;
+                // Save leftover buffer and empty it
+                Some(Self::build_text_run(start, latest_col, self.drain_buffer()))
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -8,7 +8,7 @@ use crate::grid::{self, GridCell};
 use crate::index::Column;
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Default)]
     pub struct Flags: u16 {
         const INVERSE                   = 0b0000_0000_0000_0001;
         const BOLD                      = 0b0000_0000_0000_0010;


### PR DESCRIPTION
NOTE: https://github.com/alacritty/crossfont/pull/35/ has to be merged first. The current change modifies the dependency to point at my fork. It should point to a released version instead!

Closes #50. We should be able to statically link to harfbuzz on every supported platform, so not gating this behind `cfg(unix)`.

Supersedes #2677 and #5615. 