### PR TITLE
Fix macOS release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install target
         run: rustup update && rustup target add aarch64-apple-darwin
-      - name: Check build
-        run: cargo check --target=aarch64-apple-darwin
+      - name: Build
+        run: cargo build --target=aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Test
         run: cargo test --release
-      - name: Test ARM
-        run: cargo test --release --target=aarch64-apple-darwin
+      - name: Build ARM
+        run: cargo build --release --target=aarch64-apple-darwin
       - name: Make DMG
         run: make dmg-universal
       - name: Upload Application


### PR DESCRIPTION
Since the CI machine is amd64, it is not possible to just execute the
aarch64 binary to test the application. So instead of running `cargo
test`, we just use `cargo build` instead.