### PR TITLE
Fix text joining by block selection contained last column

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -358,12 +358,9 @@ impl<T> Term<T> {
                     res += self
                         .line_to_string(line, start.column..end.column, start.column.0 != 0)
                         .trim_end();
-
-                    // If the last column is included, newline is appended automatically.
-                    if end.column != self.columns() - 1 {
-                        res += "\n";
-                    }
+                    res += "\n";
                 }
+
                 res += self.line_to_string(end.line, start.column..end.column, true).trim_end();
             },
             Some(Selection { ty: SelectionType::Lines, .. }) => {
@@ -2019,6 +2016,52 @@ mod tests {
     }
 
     #[test]
+    fn simple_selection_works() {
+        let size = SizeInfo::new(5., 5., 1.0, 1.0, 0.0, 0.0, false);
+        let mut term = Term::new(&Config::default(), size, ());
+        let grid = term.grid_mut();
+        for i in 0..4 {
+            if i == 1 {
+                continue;
+            }
+
+            grid[Line(i)][Column(0)].c = '"';
+
+            for j in 1..4 {
+                grid[Line(i)][Column(j)].c = 'a';
+            }
+
+            grid[Line(i)][Column(4)].c = '"';
+        }
+        grid[Line(2)][Column(0)].c = ' ';
+        grid[Line(2)][Column(4)].c = ' ';
+        grid[Line(2)][Column(4)].flags.insert(Flags::WRAPLINE);
+        grid[Line(3)][Column(0)].c = ' ';
+
+        // Multiple lines contain an empty line.
+        term.selection = Some(Selection::new(
+            SelectionType::Simple,
+            Point { line: Line(0), column: Column(0) },
+            Side::Left,
+        ));
+        if let Some(s) = term.selection.as_mut() {
+            s.update(Point { line: Line(2), column: Column(4) }, Side::Right);
+        }
+        assert_eq!(term.selection_to_string(), Some(String::from("\"aaa\"\n\n aaa ")));
+
+        // A wrapline.
+        term.selection = Some(Selection::new(
+            SelectionType::Simple,
+            Point { line: Line(2), column: Column(0) },
+            Side::Left,
+        ));
+        if let Some(s) = term.selection.as_mut() {
+            s.update(Point { line: Line(3), column: Column(4) }, Side::Right);
+        }
+        assert_eq!(term.selection_to_string(), Some(String::from(" aaa  aaa\"")));
+    }
+
+    #[test]
     fn semantic_selection_works() {
         let size = SizeInfo::new(5., 3., 1.0, 1.0, 0.0, 0.0, false);
         let mut term = Term::new(&Config::default(), size, ());
@@ -2088,28 +2131,46 @@ mod tests {
     }
 
     #[test]
-    fn selecting_empty_line() {
-        let size = SizeInfo::new(3.0, 3.0, 1.0, 1.0, 0.0, 0.0, false);
+    fn block_selection_works() {
+        let size = SizeInfo::new(5., 5., 1.0, 1.0, 0.0, 0.0, false);
         let mut term = Term::new(&Config::default(), size, ());
-        let mut grid: Grid<Cell> = Grid::new(3, 3, 0);
-        for l in 0..3 {
-            if l != 1 {
-                for c in 0..3 {
-                    grid[Line(l)][Column(c)].c = 'a';
-                }
+        let grid = term.grid_mut();
+        for i in 1..4 {
+            grid[Line(i)][Column(0)].c = '"';
+
+            for j in 1..4 {
+                grid[Line(i)][Column(j)].c = 'a';
             }
+
+            grid[Line(i)][Column(4)].c = '"';
         }
+        grid[Line(2)][Column(2)].c = ' ';
+        grid[Line(2)][Column(4)].flags.insert(Flags::WRAPLINE);
+        grid[Line(3)][Column(4)].c = ' ';
 
-        mem::swap(&mut term.grid, &mut grid);
-
-        let mut selection = Selection::new(
-            SelectionType::Simple,
-            Point { line: Line(0), column: Column(0) },
+        term.selection = Some(Selection::new(
+            SelectionType::Block,
+            Point { line: Line(0), column: Column(3) },
             Side::Left,
-        );
-        selection.update(Point { line: Line(2), column: Column(2) }, Side::Right);
-        term.selection = Some(selection);
-        assert_eq!(term.selection_to_string(), Some("aaa\n\naaa".into()));
+        ));
+
+        // The same column.
+        if let Some(s) = term.selection.as_mut() {
+            s.update(Point { line: Line(3), column: Column(3) }, Side::Right);
+        }
+        assert_eq!(term.selection_to_string(), Some(String::from("\na\na\na")));
+
+        // The first column.
+        if let Some(s) = term.selection.as_mut() {
+            s.update(Point { line: Line(3), column: Column(0) }, Side::Left);
+        }
+        assert_eq!(term.selection_to_string(), Some(String::from("\n\"aa\n\"a\n\"aa")));
+
+        // The last column.
+        if let Some(s) = term.selection.as_mut() {
+            s.update(Point { line: Line(3), column: Column(4) }, Side::Right);
+        }
+        assert_eq!(term.selection_to_string(), Some(String::from("\na\"\na\"\na")));
     }
 
     /// Check that the grid can be serialized back and forth losslessly.


### PR DESCRIPTION
This problem is that copied lines are joined when block selection contains the last column.

Assume a terminal grid like below.

```
aaa
bbb
```

When we select whole lines by block selection and copy it, expected copied text is `aaa\nbbb`, but actual one is `aaabbb`.

This is introduced by 8e584099.