### PR TITLE
Remove time dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commands spawn from the current directory of the foreground shell in Unix-like systems
 - Remove trailing newline from strings taken from hints or simple/semantic selections
 - Builtin font is now used for box drawing characters from `U+2500` to `U+259f`
+- Logs now print the time since startup instead of the local time
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "time",
  "unicode-width",
  "wayland-client",
  "winapi 0.3.9",
@@ -801,12 +800,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
@@ -1425,7 +1418,7 @@ version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1602,23 +1595,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
-dependencies = [
- "itoa 0.4.8",
- "libc",
- "time-macros",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "toml"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -21,7 +21,6 @@ version = "0.1.0"
 [dependencies]
 clap = { version = "3.0.0", features = ["derive"] }
 log = { version = "0.4", features = ["std", "serde"] }
-time = { version = "0.3.5", features = ["formatting", "local-offset", "macros"] }
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -131,8 +131,9 @@ impl log::Log for Logger {
 
 fn create_log_message(record: &log::Record<'_>, target: &str, start: Instant) -> String {
     let runtime = start.elapsed();
-    let runtime_str = format!("{}.{:0>9}s", runtime.as_secs(), runtime.subsec_nanos());
-    let mut message = format!("[{}] [{:<5}] [{}] ", runtime_str, record.level(), target);
+    let secs = runtime.as_secs();
+    let nanos = runtime.subsec_nanos();
+    let mut message = format!("[{}.{:0>9}s] [{:<5}] [{}] ", secs, nanos, record.level(), target);
 
     // Alignment for the lines after the first new line character in the payload. We don't deal
     // with fullwidth/unicode chars here, so just `message.len()` is sufficient.

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -9,12 +9,11 @@ use std::io::{self, LineWriter, Stdout, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use std::{env, process};
 
 use glutin::event_loop::EventLoopProxy;
 use log::{self, Level, LevelFilter};
-use time::macros::format_description;
-use time::{OffsetDateTime, UtcOffset};
 
 use crate::cli::Options;
 use crate::event::{Event, EventType};
@@ -43,7 +42,7 @@ pub struct Logger {
     logfile: Mutex<OnDemandLogFile>,
     stdout: Mutex<LineWriter<Stdout>>,
     event_proxy: Mutex<EventLoopProxy<Event>>,
-    tz_offset: UtcOffset,
+    start: Instant,
 }
 
 impl Logger {
@@ -51,12 +50,7 @@ impl Logger {
         let logfile = Mutex::new(OnDemandLogFile::new());
         let stdout = Mutex::new(LineWriter::new(io::stdout()));
 
-        Logger {
-            logfile,
-            stdout,
-            event_proxy: Mutex::new(event_proxy),
-            tz_offset: UtcOffset::current_local_offset().expect("local timezone offset"),
-        }
+        Logger { logfile, stdout, event_proxy: Mutex::new(event_proxy), start: Instant::now() }
     }
 
     fn file_path(&self) -> Option<PathBuf> {
@@ -116,7 +110,7 @@ impl log::Log for Logger {
         }
 
         // Create log message for the given `record` and `target`.
-        let message = create_log_message(record, target, self.tz_offset);
+        let message = create_log_message(record, target, self.start);
 
         if let Ok(mut logfile) = self.logfile.lock() {
             // Write to logfile.
@@ -135,12 +129,10 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
-fn create_log_message(record: &log::Record<'_>, target: &str, tz_offset: UtcOffset) -> String {
-    let time_format = format_description!(
-        "[year]-[month]-[day] [hour repr:24]:[minute]:[second].[subsecond digits:9]"
-    );
-    let now = OffsetDateTime::now_utc().to_offset(tz_offset).format(time_format).unwrap();
-    let mut message = format!("[{}] [{:<5}] [{}] ", now, record.level(), target);
+fn create_log_message(record: &log::Record<'_>, target: &str, start: Instant) -> String {
+    let runtime = start.elapsed();
+    let runtime_str = format!("{}.{:0>9}s", runtime.as_secs(), runtime.subsec_nanos());
+    let mut message = format!("[{}] [{:<5}] [{}] ", runtime_str, record.level(), target);
 
     // Alignment for the lines after the first new line character in the payload. We don't deal
     // with fullwidth/unicode chars here, so just `message.len()` is sufficient.


### PR DESCRIPTION
In 7398e9f a regression was introduced which causes Alacritty to crash
on startup since wayland has a keyboard repeat rate thread started
before our logger is initialized.

Since the latest version of time was rather inconvenient to use anyway
and there is no nice solution for this issue other than downgrading the
`time` version again, the time since startup is now logged instead of
the local time.

This should still provide all the relevant information, while getting
rid of an unnecessary dependency. While it would be possible to also
print the delta between log messages, this can be trivially computed so
it has been omitted to skip adding another `Mutex` to the `Logger`
struct.