### PR TITLE
Optimize terminal full damage

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -769,10 +769,10 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[inline]
     fn toggle_vi_mode(&mut self) {
         if self.terminal.mode().contains(TermMode::VI) {
-            // If we had search running when leaving Vi mode we should mark terminal fully damaged
+            // If we had search running when leaving Vi mode we should damage all terminal cells
             // to cleanup highlighted results.
             if self.search_state.dfas().is_some() {
-                self.terminal.mark_fully_damaged();
+                self.terminal.damage_all();
             } else {
                 // Damage line indicator and Vi cursor.
                 self.terminal.damage_vi_cursor();

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::mem;
 
+use glutin::Rect as DamageRect;
+
 use crossfont::Metrics;
 
 use alacritty_terminal::grid::Dimensions;
@@ -27,6 +29,11 @@ pub struct RenderRect {
 impl RenderRect {
     pub fn new(x: f32, y: f32, width: f32, height: f32, color: Rgb, alpha: f32) -> Self {
         RenderRect { x, y, width, height, color, alpha }
+    }
+
+    pub fn damage_rect(&self, size_info: &SizeInfo) -> DamageRect {
+        let y = (size_info.height() - self.y - self.height) as u32;
+        DamageRect { x: self.x as u32, y, width: self.width as u32, height: self.height as u32 }
     }
 }
 

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -229,6 +229,12 @@ impl<'de> Deserialize<'de> for CellRgb {
     }
 }
 
+/// Index of background color.
+pub const BACKGROUND_COLOR_INDEX: usize = 257;
+
+/// Index of cursor color.
+pub const CURSOR_COLOR_INDEX: usize = 258;
+
 /// Array of indexed colors.
 ///
 /// | Indices  | Description       |

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -258,16 +258,6 @@ impl LineDamageBounds {
     }
 }
 
-/// Terminal damage information collected since the last [`Term::reset_damage`] call.
-#[derive(Debug)]
-pub enum TermDamage<'a> {
-    /// The entire terminal is damaged.
-    Full,
-
-    /// Iterator over damaged lines in the terminal.
-    Partial(TermDamageIterator<'a>),
-}
-
 /// Iterator over the terminal's damaged lines.
 #[derive(Clone, Debug)]
 pub struct TermDamageIterator<'a> {
@@ -301,6 +291,9 @@ struct TermDamageState {
 
     /// Old selection range.
     last_selection: Option<SelectionRange>,
+
+    /// Previous visible lines `occ`.
+    last_occ: Vec<usize>,
 }
 
 impl TermDamageState {
@@ -313,6 +306,7 @@ impl TermDamageState {
             lines,
             last_cursor: Default::default(),
             last_selection: Default::default(),
+            last_occ: vec![0; num_lines],
         }
     }
 
@@ -323,10 +317,17 @@ impl TermDamageState {
         self.last_selection = None;
         self.is_fully_damaged = true;
 
+        self.last_occ.clear();
+        self.last_occ.reserve(num_lines);
+
         self.lines.clear();
         self.lines.reserve(num_lines);
         for line in 0..num_lines {
             self.lines.push(LineDamageBounds::undamaged(line, num_cols));
+
+            // Since we've resized the terminal we should redraw the entire screen, so we're
+            // marking terminal as fully damaged and make it look like all cells are occupied.
+            self.last_occ.push(num_cols);
         }
     }
 
@@ -502,7 +503,7 @@ impl<T> Term<T> {
     }
 
     #[must_use]
-    pub fn damage(&mut self, selection: Option<SelectionRange>) -> TermDamage<'_> {
+    pub fn damage(&mut self, selection: Option<SelectionRange>) -> TermDamageIterator<'_> {
         // Ensure the entire terminal is damaged after entering insert mode.
         // Leaving is handled in the ansi handler.
         if self.mode.contains(TermMode::INSERT) {
@@ -511,15 +512,39 @@ impl<T> Term<T> {
 
         // Early return if the entire terminal is damaged.
         if self.damage.is_fully_damaged {
+            for line in 0..self.screen_lines() {
+                let grid_line = Line(line as i32 - self.grid.display_offset() as i32);
+                let new_occ = self.grid[grid_line].occ;
+                let right = cmp::max(new_occ, self.damage.last_occ[line]);
+
+                self.damage.last_occ[line] = new_occ;
+
+                // Don't have to do anything when the line wasn't touched at all, since `occ` on row
+                // doesn't include right bound.
+                if right == 0 {
+                    continue;
+                }
+
+                self.damage_line(line, 0, cmp::min(right - 1, self.columns() - 1));
+            }
+
             self.damage.last_cursor = self.grid.cursor.point;
             self.damage.last_selection = selection;
-            return TermDamage::Full;
+            return TermDamageIterator::new(&self.damage.lines);
+        } else {
+            // We should always maintain `occ` state from the previous call to `[Term::damage]` so
+            // when we switch from partial damage to full damage we will cleanup viewport properly.
+            for line in 0..self.screen_lines() {
+                let grid_line = Line(line as i32 - self.grid.display_offset() as i32);
+                let occ = self.grid[grid_line].occ;
+                self.damage.last_occ[line] = occ;
+            }
         }
 
         // Add information about old cursor position and new one if they are not the same, so we
         // cover everything that was produced by `Term::input`.
         if self.damage.last_cursor != self.grid.cursor.point {
-            // Cursor cooridanates are always inside viewport even if you have `display_offset`.
+            // Cursor coordinates are always inside viewport even if you have `display_offset`.
             let point =
                 Point::new(self.damage.last_cursor.line.0 as usize, self.damage.last_cursor.column);
             self.damage.damage_point(point);
@@ -542,7 +567,7 @@ impl<T> Term<T> {
         }
         self.damage.last_selection = selection;
 
-        TermDamage::Partial(TermDamageIterator::new(&self.damage.lines))
+        TermDamageIterator::new(&self.damage.lines)
     }
 
     /// Resets the terminal damage information.
@@ -550,9 +575,22 @@ impl<T> Term<T> {
         self.damage.reset(self.columns());
     }
 
+    /// Marks terminal as fully damaged making it to produce the maximum damage area of occupied
+    /// cells intersected from previous call to [`Term::damage`] and the next one.
+    ///
+    /// If the goal is to damage all the cells including past `Row.occ` call `[Term::damage_all]`.
     #[inline]
-    pub fn mark_fully_damaged(&mut self) {
+    fn mark_fully_damaged(&mut self) {
         self.damage.is_fully_damaged = true;
+    }
+
+    /// Damages all the cells in the terminal including empty cells and unoccupied.
+    #[inline]
+    pub fn damage_all(&mut self) {
+        let num_cols = self.columns() - 1;
+        for line in 0..self.screen_lines() {
+            self.damage_line(line, 0, num_cols);
+        }
     }
 
     /// Damage line in a terminal viewport.
@@ -2011,7 +2049,7 @@ impl<T: EventListener> Handler for Term<T> {
         style.shape = shape;
     }
 
-    #[inline]
+    #[inline(never)]
     fn set_title(&mut self, title: Option<String>) {
         trace!("Setting title to '{:?}'", title);
 
@@ -2751,10 +2789,7 @@ mod tests {
         term.input('e');
         let right = term.grid.cursor.point.column.0;
 
-        let mut damaged_lines = match term.damage(None) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(None);
         assert_eq!(damaged_lines.next(), Some(LineDamageBounds { line: 0, left, right }));
         assert_eq!(damaged_lines.next(), None);
         term.reset_damage();
@@ -2769,10 +2804,7 @@ mod tests {
         selection.update(Point::new(Line(line), Column(5)), Side::Left);
         let selection_range = selection.to_range(&term);
 
-        let mut damaged_lines = match term.damage(selection_range) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(selection_range);
         let line = line as usize;
         // Skip cursor damage information, since we're just testing selection.
         damaged_lines.next();
@@ -2782,10 +2814,7 @@ mod tests {
 
         // Check that existing selection gets damaged when it is removed.
 
-        let mut damaged_lines = match term.damage(None) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(None);
         // Skip cursor damage information, since we're just testing selection clearing.
         damaged_lines.next();
         assert_eq!(damaged_lines.next(), Some(LineDamageBounds { line, left, right }));
@@ -2803,10 +2832,7 @@ mod tests {
         let line = vi_cursor_point.line.0 as usize;
         let left = vi_cursor_point.column.0 as usize;
         let right = left;
-        let mut damaged_lines = match term.damage(None) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(None);
         // Skip cursor damage information, since we're just testing Vi cursor.
         damaged_lines.next();
         assert_eq!(damaged_lines.next(), Some(LineDamageBounds { line, left, right }));


### PR DESCRIPTION
When terminal should be fully damaged we only want to occupied cells,
thus now alacritty_terminal always returns `TermDamageIterator`, but
when terminal was fully damaged it damages all the lines from 0 up to
line.occ. That helps a lot with something like `yes` or when scrolling
scrollback buffer by reducing the amount of damaged area.