### PR TITLE
Add damage tracking and reporting to compatible compositors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
- - Option `font.builtin_box_drawing` to disable the built-in font for drawing box characters
+- Option `font.builtin_box_drawing` to disable the built-in font for drawing box characters
+- Track and report surface damage information to Wayland compositors
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.16.1-dev"
+version = "0.17.0-dev"
 dependencies = [
  "alacritty_config_derive",
  "base64",

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -876,3 +876,6 @@
 
   # Print all received window events.
   #print_events: false
+
+  # Highlight window damage information.
+  #highlight_damage: false

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.56.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.16.1-dev"
+version = "0.17.0-dev"
 default-features = false
 
 [dependencies.alacritty_config_derive]

--- a/alacritty/src/config/debug.rs
+++ b/alacritty/src/config/debug.rs
@@ -15,6 +15,9 @@ pub struct Debug {
     /// Should show render timer.
     pub render_timer: bool,
 
+    /// Highlight damage information produced by alacritty.
+    pub highlight_damage: bool,
+
     /// Record ref test.
     #[config(skip)]
     pub ref_test: bool,
@@ -27,6 +30,7 @@ impl Default for Debug {
             print_events: Default::default(),
             persistent_logging: Default::default(),
             render_timer: Default::default(),
+            highlight_damage: Default::default(),
             ref_test: Default::default(),
         }
     }

--- a/alacritty/src/display/damage.rs
+++ b/alacritty/src/display/damage.rs
@@ -1,0 +1,86 @@
+use std::cmp;
+use std::iter::Peekable;
+
+use glutin::Rect;
+
+use alacritty_terminal::term::{LineDamageBounds, SizeInfo, TermDamageIterator};
+
+/// Iterator which converts `alacritty_terminal` damage information into renderer damaged rects.
+pub struct RenderDamageIterator<'a> {
+    damaged_lines: Peekable<TermDamageIterator<'a>>,
+    size_info: SizeInfo<u32>,
+}
+
+impl<'a> RenderDamageIterator<'a> {
+    pub fn new(damaged_lines: TermDamageIterator<'a>, size_info: SizeInfo<u32>) -> Self {
+        Self { damaged_lines: damaged_lines.peekable(), size_info }
+    }
+
+    #[inline]
+    fn rect_for_line(&self, line_damage: LineDamageBounds) -> Rect {
+        let size_info = &self.size_info;
+        let y_top = size_info.height() - size_info.padding_y();
+        let x = size_info.padding_x() + line_damage.left as u32 * size_info.cell_width();
+        let y = y_top - (line_damage.line + 1) as u32 * size_info.cell_height();
+        let width = (line_damage.right - line_damage.left + 1) as u32 * size_info.cell_width();
+        Rect { x, y, height: size_info.cell_height(), width }
+    }
+
+    // Make sure to damage near cells to include wide chars.
+    #[inline]
+    fn overdamage(&self, mut rect: Rect) -> Rect {
+        let size_info = &self.size_info;
+        rect.x = rect.x.saturating_sub(size_info.cell_width());
+        rect.width = cmp::min(size_info.width() - rect.x, rect.width + 2 * size_info.cell_width());
+        rect.y = rect.y.saturating_sub(size_info.cell_height() / 2);
+        rect.height = cmp::min(size_info.height() - rect.y, rect.height + size_info.cell_height());
+
+        rect
+    }
+}
+
+impl<'a> Iterator for RenderDamageIterator<'a> {
+    type Item = Rect;
+
+    fn next(&mut self) -> Option<Rect> {
+        let line = self.damaged_lines.next()?;
+        let mut total_damage_rect = self.overdamage(self.rect_for_line(line));
+
+        // Merge rectangles which overlap with each other.
+        while let Some(line) = self.damaged_lines.peek().copied() {
+            let next_rect = self.overdamage(self.rect_for_line(line));
+            if !rects_overlap(total_damage_rect, next_rect) {
+                break;
+            }
+
+            total_damage_rect = merge_rects(total_damage_rect, next_rect);
+            let _ = self.damaged_lines.next();
+        }
+
+        Some(total_damage_rect)
+    }
+}
+
+/// Check if two given [`glutin::Rect`] overlap.
+fn rects_overlap(lhs: Rect, rhs: Rect) -> bool {
+    !(
+        // `lhs` is left of `rhs`.
+        lhs.x + lhs.width < rhs.x
+        // `lhs` is right of `rhs`.
+        || rhs.x + rhs.width < lhs.x
+        // `lhs` is below `rhs`.
+        || lhs.y + lhs.height < rhs.y
+        // `lhs` is above `rhs`.
+        || rhs.y + rhs.height < lhs.y
+    )
+}
+
+/// Merge two [`glutin::Rect`] by producing the smallest rectangle that contains both.
+#[inline]
+fn merge_rects(lhs: Rect, rhs: Rect) -> Rect {
+    let left_x = cmp::min(lhs.x, rhs.x);
+    let right_x = cmp::max(lhs.x + lhs.width, rhs.x + rhs.width);
+    let y_top = cmp::max(lhs.y + lhs.height, rhs.y + rhs.height);
+    let y_bottom = cmp::min(lhs.y, rhs.y);
+    Rect { x: left_x, y: y_bottom, width: right_x - left_x, height: y_top - y_bottom }
+}

