### PR TITLE
Add option to control built-in box drawing chars

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -178,6 +178,13 @@
   # it is recommended to set `use_thin_strokes` to `false`.
   #use_thin_strokes: true
 
+  # Use built-in font for box drawing characters.
+  #
+  # If `true`, Alacritty will use a custom built-in font for box drawing
+  # characters (Unicode points 2500 - 259f).
+  #
+  #use_built_in_font_for_box_drawing: false
+
 # If `true`, bold text is drawn using the bright color variants.
 #draw_bold_text_with_bright_colors: false
 

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -38,6 +38,9 @@ pub struct Font {
 
     /// Font size in points.
     size: Size,
+
+    /// Whether to use the built-in font for box drawing characters.
+    pub use_built_in_font_for_box_drawing: bool,
 }
 
 impl Font {

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -351,8 +351,14 @@ impl Display {
             info!("Initializing glyph cache...");
             let init_start = Instant::now();
 
-            let cache =
-                renderer.with_loader(|mut api| GlyphCache::new(rasterizer, &font, &mut api))?;
+            let cache = renderer.with_loader(|mut api| {
+                GlyphCache::new(
+                    rasterizer,
+                    &font,
+                    &mut api,
+                    config.font.use_built_in_font_for_box_drawing,
+                )
+            })?;
 
             let stop = init_start.elapsed();
             let stop_f = stop.as_secs() as f64 + f64::from(stop.subsec_nanos()) / 1_000_000_000f64;


### PR DESCRIPTION
Adds a `font.use_built_in_font_for_box_drawing` config option to control whether the built-in font is used for drawing box characters. See #5809 for reference.