### PR TITLE
Fix builtin font lines rendering with font.offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - OSC 4 not handling `?`
 - `?` in OSC strings reporting default colors instead of modified ones
 - OSC 104 not clearing colors when second parameter is empty
+- Builtin font lines not contiguous when `font.offset` is used
+- `font.glyph_offset` is no longer applied on builtin font
 
 ## 0.10.0
 


### PR DESCRIPTION
This commit takes into account font offset when generating builtin font.

--

I'm not sure about the thickness of those lines and the config option to disable them.  As for a thickness I'd pick something like `width / 4` and as for a config option I'm not sure, but we could add, I guess. What do you think @chrisduerr ?