--- a/alacritty/src/display/meter.rs
+++ b/alacritty/src/display/meter.rs
@@ -31,7 +31,7 @@ pub struct Meter {
     /// Average sample time in microseconds.
     avg: f64,
 
-    /// Index of next time to update..
+    /// Index of next time to update.
     index: usize,
 }
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -39,7 +39,7 @@ use glutin::platform::windows::IconExtWindows;
 use glutin::window::{
     CursorIcon, Fullscreen, UserAttentionType, Window as GlutinWindow, WindowBuilder, WindowId,
 };
-use glutin::{self, ContextBuilder, PossiblyCurrent, WindowedContext};
+use glutin::{self, ContextBuilder, PossiblyCurrent, Rect, WindowedContext};
 #[cfg(target_os = "macos")]
 use objc::{msg_send, sel, sel_impl};
 #[cfg(target_os = "macos")]
@@ -426,6 +426,14 @@ impl Window {
 
     pub fn swap_buffers(&self) {
         self.windowed_context.swap_buffers().expect("swap buffers");
+    }
+
+    pub fn swap_buffers_with_damage(&self, damage: &[Rect]) {
+        self.windowed_context.swap_buffers_with_damage(damage).expect("swap buffes with damage");
+    }
+
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        self.windowed_context.swap_buffers_with_damage_supported()
     }
 
     pub fn resize(&self, size: PhysicalSize<u32>) {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -768,7 +768,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     /// Toggle the vi mode status.
     #[inline]
     fn toggle_vi_mode(&mut self) {
-        if !self.terminal.mode().contains(TermMode::VI) {
+        if self.terminal.mode().contains(TermMode::VI) {
+            // Damage line indicator and Vi cursor if we're leaving Vi mode.
+            self.terminal.damage_vi_cursor();
+            self.terminal.damage_line(0, 0, self.terminal.columns() - 1);
+        } else {
             self.clear_selection();
         }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -801,7 +801,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         self.ctx.on_typing_start();
 
-        self.ctx.scroll(Scroll::Bottom);
+        if self.ctx.terminal().grid().display_offset() != 0 {
+            self.ctx.scroll(Scroll::Bottom);
+        }
         self.ctx.clear_selection();
 
         let utf8_len = c.len_utf8();

--- a/alacritty/src/renderer/builtin_font.rs
+++ b/alacritty/src/renderer/builtin_font.rs
@@ -784,7 +784,7 @@ impl Canvas {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crossfont::Metrics;
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.16.1-dev"
+version = "0.17.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -10,7 +10,7 @@ mod scrolling;
 
 use crate::ansi::{CursorShape, CursorStyle};
 
-pub use crate::config::scrolling::Scrolling;
+pub use crate::config::scrolling::{Scrolling, MAX_SCROLLBACK_LINES};
 
 pub const LOG_TARGET_CONFIG: &str = "alacritty_config_derive";
 const MIN_BLINK_INTERVAL: u64 = 10;

--- a/alacritty_terminal/src/config/scrolling.rs
+++ b/alacritty_terminal/src/config/scrolling.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer};
 use alacritty_config_derive::ConfigDeserialize;
 
 /// Maximum scrollback amount configurable.
-const MAX_SCROLLBACK_LINES: u32 = 100_000;
+pub const MAX_SCROLLBACK_LINES: u32 = 100_000;
 
 /// Struct for scrolling related settings.
 #[derive(ConfigDeserialize, Copy, Clone, Debug, PartialEq, Eq)]

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -41,6 +41,7 @@ pub struct SelectionRange {
 
 impl SelectionRange {
     pub fn new(start: Point, end: Point, is_block: bool) -> Self {
+        assert!(start <= end);
         Self { start, end, is_block }
     }
 }

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -52,7 +52,7 @@ pub enum ViMotion {
 }
 
 /// Cursor tracking vi mode position.
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, PartialEq, Eq)]
 pub struct ViModeCursor {
     pub point: Point,
 }


### PR DESCRIPTION
This allows compositors to only process damaged (that is, updated)
regions of our window buffer, which for larger window sizes (think 4k)
should significantly reduce compositing workload under compositors that
support/honor it, which is good for performance, battery life and lower
latency over remote connections like VNC.

On Wayland, clients are expected to always report correct damage, so
this makes us a good citizen there. It can also aid remote desktop
(waypipe, rdp, vnc, ...) and other types of screencopy by having damage
bubble up correctly.

Fixes #3186.

--
This uses ideas from #2724, since they were performing quite good. For example there's no damage updates in `Term::input` at all, except when wrapping a line. The way damage tracking is implement is that we create an empty information about damage state of each line and store it on a terminal and update damage bounds with left most and right most damaged cells respectively damaging everything between later on.

So this approach allows us to damage only cursor when for example starting writing and ending, and when cursor is unconditionally moved somewhere(jumping with goto, etc), leaving everything that was inserted between bounds with something like `Term::input` automatically damaged.

In cases where damaging becomes complicated we fallback to damaging just entire screen (e.g. when scrolling).

The approach is performing the same as master for me. So this patch is in a good state IMHO, however it requires developing a test suite for it, since not all systems allow to report damage to compositors.