### PR TITLE
Remove shared PID/FD variables

### DIFF
--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -1,42 +1,31 @@
-#[cfg(not(windows))]
-use std::error::Error;
 use std::ffi::OsStr;
-use std::fmt::Debug;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::fs;
 use std::io;
-#[cfg(not(windows))]
-use std::os::unix::process::CommandExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
-#[cfg(not(windows))]
-use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use log::{debug, warn};
-#[cfg(windows)]
-use winapi::um::winbase::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
+#[rustfmt::skip]
+#[cfg(not(windows))]
+use {
+    std::error::Error,
+    std::os::unix::process::CommandExt,
+    std::os::unix::io::RawFd,
+    std::path::PathBuf,
+};
 
 #[cfg(not(windows))]
-use alacritty_terminal::tty;
+use libc::pid_t;
+#[cfg(windows)]
+use winapi::um::winbase::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
 #[cfg(target_os = "macos")]
 use crate::macos;
 
-/// Start the daemon and log error on failure.
-pub fn start_daemon<I, S>(program: &str, args: I)
-where
-    I: IntoIterator<Item = S> + Debug + Copy,
-    S: AsRef<OsStr>,
-{
-    match spawn_daemon(program, args) {
-        Ok(_) => debug!("Launched {} with args {:?}", program, args),
-        Err(_) => warn!("Unable to launch {} with args {:?}", program, args),
-    }
-}
-
+/// Start a new process in the background.
 #[cfg(windows)]
-fn spawn_daemon<I, S>(program: &str, args: I) -> io::Result<()>
+pub fn spawn_daemon<I, S>(program: &str, args: I) -> io::Result<()>
 where
     I: IntoIterator<Item = S> + Copy,
     S: AsRef<OsStr>,
@@ -55,37 +44,21 @@ where
         .map(|_| ())
 }
 
-/// Get working directory of controlling process.
+/// Start a new process in the background.
 #[cfg(not(windows))]
-pub fn foreground_process_path() -> Result<PathBuf, Box<dyn Error>> {
-    let mut pid = unsafe { libc::tcgetpgrp(tty::master_fd()) };
-    if pid < 0 {
-        pid = tty::child_pid();
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
-    let link_path = format!("/proc/{}/cwd", pid);
-    #[cfg(target_os = "freebsd")]
-    let link_path = format!("/compat/linux/proc/{}/cwd", pid);
-
-    #[cfg(not(target_os = "macos"))]
-    let cwd = fs::read_link(link_path)?;
-
-    #[cfg(target_os = "macos")]
-    let cwd = macos::proc::cwd(pid)?;
-
-    Ok(cwd)
-}
-
-#[cfg(not(windows))]
-fn spawn_daemon<I, S>(program: &str, args: I) -> io::Result<()>
+pub fn spawn_daemon<I, S>(
+    program: &str,
+    args: I,
+    master_fd: RawFd,
+    shell_pid: u32,
+) -> io::Result<()>
 where
     I: IntoIterator<Item = S> + Copy,
     S: AsRef<OsStr>,
 {
     let mut command = Command::new(program);
     command.args(args).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
-    if let Ok(cwd) = foreground_process_path() {
+    if let Ok(cwd) = foreground_process_path(master_fd, shell_pid) {
         command.current_dir(cwd);
     }
     unsafe {
@@ -107,4 +80,29 @@ where
             .wait()
             .map(|_| ())
     }
+}
+
+/// Get working directory of controlling process.
+#[cfg(not(windows))]
+pub fn foreground_process_path(
+    master_fd: RawFd,
+    shell_pid: u32,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let mut pid = unsafe { libc::tcgetpgrp(master_fd) };
+    if pid < 0 {
+        pid = shell_pid as pid_t;
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
+    let link_path = format!("/proc/{}/cwd", pid);
+    #[cfg(target_os = "freebsd")]
+    let link_path = format!("/compat/linux/proc/{}/cwd", pid);
+
+    #[cfg(not(target_os = "macos"))]
+    let cwd = fs::read_link(link_path)?;
+
+    #[cfg(target_os = "macos")]
+    let cwd = macos::proc::cwd(pid)?;
+
+    Ok(cwd)
 }

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -5,6 +5,8 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 use std::mem;
+#[cfg(not(windows))]
+use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -49,6 +51,10 @@ pub struct WindowContext {
     font_size: Size,
     mouse: Mouse,
     dirty: bool,
+    #[cfg(not(windows))]
+    master_fd: RawFd,
+    #[cfg(not(windows))]
+    shell_pid: u32,
 }
 
 impl WindowContext {
@@ -97,6 +103,11 @@ impl WindowContext {
             .unwrap_or(Cow::Borrowed(&config.terminal_config.pty_config));
         let pty = tty::new(&pty_config, &display.size_info, display.window.x11_window_id())?;
 
+        #[cfg(not(windows))]
+        let master_fd = pty.file().as_raw_fd();
+        #[cfg(not(windows))]
+        let shell_pid = pty.child().id();
+
         // Create the pseudoterminal I/O loop.
         //
         // PTY I/O is ran on another thread as to not occupy cycles used by the
@@ -129,6 +140,10 @@ impl WindowContext {
             notifier: Notifier(loop_tx),
             terminal,
             display,
+            #[cfg(not(windows))]
+            master_fd,
+            #[cfg(not(windows))]
+            shell_pid,
             suppress_chars: Default::default(),
             message_buffer: Default::default(),
             received_count: Default::default(),
@@ -246,6 +261,10 @@ impl WindowContext {
             mouse: &mut self.mouse,
             dirty: &mut self.dirty,
             terminal: &mut terminal,
+            #[cfg(not(windows))]
+            master_fd: self.master_fd,
+            #[cfg(not(windows))]
+            shell_pid: self.shell_pid,
             event_proxy,
             event_loop,
             clipboard,


### PR DESCRIPTION
The existing PID/FD atomics in alacritty_terminal/src/tty/unix.rs were
shared across all Alacritty windows, causing problem with the new
multiwindow feature.

Instead of sharing these between the different windows, the master FD
and shell PID are now stored on the `window_context`.

Unfortunately this makes spawning new daemons a little more complicated,
having to pass through additional parameters. To ease this a little bit
the helper method `spawn_daemon` has been defined on the
`ActionContext`, making it accessible from most parts of Alacritty's
event loop.

Fixes #5700.