### PR TITLE
Update YAML config location in README for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ following locations:
 
 On Windows, the config file should be located at:
 
-`%APPDATA%\alacritty\alacritty.yml`
+`%APPDATA%\Roaming\alacritty\alacritty.yml`
 
 ## Contributing
 


### PR DESCRIPTION
The README states `%APPDATA%\alacritty\alacritty.yml`, but [a comment in issue 3309](https://github.com/alacritty/alacritty/issues/3309#issuecomment-583313866) suggests including the `Roaming` directory in the path. I tried both and `%APPDATA%\Roaming\alacritty\alacritty.yml` worked.