### PR TITLE
Update time crate to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,12 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
@@ -1419,7 +1425,7 @@ version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -1599,13 +1605,20 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
+ "itoa 0.4.8",
  "libc",
- "winapi 0.3.9",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "toml"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -21,7 +21,7 @@ version = "0.1.0"
 [dependencies]
 clap = { version = "3.0.0", features = ["derive"] }
 log = { version = "0.4", features = ["std", "serde"] }
-time = "0.1.40"
+time = { version = "0.3.5", features = ["formatting", "local-offset", "macros"] }
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -13,6 +13,8 @@ use std::{env, process};
 
 use glutin::event_loop::EventLoopProxy;
 use log::{self, Level, LevelFilter};
+use time::macros::format_description;
+use time::{OffsetDateTime, UtcOffset};
 
 use crate::cli::Options;
 use crate::event::{Event, EventType};
@@ -41,6 +43,7 @@ pub struct Logger {
     logfile: Mutex<OnDemandLogFile>,
     stdout: Mutex<LineWriter<Stdout>>,
     event_proxy: Mutex<EventLoopProxy<Event>>,
+    tz_offset: UtcOffset,
 }
 
 impl Logger {
@@ -48,7 +51,12 @@ impl Logger {
         let logfile = Mutex::new(OnDemandLogFile::new());
         let stdout = Mutex::new(LineWriter::new(io::stdout()));
 
-        Logger { logfile, stdout, event_proxy: Mutex::new(event_proxy) }
+        Logger {
+            logfile,
+            stdout,
+            event_proxy: Mutex::new(event_proxy),
+            tz_offset: UtcOffset::current_local_offset().expect("local timezone offset"),
+        }
     }
 
     fn file_path(&self) -> Option<PathBuf> {
@@ -108,7 +116,7 @@ impl log::Log for Logger {
         }
 
         // Create log message for the given `record` and `target`.
-        let message = create_log_message(record, target);
+        let message = create_log_message(record, target, self.tz_offset);
 
         if let Ok(mut logfile) = self.logfile.lock() {
             // Write to logfile.
@@ -127,8 +135,11 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
-fn create_log_message(record: &log::Record<'_>, target: &str) -> String {
-    let now = time::strftime("%F %T.%f", &time::now()).unwrap();
+fn create_log_message(record: &log::Record<'_>, target: &str, tz_offset: UtcOffset) -> String {
+    let time_format = format_description!(
+        "[year]-[month]-[day] [hour repr:24]:[minute]:[second].[subsecond digits:9]"
+    );
+    let now = OffsetDateTime::now_utc().to_offset(tz_offset).format(time_format).unwrap();
     let mut message = format!("[{}] [{:<5}] [{}] ", now, record.level(), target);
 
     // Alignment for the lines after the first new line character in the payload. We don't deal


### PR DESCRIPTION
Due to unsoundness issues (c.f., time-rs/time#380 and time-rs/time#293), determining the local timezone can only happen while single-threaded.

Determine the timezone early in startup and apply the offset to the UTC timestamp before formatting.