### PR TITLE
Fix repeated permission requests on M1 macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Builtin font lines not contiguous when `font.offset` is used
 - `font.glyph_offset` is no longer applied on builtin font
 - Buili-in font arcs alignment
+- Repeated permission prompts on M1 macs
 
 ## 0.10.0
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ $(APP_NAME)-%: $(TARGET)-%
 	@cp -fp $(APP_BINARY) $(APP_BINARY_DIR)
 	@cp -fp $(COMPLETIONS) $(APP_COMPLETIONS_DIR)
 	@touch -r "$(APP_BINARY)" "$(APP_DIR)/$(APP_NAME)"
+	@codesign --remove-signature "$(APP_DIR)/$(APP_NAME)"
+	@codesign --force --deep --sign - "$(APP_DIR)/$(APP_NAME)"
 	@echo "Created '$(APP_NAME)' in '$(APP_DIR)'"
 
 dmg: $(DMG_NAME)-native ## Create an Alacritty.dmg


### PR DESCRIPTION
This adds a codesign step to our makefile build which should
automatically sign the application and resolve the issues on M1 macs
where Alacritty constantly requests permissions.

Since self-signing does still seem to fix this issue after sharing the
resulting `Alacritty.app` with other M1 macs, the binary produced by our
release build should also be fixed automatically.

Fixes #5840.