### PR TITLE
Add ´?´ handling in OSC 4 and correctly query modified colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The `--help` output was reworked with a new colorful syntax
 
+### Fixed
+
+- OSC 4 not handling `?`
+- `?` in OSC strings reporting default colors instead of modified ones
+
 ## 0.10.0
 
 ### Packaging

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1076,7 +1076,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         self.ctx.write_to_pty(text.into_bytes());
                     },
                     TerminalEvent::ColorRequest(index, format) => {
-                        let text = format(self.ctx.display.colors[index]);
+                        let text = format(self.ctx.terminal().colors()[index].unwrap_or(self.ctx.display.colors[index]));
                         self.ctx.write_to_pty(text.into_bytes());
                     },
                     TerminalEvent::PtyWrite(text) => self.ctx.write_to_pty(text.into_bytes()),

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1076,8 +1076,9 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         self.ctx.write_to_pty(text.into_bytes());
                     },
                     TerminalEvent::ColorRequest(index, format) => {
-                        let text = format(self.ctx.terminal().colors()[index].unwrap_or(self.ctx.display.colors[index]));
-                        self.ctx.write_to_pty(text.into_bytes());
+                        let color = self.ctx.terminal().colors()[index]
+                            .unwrap_or(self.ctx.display.colors[index]);
+                        self.ctx.write_to_pty(format(color).into_bytes());
                     },
                     TerminalEvent::PtyWrite(text) => self.ctx.write_to_pty(text.into_bytes()),
                     TerminalEvent::MouseCursorDirty => self.reset_mouse_cursor(),

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -974,15 +974,24 @@ where
             b"4" => {
                 if params.len() > 1 && params.len() % 2 != 0 {
                     for chunk in params[1..].chunks(2) {
-                        let index = parse_number(chunk[0]);
-                        let color = xparse_color(chunk[1]);
-                        if let (Some(i), Some(c)) = (index, color) {
-                            self.handler.set_color(i as usize, c);
-                            return;
+                        if let Some(index) = parse_number(chunk[0]) {
+                            if let Some(c) = xparse_color(chunk[1]) {
+                                self.handler.set_color(index as usize, c);
+                            } else if chunk[1] == b"?" {
+                                self.handler.dynamic_color_sequence(
+                                    index,
+                                    index as usize,
+                                    terminator,
+                                );
+                            } else {
+                                unhandled(params);
+                            }
                         }
                     }
+                    return;
                 }
                 unhandled(params);
+                
             },
 
             // Get/set Foreground, Background, Cursor colors.

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -979,7 +979,7 @@ where
 
                 for chunk in params[1..].chunks(2) {
                     let index = match parse_number(chunk[0]) {
-                        Some(i) => i,
+                        Some(index) => index,
                         None => {
                             unhandled(params);
                             continue;

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1505,6 +1505,7 @@ mod tests {
         charset: StandardCharset,
         attr: Option<Attr>,
         identity_reported: bool,
+        color: Option<Rgb>
     }
 
     impl Handler for MockHandler {
@@ -1528,6 +1529,10 @@ mod tests {
         fn reset_state(&mut self) {
             *self = Self::default();
         }
+
+        fn set_color(&mut self, _: usize, c: Rgb) {
+            self.color = Some(c);
+        }
     }
 
     impl Default for MockHandler {
@@ -1537,6 +1542,7 @@ mod tests {
                 charset: StandardCharset::Ascii,
                 attr: None,
                 identity_reported: false,
+                color: None
             }
         }
     }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1753,6 +1753,6 @@ mod tests {
             parser.advance(&mut handler, *byte);
         }
 
-        assert_eq!(handler.color, xparse_color(&[b'#', b'f', b'f', b'f']));
+        assert_eq!(handler.color, Some(Rgb { r: 0xf0, g: 0xf0, b: 0xf0 }));
     }
 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1505,7 +1505,7 @@ mod tests {
         charset: StandardCharset,
         attr: Option<Attr>,
         identity_reported: bool,
-        color: Option<Rgb>
+        color: Option<Rgb>,
     }
 
     impl Handler for MockHandler {
@@ -1542,7 +1542,7 @@ mod tests {
                 charset: StandardCharset::Ascii,
                 attr: None,
                 identity_reported: false,
-                color: None
+                color: None,
             }
         }
     }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -972,26 +972,27 @@ where
 
             // Set color index.
             b"4" => {
-                if params.len() > 1 && params.len() % 2 != 0 {
-                    for chunk in params[1..].chunks(2) {
-                        if let Some(index) = parse_number(chunk[0]) {
-                            if let Some(c) = xparse_color(chunk[1]) {
-                                self.handler.set_color(index as usize, c);
-                            } else if chunk[1] == b"?" {
-                                self.handler.dynamic_color_sequence(
-                                    index,
-                                    index as usize,
-                                    terminator,
-                                );
-                            } else {
-                                unhandled(params);
-                            }
-                        }
-                    }
+                if params.len() <= 1 || params.len() % 2 == 0 {
+                    unhandled(params);
                     return;
                 }
-                unhandled(params);
-                
+
+                for chunk in params[1..].chunks(2) {
+                    let index = if let Some(i) = parse_number(chunk[0]) {
+                        i
+                    } else {
+                        unhandled(params);
+                        continue;
+                    };
+
+                    if let Some(c) = xparse_color(chunk[1]) {
+                        self.handler.set_color(index as usize, c);
+                    } else if chunk[1] == b"?" {
+                        self.handler.dynamic_color_sequence(index, index as usize, terminator);
+                    } else {
+                        unhandled(params);
+                    }
+                }
             },
 
             // Get/set Foreground, Background, Cursor colors.

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -978,11 +978,12 @@ where
                 }
 
                 for chunk in params[1..].chunks(2) {
-                    let index = if let Some(i) = parse_number(chunk[0]) {
-                        i
-                    } else {
-                        unhandled(params);
-                        continue;
+                    let index = match parse_number(chunk[0]) {
+                        Some(i) => i,
+                        None => {
+                            unhandled(params);
+                            continue;
+                        },
                     };
 
                     if let Some(c) = xparse_color(chunk[1]) {

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1734,4 +1734,18 @@ mod tests {
     fn parse_number_too_large() {
         assert_eq!(parse_number(b"321"), None);
     }
+
+    #[test]
+    fn parse_osc4_set_color() {
+        let bytes: &[u8] = &[0x1b, b']', b'4', b';', b'0', b';', b'#', b'f', b'f', b'f', 0x1b];
+
+        let mut parser = Processor::new();
+        let mut handler = MockHandler::default();
+
+        for byte in bytes {
+            parser.advance(&mut handler, *byte);
+        }
+
+        assert_eq!(handler.color, xparse_color(&[b'#', b'f', b'f', b'f']));
+    }
 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1744,7 +1744,7 @@ mod tests {
 
     #[test]
     fn parse_osc4_set_color() {
-        let bytes: &[u8] = &[0x1b, b']', b'4', b';', b'0', b';', b'#', b'f', b'f', b'f', 0x1b];
+        let bytes: &[u8] = b"\x1b]4;0;#fff\x1b\\";
 
         let mut parser = Processor::new();
         let mut handler = MockHandler::default();

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -818,6 +818,10 @@ impl<T> Term<T> {
         cursor_cell.bg = bg;
         cursor_cell.flags = flags;
     }
+
+    pub fn colors(&self) -> &Colors {
+        &self.colors
+    }
 }
 
 impl<T> Dimensions for Term<T> {


### PR DESCRIPTION
Related #5542

- Handle `?` in OSC 4:
```
$ echo -ne '\e]4;1;?\a'; cat
^[]1;rgb:cccc/2424/1d1d^G
```
- Modify handling of `TerminalEvent::ColorRequest` to correcly report modified colors
- Add some tests for OSC 4  parsing