### PR TITLE
Fix CreateNewWindow CLI fallback

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -225,7 +225,7 @@ impl TerminalOptions {
             pty_config.shell = Some(command);
         }
 
-        pty_config.hold = self.hold;
+        pty_config.hold |= self.hold;
     }
 }
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -100,8 +100,6 @@ impl Options {
 
     /// Override configuration file with options from the CLI.
     pub fn override_config(&self, config: &mut UiConfig) {
-        self.terminal_options.override_pty_config(&mut config.terminal_config.pty_config);
-
         if let Some(title) = self.title.clone() {
             config.window.title = title
         }

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -100,20 +100,7 @@ impl Options {
 
     /// Override configuration file with options from the CLI.
     pub fn override_config(&self, config: &mut UiConfig) {
-        if let Some(working_directory) = &self.terminal_options.working_directory {
-            if working_directory.is_dir() {
-                config.terminal_config.pty_config.working_directory =
-                    Some(working_directory.to_owned());
-            } else {
-                error!("Invalid working directory: {:?}", working_directory);
-            }
-        }
-
-        if let Some(command) = self.terminal_options.command() {
-            config.terminal_config.pty_config.shell = Some(command);
-        }
-
-        config.terminal_config.pty_config.hold = self.terminal_options.hold;
+        self.terminal_options.override_pty_config(&mut config.terminal_config.pty_config);
 
         if let Some(title) = self.title.clone() {
             config.window.title = title
@@ -218,27 +205,37 @@ pub struct TerminalOptions {
 }
 
 impl TerminalOptions {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.working_directory.is_none() && !self.hold && self.command.is_empty()
-    }
-
     /// Shell override passed through the CLI.
     pub fn command(&self) -> Option<Program> {
         let (program, args) = self.command.split_first()?;
         Some(Program::WithArgs { program: program.clone(), args: args.to_vec() })
     }
+
+    /// Override the [`PtyConfig`]'s fields with the [`TerminalOptions`].
+    pub fn override_pty_config(&self, pty_config: &mut PtyConfig) {
+        if let Some(working_directory) = &self.working_directory {
+            if working_directory.is_dir() {
+                pty_config.working_directory = Some(working_directory.to_owned());
+            } else {
+                error!("Invalid working directory: {:?}", working_directory);
+            }
+        }
+
+        if let Some(command) = self.command() {
+            pty_config.shell = Some(command);
+        }
+
+        pty_config.hold = self.hold;
+    }
 }
 
 impl From<TerminalOptions> for PtyConfig {
     fn from(mut options: TerminalOptions) -> Self {
-        let working_directory = options.working_directory.take();
-        let shell = options.command();
-        let hold = options.hold;
-        PtyConfig { shell, working_directory, hold }
+        PtyConfig {
+            working_directory: options.working_directory.take(),
+            shell: options.command(),
+            hold: options.hold,
+        }
     }
 }
 

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -78,8 +78,7 @@ impl HintState {
             if hint.post_processing {
                 matches
                     .drain(..)
-                    .map(|rm| HintPostProcessor::new(term, regex, rm).collect::<Vec<_>>())
-                    .flatten()
+                    .flat_map(|rm| HintPostProcessor::new(term, regex, rm).collect::<Vec<_>>())
                     .collect()
             } else {
                 matches.0

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1206,16 +1206,10 @@ impl Processor {
         &mut self,
         event_loop: &EventLoopWindowTarget<Event>,
         proxy: EventLoopProxy<Event>,
-        options: Option<TerminalOptions>,
+        options: TerminalOptions,
     ) -> Result<(), Box<dyn Error>> {
-        let pty_config = match options {
-            Some(options) => {
-                let mut pty_config = self.config.terminal_config.pty_config.clone();
-                options.override_pty_config(&mut pty_config);
-                Cow::Owned(pty_config)
-            },
-            None => Cow::Borrowed(&self.config.terminal_config.pty_config),
-        };
+        let mut pty_config = self.config.terminal_config.pty_config.clone();
+        options.override_pty_config(&mut pty_config);
 
         let window_context = WindowContext::new(
             &self.config,
@@ -1327,7 +1321,7 @@ impl Processor {
                 GlutinEvent::UserEvent(Event {
                     payload: EventType::CreateWindow(options), ..
                 }) => {
-                    if let Err(err) = self.create_window(event_loop, proxy.clone(), Some(options)) {
+                    if let Err(err) = self.create_window(event_loop, proxy.clone(), options) {
                         error!("Could not open window: {:?}", err);
                     }
                 },

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -34,7 +34,7 @@ use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::term::search::{Match, RegexSearch};
 use alacritty_terminal::term::{ClipboardType, SizeInfo, Term, TermMode};
 
-use crate::cli::{Options as CliOptions, TerminalOptions as TerminalCliOptions};
+use crate::cli::{Options as CliOptions, TerminalOptions};
 use crate::clipboard::Clipboard;
 use crate::config::ui_config::{HintAction, HintInternalAction};
 use crate::config::{self, UiConfig};
@@ -88,7 +88,7 @@ pub enum EventType {
     ConfigReload(PathBuf),
     Message(Message),
     Scroll(Scroll),
-    CreateWindow(Option<TerminalCliOptions>),
+    CreateWindow(TerminalOptions),
     BlinkCursor,
     SearchNext,
 }
@@ -379,21 +379,19 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
     #[cfg(not(windows))]
     fn create_new_window(&mut self) {
-        let cwd = foreground_process_path(self.master_fd, self.shell_pid);
-        let options = if let Ok(working_directory) = cwd {
-            let mut options = TerminalCliOptions::new();
+        let mut options = TerminalOptions::default();
+        if let Ok(working_directory) = foreground_process_path(self.master_fd, self.shell_pid) {
             options.working_directory = Some(working_directory);
-            Some(options)
-        } else {
-            None
-        };
+        }
 
         let _ = self.event_proxy.send_event(Event::new(EventType::CreateWindow(options), None));
     }
 
     #[cfg(windows)]
     fn create_new_window(&mut self) {
-        let _ = self.event_proxy.send_event(Event::new(EventType::CreateWindow(None), None));
+        let _ = self
+            .event_proxy
+            .send_event(Event::new(EventType::CreateWindow(TerminalOptions::default()), None));
     }
 
     fn spawn_daemon<I, S>(&self, program: &str, args: I)
@@ -753,7 +751,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             }
         } else if self.terminal().mode().contains(TermMode::BRACKETED_PASTE) {
             self.write_to_pty(&b"\x1b[200~"[..]);
-            self.write_to_pty(text.replace("\x1b", "").into_bytes());
+            self.write_to_pty(text.replace('\x1b', "").into_bytes());
             self.write_to_pty(&b"\x1b[201~"[..]);
         } else {
             // In non-bracketed (ie: normal) mode, terminal applications cannot distinguish
@@ -762,7 +760,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             // pasting... since that's neither practical nor sensible (and probably an impossible
             // task to solve in a general way), we'll just replace line breaks (windows and unix
             // style) with a single carriage return (\r, which is what the Enter key produces).
-            self.write_to_pty(text.replace("\r\n", "\r").replace("\n", "\r").into_bytes());
+            self.write_to_pty(text.replace("\r\n", "\r").replace('\n', "\r").into_bytes());
         }
     }
 
@@ -1207,12 +1205,21 @@ impl Processor {
     pub fn create_window(
         &mut self,
         event_loop: &EventLoopWindowTarget<Event>,
-        options: Option<TerminalCliOptions>,
         proxy: EventLoopProxy<Event>,
+        options: Option<TerminalOptions>,
     ) -> Result<(), Box<dyn Error>> {
+        let pty_config = match options {
+            Some(options) => {
+                let mut pty_config = self.config.terminal_config.pty_config.clone();
+                options.override_pty_config(&mut pty_config);
+                Cow::Owned(pty_config)
+            },
+            None => Cow::Borrowed(&self.config.terminal_config.pty_config),
+        };
+
         let window_context = WindowContext::new(
             &self.config,
-            options,
+            &pty_config,
             event_loop,
             proxy,
             #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
@@ -1320,7 +1327,7 @@ impl Processor {
                 GlutinEvent::UserEvent(Event {
                     payload: EventType::CreateWindow(options), ..
                 }) => {
-                    if let Err(err) = self.create_window(event_loop, options, proxy.clone()) {
+                    if let Err(err) = self.create_window(event_loop, proxy.clone(), Some(options)) {
                         error!("Could not open window: {:?}", err);
                     }
                 },

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -802,11 +802,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         self.ctx.clear_selection();
 
         let utf8_len = c.len_utf8();
-        let mut bytes = Vec::with_capacity(utf8_len);
-        unsafe {
-            bytes.set_len(utf8_len);
-            c.encode_utf8(&mut bytes[..]);
-        }
+        let mut bytes = vec![0; utf8_len];
+        c.encode_utf8(&mut bytes[..]);
 
         if self.ctx.config().alt_send_esc
             && *self.ctx.received_count() == 0
@@ -1007,7 +1004,7 @@ mod tests {
         }
 
         fn terminal_mut(&mut self) -> &mut Term<T> {
-            &mut self.terminal
+            self.terminal
         }
 
         fn size_info(&self) -> SizeInfo {

--- a/alacritty/src/ipc.rs
+++ b/alacritty/src/ipc.rs
@@ -58,8 +58,8 @@ pub fn spawn_ipc_socket(options: &Options, event_proxy: EventLoopProxy<Event>) -
 
             // Handle IPC events.
             match message {
-                SocketMessage::CreateWindow(terminal_options) => {
-                    let event = Event::new(EventType::CreateWindow(Some(terminal_options)), None);
+                SocketMessage::CreateWindow(options) => {
+                    let event = Event::new(EventType::CreateWindow(options), None);
                     let _ = event_proxy.send_event(event);
                 },
             }

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -182,7 +182,7 @@ fn alacritty(options: Options) -> Result<(), String> {
 
     // Create the first Alacritty window.
     let proxy = window_event_loop.create_proxy();
-    processor.create_window(&window_event_loop, None, proxy).map_err(|err| err.to_string())?;
+    processor.create_window(&window_event_loop, proxy, None).map_err(|err| err.to_string())?;
 
     info!("Initialisation complete");
 

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -178,11 +178,14 @@ fn alacritty(options: Options) -> Result<(), String> {
     };
 
     // Event processor.
+    let cli_options = options.terminal_options.clone();
     let mut processor = Processor::new(config, options, &window_event_loop);
 
     // Create the first Alacritty window.
     let proxy = window_event_loop.create_proxy();
-    processor.create_window(&window_event_loop, proxy, None).map_err(|err| err.to_string())?;
+    processor
+        .create_window(&window_event_loop, proxy, cli_options)
+        .map_err(|err| err.to_string())?;
 
     info!("Initialisation complete");
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -697,6 +697,7 @@ pub enum NamedColor {
 }
 
 impl NamedColor {
+    #[must_use]
     pub fn to_bright(self) -> Self {
         match self {
             NamedColor::Foreground => NamedColor::BrightForeground,
@@ -721,6 +722,7 @@ impl NamedColor {
         }
     }
 
+    #[must_use]
     pub fn to_dim(self) -> Self {
         match self {
             NamedColor::Black => NamedColor::DimBlack,

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -20,6 +20,7 @@ pub enum Direction {
 }
 
 impl Direction {
+    #[must_use]
     pub fn opposite(self) -> Self {
         match self {
             Side::Right => Side::Left,
@@ -133,6 +134,7 @@ pub struct Line(pub i32);
 
 impl Line {
     /// Clamp a line to a grid boundary.
+    #[must_use]
     pub fn grid_clamp<D: Dimensions>(self, dimensions: &D, boundary: Boundary) -> Self {
         match boundary {
             Boundary::Cursor => max(Line(0), min(dimensions.bottommost_line(), self)),


### PR DESCRIPTION
The existing behavior for the new CreateNewWindow actions was to always
pass in their own options, which would discard the existing options
configured on the terminal's PTY config.

To fix this the behavior for CreateNewWindow is now the same as for the
initial window creation, the config values are overwritten conditionally
based on their individual presence in the CLI options.

However this also means that all temporary CLI options set on the
"master" Alacritty instance are inherited by all future windows.

Fixes #5659.