### PR TITLE
Use `with_position` instead of `set_outer_position`

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::Ordering;
 use std::time::Instant;
 use std::{f64, mem};
 
-use glutin::dpi::{PhysicalPosition, PhysicalSize};
+use glutin::dpi::PhysicalSize;
 use glutin::event::ModifiersState;
 use glutin::event_loop::EventLoopWindowTarget;
 #[cfg(not(any(target_os = "macos", windows)))]
@@ -307,14 +307,6 @@ impl Display {
         }
 
         window.set_visible(true);
-
-        // Set window position.
-        //
-        // TODO: replace `set_position` with `with_position` once available.
-        // Upstream issue: https://github.com/rust-windowing/winit/issues/806.
-        if let Some(position) = config.window.position {
-            window.set_outer_position(PhysicalPosition::from((position.x, position.y)));
-        }
 
         #[allow(clippy::single_match)]
         #[cfg(not(windows))]

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -175,7 +175,12 @@ impl Window {
         wayland_event_queue: Option<&EventQueue>,
     ) -> Result<Window> {
         let identity = identity.clone();
-        let window_builder = Window::get_platform_window(&identity, &config.window);
+        let mut window_builder = Window::get_platform_window(&identity, &config.window);
+
+        if let Some(position) = config.window.position {
+            window_builder = window_builder
+                .with_position(PhysicalPosition::<i32>::from((position.x, position.y)));
+        }
 
         // Check if we're running Wayland to disable vsync.
         #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
@@ -358,10 +363,6 @@ impl Window {
         let attention = if is_urgent { Some(UserAttentionType::Critical) } else { None };
 
         self.window().request_user_attention(attention);
-    }
-
-    pub fn set_outer_position(&self, pos: PhysicalPosition<i32>) {
-        self.window().set_outer_position(pos);
     }
 
     #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]


### PR DESCRIPTION
This uses `with_position` method on a `WindowBuilder` instead of setting
window position on a created window later on.

--
I wasn't able to test this, since it's not something that is allowed on Wayland. So leaving it up to you.