### PR TITLE
Fix block selection expansion with Ctrl + RMB

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -528,8 +528,9 @@
 #
 # - `mods` (see key bindings)
 #mouse_bindings:
-#  - { mouse: Right,             action: ExpandSelection }
-#  - { mouse: Middle, mode: ~Vi, action: PasteSelection  }
+#  - { mouse: Right,                 action: ExpandSelection }
+#  - { mouse: Right,  mods: Control, action: ExpandSelection }
+#  - { mouse: Middle, mode: ~Vi,     action: PasteSelection  }
 
 # Key bindings
 #

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -363,7 +363,8 @@ macro_rules! bindings {
 pub fn default_mouse_bindings() -> Vec<MouseBinding> {
     bindings!(
         MouseBinding;
-        MouseButton::Right;                    MouseAction::ExpandSelection;
+        MouseButton::Right;                         MouseAction::ExpandSelection;
+        MouseButton::Right,   ModifiersState::CTRL; MouseAction::ExpandSelection;
         MouseButton::Middle, ~BindingMode::VI; Action::PasteSelection;
     )
 }


### PR DESCRIPTION
When 'ExpandSelection' binding was added only default binding for
RightClick was added, however to expand block selection holding control
when doing a click is required, so this commit adds a binding for
'RMB + Control'.