### PR TITLE
Fix OSC 104 without parameters not reseting colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - OSC 4 not handling `?`
 - `?` in OSC strings reporting default colors instead of modified ones
-- OSC 104 not working when called without parameters but with a trailling semicolon (e.g. '\e]104;\e\\')
+- OSC 104 not clearing colors when second parameter is empty
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - OSC 4 not handling `?`
 - `?` in OSC strings reporting default colors instead of modified ones
+- OSC 104 not working when called without parameters but with a trailling semicolon (e.g. '\e]104;\e\\')
 
 ## 0.10.0
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1506,8 +1506,7 @@ mod tests {
         attr: Option<Attr>,
         identity_reported: bool,
         color: Option<Rgb>,
-        reset_color_index: Option<usize>,
-        reset_color_count: usize,
+        reset_colors: Vec<usize>,
     }
 
     impl Handler for MockHandler {
@@ -1537,8 +1536,7 @@ mod tests {
         }
 
         fn reset_color(&mut self, index: usize) {
-            self.reset_color_index = Some(index);
-            self.reset_color_count += 1;
+            self.reset_colors.push(index)
         }
     }
 
@@ -1550,8 +1548,7 @@ mod tests {
                 attr: None,
                 identity_reported: false,
                 color: None,
-                reset_color_index: None,
-                reset_color_count: 0,
+                reset_colors: Vec::new(),
             }
         }
     }
@@ -1776,8 +1773,7 @@ mod tests {
             parser.advance(&mut handler, *byte);
         }
 
-        assert_eq!(handler.reset_color_index, Some(1));
-        assert_eq!(handler.reset_color_count, 1);
+        assert_eq!(handler.reset_colors, vec![1]);
     }
 
     #[test]
@@ -1791,7 +1787,8 @@ mod tests {
             parser.advance(&mut handler, *byte);
         }
 
-        assert_eq!(handler.reset_color_count, 256);
+        let expected: Vec<usize> = (0..256).collect();
+        assert_eq!(handler.reset_colors, expected);
 
         // And test without trailling semicolon
         let bytes: &[u8] = b"\x1b]104\x1b\\";
@@ -1803,6 +1800,6 @@ mod tests {
             parser.advance(&mut handler, *byte);
         }
 
-        assert_eq!(handler.reset_color_count, 256);
+        assert_eq!(handler.reset_colors, expected);
     }
 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1064,7 +1064,7 @@ where
             // Reset color index.
             b"104" => {
                 // Reset all color indexes when no parameters are given.
-                if params.len() == 1 {
+                if params.len() == 1 || (params.len() > 1 && params[1].is_empty()) {
                     for i in 0..256 {
                         self.handler.reset_color(i);
                     }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1064,7 +1064,7 @@ where
             // Reset color index.
             b"104" => {
                 // Reset all color indexes when no parameters are given.
-                if params.len() == 1 || (params.len() > 1 && params[1].is_empty()) {
+                if params.len() == 1 || params[1].is_empty() {
                     for i in 0..256 {
                         self.handler.reset_color(i);
                     }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1789,8 +1789,10 @@ mod tests {
 
         let expected: Vec<usize> = (0..256).collect();
         assert_eq!(handler.reset_colors, expected);
+    }
 
-        // And test without trailling semicolon
+    #[test]
+    fn parse_osc104_reset_all_colors_no_semicolon() {
         let bytes: &[u8] = b"\x1b]104\x1b\\";
 
         let mut parser = Processor::new();
@@ -1800,6 +1802,7 @@ mod tests {
             parser.advance(&mut handler, *byte);
         }
 
+        let expected: Vec<usize> = (0..256).collect();
         assert_eq!(handler.reset_colors, expected);
     }
 }


### PR DESCRIPTION
Fixes #5542

Fix a bug where using OSC 104 without parameters but with a trailling semicolon (e.g. `\e]104;\e\\`) would not be handled.