### PR TITLE
Remove outdated changelog URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ You can find an overview over the features available in Alacritty [here](./docs/
 - [Announcing Alacritty, a GPU-Accelerated Terminal Emulator](https://jwilm.io/blog/announcing-alacritty/) January 6, 2017
 - [A talk about Alacritty at the Rust Meetup January 2017](https://www.youtube.com/watch?v=qHOdYO3WUTk) January 19, 2017
 - [Alacritty Lands Scrollback, Publishes Benchmarks](https://jwilm.io/blog/alacritty-lands-scrollback/) September 17, 2018
-- [Version 0.3.0 Release Announcement](https://blog.christianduerr.com/alacritty_030_announcement) April 07, 2019
-- [Version 0.5.0 Release Announcement](https://blog.christianduerr.com/alacritty_0_5_0_announcement) July 31, 2020
 
 ## Installation
 


### PR DESCRIPTION
Alacritty's website (https://alacritty.org) is now advertised publicly
on the GitHub page. Since that includes the old 0.3.0 and 0.5.0
changelogs, it's not necessary to point them out separately anymore.