### PR TITLE
Fix fullwidth char regex search infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Freeze when the vi cursor is on the scrollback and scrollback clear is invoked
 - Vi cursor on topmost of the display moving downward when scrolled into history with active output
 - Input lag on Wayland with Nvidia binary driver
+- Crash when hovering the mouse over fullwidth characters
 
 ### Removed
 


### PR DESCRIPTION
This resolves an issue where the regex search could loop indefinitely
when the end point was defined in a location containing a fullwidth
character, thus skipping over the end before termination.

Fixes #5753.