### PR TITLE
Use buffer age to perform partial rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,8 +651,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ea9dbe544bc8a657c4c4a798c2d16cd01b549820e47657297549d28371f6d2"
+source = "git+https://github.com/kchibisov/glutin?branch=buffer-age#fc89d3166bd83c003dc4c123bc622546f117c5c9"
 dependencies = [
  "android_glue",
  "cgl",
@@ -678,8 +677,7 @@ dependencies = [
 [[package]]
 name = "glutin_egl_sys"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2abb6aa55523480c4adc5a56bbaa249992e2dddb2fc63dc96e04a3355364c211"
+source = "git+https://github.com/kchibisov/glutin?branch=buffer-age#fc89d3166bd83c003dc4c123bc622546f117c5c9"
 dependencies = [
  "gl_generator",
  "winapi 0.3.9",
@@ -688,14 +686,12 @@ dependencies = [
 [[package]]
 name = "glutin_emscripten_sys"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80de4146df76e8a6c32b03007bc764ff3249dcaeb4f675d68a06caf1bac363f1"
+source = "git+https://github.com/kchibisov/glutin?branch=buffer-age#fc89d3166bd83c003dc4c123bc622546f117c5c9"
 
 [[package]]
 name = "glutin_gles2_sys"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094e708b730a7c8a1954f4f8a31880af00eb8a1c5b5bf85d28a0a3c6d69103"
+source = "git+https://github.com/kchibisov/glutin?branch=buffer-age#fc89d3166bd83c003dc4c123bc622546f117c5c9"
 dependencies = [
  "gl_generator",
  "objc",
@@ -704,8 +700,7 @@ dependencies = [
 [[package]]
 name = "glutin_glx_sys"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e393c8fc02b807459410429150e9c4faffdb312d59b8c038566173c81991351"
+source = "git+https://github.com/kchibisov/glutin?branch=buffer-age#fc89d3166bd83c003dc4c123bc622546f117c5c9"
 dependencies = [
  "gl_generator",
  "x11-dl",
@@ -714,8 +709,7 @@ dependencies = [
 [[package]]
 name = "glutin_wgl_sys"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5951a1569dbab865c6f2a863efafff193a93caf05538d193e9e3816d21696"
+source = "git+https://github.com/kchibisov/glutin?branch=buffer-age#fc89d3166bd83c003dc4c123bc622546f117c5c9"
 dependencies = [
  "gl_generator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
 lto = true
 debug = 1
 incremental = false
+
+[patch.crates-io]
+glutin = { git = "https://github.com/kchibisov/glutin", branch = "buffer-age" }

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -13,12 +13,8 @@ uniform sampler2D mask;
 
 void main() {
     if (backgroundPass != 0) {
-        if (bg.a == 0.0) {
-            discard;
-        }
-
         alphaMask = vec4(1.0);
-        color = vec4(bg.rgb, bg.a);
+        color = vec4(bg.rgb * bg.a, bg.a);
     } else if ((int(fg.a) & COLORED) != 0) {
         // Color glyphs, like emojis.
         vec4 glyphColor = texture(mask, TexCoords);

--- a/alacritty/src/display/damage.rs
+++ b/alacritty/src/display/damage.rs
@@ -1,9 +1,17 @@
+//! Damage tracking and shaping routines.
+
 use std::cmp;
+use std::collections::VecDeque;
 use std::iter::Peekable;
 
 use glutin::Rect;
 
+use alacritty_terminal::index::Point;
+use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::term::{LineDamageBounds, SizeInfo, TermDamageIterator};
+
+/// Maximum percent of area growth from merging damaged rects.
+const MAX_GROWTH: f32 = 0.3;
 
 /// Iterator which converts `alacritty_terminal` damage information into renderer damaged rects.
 pub struct RenderDamageIterator<'a> {
@@ -12,7 +20,8 @@ pub struct RenderDamageIterator<'a> {
 }
 
 impl<'a> RenderDamageIterator<'a> {
-    pub fn new(damaged_lines: TermDamageIterator<'a>, size_info: SizeInfo<u32>) -> Self {
+    pub fn new(damaged_lines: &'a [LineDamageBounds], size_info: SizeInfo<u32>) -> Self {
+        let damaged_lines = TermDamageIterator::new(damaged_lines);
         Self { damaged_lines: damaged_lines.peekable(), size_info }
     }
 
@@ -46,14 +55,29 @@ impl<'a> Iterator for RenderDamageIterator<'a> {
         let line = self.damaged_lines.next()?;
         let mut total_damage_rect = self.overdamage(self.rect_for_line(line));
 
-        // Merge rectangles which overlap with each other.
+        // We don't want to merge `total_damage_rect` with lines that a much longer/shorter than
+        // it, since we'd end up damaging in suboptimal way.
+        let max_width_growth = self.size_info.width() / 3;
+
+        // Merge rectangles which overlap with each other, unless they don't grow by
+        // `max_width_growth` at once.
         while let Some(line) = self.damaged_lines.peek().copied() {
             let next_rect = self.overdamage(self.rect_for_line(line));
-            if !rects_overlap(total_damage_rect, next_rect) {
+            if !rects_overlap(&total_damage_rect, &next_rect) {
                 break;
             }
 
-            total_damage_rect = merge_rects(total_damage_rect, next_rect);
+            let merged_rect = merge_rects(total_damage_rect, next_rect);
+
+            // If the width growth is higher than `max_width_growth` don't merge rects and the
+            // area growth is larger than `MAX_GROWTH` to avoid overdamaging.
+            if width_growth(&total_damage_rect, &next_rect) > max_width_growth
+                && area_growth(&total_damage_rect, &merged_rect) > MAX_GROWTH
+            {
+                break;
+            }
+
+            total_damage_rect = merged_rect;
             let _ = self.damaged_lines.next();
         }
 
@@ -61,8 +85,24 @@ impl<'a> Iterator for RenderDamageIterator<'a> {
     }
 }
 
+/// The growth of width of intersected `[glutin::Rect]`.
+fn width_growth(lhs: &Rect, rhs: &Rect) -> u32 {
+    let lhs_x_end = (lhs.x + lhs.width) as i32;
+    let rhs_x_end = (rhs.x + rhs.width) as i32;
+
+    // The amount damage rect width growth.
+    (lhs.x as i32 - rhs.x as i32).abs() as u32 + (lhs_x_end - rhs_x_end).abs() as u32
+}
+
+/// Area occupied by `[glutin::Rect]`.
+fn area_growth(lhs: &Rect, rhs: &Rect) -> f32 {
+    let lhs_area = lhs.width * lhs.height;
+    let rhs_area = rhs.width * rhs.height;
+    1. - cmp::min(rhs_area, lhs_area) as f32 / cmp::max(rhs_area, lhs_area) as f32
+}
+
 /// Check if two given [`glutin::Rect`] overlap.
-fn rects_overlap(lhs: Rect, rhs: Rect) -> bool {
+pub fn rects_overlap(lhs: &Rect, rhs: &Rect) -> bool {
     !(
         // `lhs` is left of `rhs`.
         lhs.x + lhs.width < rhs.x
@@ -76,11 +116,119 @@ fn rects_overlap(lhs: Rect, rhs: Rect) -> bool {
 }
 
 /// Merge two [`glutin::Rect`] by producing the smallest rectangle that contains both.
-#[inline]
-fn merge_rects(lhs: Rect, rhs: Rect) -> Rect {
+pub fn merge_rects(lhs: Rect, rhs: Rect) -> Rect {
     let left_x = cmp::min(lhs.x, rhs.x);
     let right_x = cmp::max(lhs.x + lhs.width, rhs.x + rhs.width);
     let y_top = cmp::max(lhs.y + lhs.height, rhs.y + rhs.height);
     let y_bottom = cmp::min(lhs.y, rhs.y);
     Rect { x: left_x, y: y_bottom, width: right_x - left_x, height: y_top - y_bottom }
+}
+
+/// Maximum number of terminal damage states we maintain.
+const HISTORY_DAMAGE: usize = 4;
+
+/// Track damage information from `HISTORY_DAMAGE` amount of frames from `alacritty_terminal`.
+#[derive(Debug)]
+pub struct TerminalDamageHistory {
+    using_frames: usize,
+    history: VecDeque<Vec<LineDamageBounds>>,
+    should_clear: VecDeque<bool>,
+}
+
+impl TerminalDamageHistory {
+    pub fn new() -> Self {
+        let should_clear = VecDeque::with_capacity(HISTORY_DAMAGE);
+        Self { using_frames: 1, history: VecDeque::with_capacity(HISTORY_DAMAGE), should_clear }
+    }
+
+    /// Saves damages information as the information for the current frame updating the previously
+    /// saved damage state.
+    #[inline]
+    pub fn save_damage(&mut self, damage: &[LineDamageBounds], should_clear: bool) {
+        // We don't need to track frames older than `HISTORY_DAMAGE`.
+        if self.history.len() == HISTORY_DAMAGE {
+            let _ = self.history.pop_back();
+            let _ = self.should_clear.pop_back();
+        }
+
+        self.history.push_front(damage.to_owned());
+        self.should_clear.push_front(should_clear);
+    }
+
+    /// Return current size of the history.
+    #[inline]
+    pub fn history_size(&self) -> usize {
+        self.history.len()
+    }
+
+    /// Checks whether the given `point` is damaged checking `num_frames` amount of frames.
+    #[inline]
+    pub fn is_damaged(&self, point: Point<usize>) -> bool {
+        if self.using_frames > self.history_size() {
+            return true;
+        }
+
+        // Check previous frames.
+        for index in 0..self.using_frames {
+            let line = self.history[index][point.line];
+
+            // Enlarge bounds to account for wide chars.
+            if point.column >= line.left.saturating_sub(1) && point.column <= line.right + 1 {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Damage information for the lastest frame added to the history.
+    #[inline]
+    pub fn latest_damage(&self) -> &[LineDamageBounds] {
+        &self.history[0]
+    }
+
+    /// Damage all the lines in the current frame.
+    #[inline]
+    pub fn damage_all(&mut self, size_info: &SizeInfo) {
+        let last_column = size_info.columns() - 1;
+        for line in self.history[0].iter_mut() {
+            line.left = 0;
+            line.right = last_column;
+        }
+    }
+
+    /// Damage line in the current frame.
+    #[inline]
+    pub fn damage_line(&mut self, line: usize, left: usize, right: usize) {
+        self.history[0][line].left = cmp::min(self.history[0][line].left, left);
+        self.history[0][line].right = cmp::max(self.history[0][line].right, right);
+    }
+
+    /// Invalidate all previously saved damage.
+    #[inline]
+    pub fn invalidate(&mut self) {
+        self.using_frames = 1;
+        self.should_clear.clear();
+        self.history.clear();
+    }
+
+    /// Use that `num_frames` amount of frames when checking whether the points are damaged.
+    pub fn use_frames(&mut self, num_frames: usize) {
+        self.using_frames = num_frames;
+    }
+
+    /// Check if the window will be cleared.
+    pub fn should_clear(&self) -> bool {
+        if self.using_frames > self.history_size() {
+            return true;
+        }
+
+        for index in 0..self.using_frames {
+            if self.should_clear[index] {
+                return true;
+            }
+        }
+
+        false
+    }
 }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -769,10 +769,10 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[inline]
     fn toggle_vi_mode(&mut self) {
         if self.terminal.mode().contains(TermMode::VI) {
-            // If we had search running when leaving Vi mode we should mark terminal fully damaged
+            // If we had search running when leaving Vi mode we should damage all terminal cells
             // to cleanup highlighted results.
             if self.search_state.dfas().is_some() {
-                self.terminal.mark_fully_damaged();
+                self.terminal.damage_all();
             } else {
                 // Damage line indicator and Vi cursor.
                 self.terminal.damage_vi_cursor();

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::mem;
 
+use glutin::Rect as DamageRect;
+
 use crossfont::Metrics;
 
 use alacritty_terminal::grid::Dimensions;
@@ -27,6 +29,11 @@ pub struct RenderRect {
 impl RenderRect {
     pub fn new(x: f32, y: f32, width: f32, height: f32, color: Rgb, alpha: f32) -> Self {
         RenderRect { x, y, width, height, color, alpha }
+    }
+
+    pub fn damage_rect(&self, size_info: &SizeInfo) -> DamageRect {
+        let y = (size_info.height() - self.y - self.height) as u32;
+        DamageRect { x: self.x as u32, y, width: self.width as u32, height: self.height as u32 }
     }
 }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -258,16 +258,6 @@ impl LineDamageBounds {
     }
 }
 
-/// Terminal damage information collected since the last [`Term::reset_damage`] call.
-#[derive(Debug)]
-pub enum TermDamage<'a> {
-    /// The entire terminal is damaged.
-    Full,
-
-    /// Iterator over damaged lines in the terminal.
-    Partial(TermDamageIterator<'a>),
-}
-
 /// Iterator over the terminal's damaged lines.
 #[derive(Clone, Debug)]
 pub struct TermDamageIterator<'a> {
@@ -275,7 +265,7 @@ pub struct TermDamageIterator<'a> {
 }
 
 impl<'a> TermDamageIterator<'a> {
-    fn new(line_damage: &'a [LineDamageBounds]) -> Self {
+    pub fn new(line_damage: &'a [LineDamageBounds]) -> Self {
         Self { line_damage: line_damage.iter() }
     }
 }
@@ -301,6 +291,9 @@ struct TermDamageState {
 
     /// Old selection range.
     last_selection: Option<SelectionRange>,
+
+    /// Previous visible lines `occ`.
+    last_occ: Vec<usize>,
 }
 
 impl TermDamageState {
@@ -313,6 +306,7 @@ impl TermDamageState {
             lines,
             last_cursor: Default::default(),
             last_selection: Default::default(),
+            last_occ: vec![0; num_lines],
         }
     }
 
@@ -323,10 +317,17 @@ impl TermDamageState {
         self.last_selection = None;
         self.is_fully_damaged = true;
 
+        self.last_occ.clear();
+        self.last_occ.reserve(num_lines);
+
         self.lines.clear();
         self.lines.reserve(num_lines);
         for line in 0..num_lines {
             self.lines.push(LineDamageBounds::undamaged(line, num_cols));
+
+            // Since we've resized the terminal we should redraw the entire screen, so we're
+            // marking terminal as fully damaged and make it look like all cells are occupied.
+            self.last_occ.push(num_cols);
         }
     }
 
@@ -502,7 +503,7 @@ impl<T> Term<T> {
     }
 
     #[must_use]
-    pub fn damage(&mut self, selection: Option<SelectionRange>) -> TermDamage<'_> {
+    pub fn damage(&mut self, selection: Option<SelectionRange>) -> &Vec<LineDamageBounds> {
         // Ensure the entire terminal is damaged after entering insert mode.
         // Leaving is handled in the ansi handler.
         if self.mode.contains(TermMode::INSERT) {
@@ -511,15 +512,39 @@ impl<T> Term<T> {
 
         // Early return if the entire terminal is damaged.
         if self.damage.is_fully_damaged {
+            for line in 0..self.screen_lines() {
+                let grid_line = Line(line as i32 - self.grid.display_offset() as i32);
+                let new_occ = self.grid[grid_line].occ;
+                let right = cmp::max(new_occ, self.damage.last_occ[line]);
+
+                self.damage.last_occ[line] = new_occ;
+
+                // Don't have to do anything when the line wasn't touched at all, since `occ` on row
+                // doesn't include right bound.
+                if right == 0 {
+                    continue;
+                }
+
+                self.damage_line(line, 0, cmp::min(right - 1, self.columns() - 1));
+            }
+
             self.damage.last_cursor = self.grid.cursor.point;
             self.damage.last_selection = selection;
-            return TermDamage::Full;
+            return &self.damage.lines;
+        } else {
+            // We should always maintain `occ` state from the previous call to `[Term::damage]` so
+            // when we switch from partial damage to full damage we will cleanup viewport properly.
+            for line in 0..self.screen_lines() {
+                let grid_line = Line(line as i32 - self.grid.display_offset() as i32);
+                let occ = self.grid[grid_line].occ;
+                self.damage.last_occ[line] = occ;
+            }
         }
 
         // Add information about old cursor position and new one if they are not the same, so we
         // cover everything that was produced by `Term::input`.
         if self.damage.last_cursor != self.grid.cursor.point {
-            // Cursor cooridanates are always inside viewport even if you have `display_offset`.
+            // Cursor coordinates are always inside viewport even if you have `display_offset`.
             let point =
                 Point::new(self.damage.last_cursor.line.0 as usize, self.damage.last_cursor.column);
             self.damage.damage_point(point);
@@ -542,7 +567,7 @@ impl<T> Term<T> {
         }
         self.damage.last_selection = selection;
 
-        TermDamage::Partial(TermDamageIterator::new(&self.damage.lines))
+        &self.damage.lines
     }
 
     /// Resets the terminal damage information.
@@ -550,9 +575,22 @@ impl<T> Term<T> {
         self.damage.reset(self.columns());
     }
 
+    /// Marks terminal as fully damaged making it to produce the maximum damage area of occupied
+    /// cells intersected from previous call to [`Term::damage`] and the next one.
+    ///
+    /// If the goal is to damage all the cells including past `Row.occ` call `[Term::damage_all]`.
     #[inline]
     pub fn mark_fully_damaged(&mut self) {
         self.damage.is_fully_damaged = true;
+    }
+
+    /// Damages all the cells in the terminal including empty cells and unoccupied.
+    #[inline]
+    pub fn damage_all(&mut self) {
+        let num_cols = self.columns() - 1;
+        for line in 0..self.screen_lines() {
+            self.damage_line(line, 0, num_cols);
+        }
     }
 
     /// Damage line in a terminal viewport.
@@ -695,11 +733,11 @@ impl<T> Term<T> {
 
     /// Terminal content required for rendering.
     #[inline]
-    pub fn renderable_content(&self) -> RenderableContent<'_>
+    pub fn renderable_content(&self, selection: Option<SelectionRange>) -> RenderableContent<'_>
     where
         T: EventListener,
     {
-        RenderableContent::new(self)
+        RenderableContent::new(self, selection)
     }
 
     /// Access to the raw grid data structure.
@@ -1624,7 +1662,12 @@ impl<T: EventListener> Handler for Term<T> {
 
         // Damage terminal if the color changed and it's not the cursor.
         if index != NamedColor::Cursor as usize && self.colors[index] != Some(color) {
-            self.mark_fully_damaged();
+            if index == NamedColor::Background as usize {
+                // Background changes require redrawing the entire screen.
+                self.damage_all();
+            } else {
+                self.mark_fully_damaged();
+            }
         }
 
         self.colors[index] = Some(color);
@@ -1654,7 +1697,12 @@ impl<T: EventListener> Handler for Term<T> {
 
         // Damage terminal if the color changed and it's not the cursor.
         if index != NamedColor::Cursor as usize && self.colors[index].is_some() {
-            self.mark_fully_damaged();
+            if index == NamedColor::Background as usize {
+                // Background changes require redrawing the entire screen.
+                self.damage_all();
+            } else {
+                self.mark_fully_damaged();
+            }
         }
 
         self.colors[index] = None;
@@ -1702,6 +1750,7 @@ impl<T: EventListener> Handler for Term<T> {
         let bg = self.grid.cursor.template.bg;
 
         let screen_lines = self.screen_lines();
+        // TODO fix this bloody function.
 
         match mode {
             ansi::ClearMode::Above => {
@@ -1738,6 +1787,7 @@ impl<T: EventListener> Handler for Term<T> {
             ansi::ClearMode::All => {
                 if self.mode.contains(TermMode::ALT_SCREEN) {
                     self.grid.reset_region(..);
+                    self.damage_all();
                 } else {
                     let old_offset = self.grid.display_offset();
 
@@ -2023,7 +2073,7 @@ impl<T: EventListener> Handler for Term<T> {
         style.shape = shape;
     }
 
-    #[inline]
+    #[inline(never)]
     fn set_title(&mut self, title: Option<String>) {
         trace!("Setting title to '{:?}'", title);
 
@@ -2188,12 +2238,12 @@ pub struct RenderableContent<'a> {
 }
 
 impl<'a> RenderableContent<'a> {
-    fn new<T>(term: &'a Term<T>) -> Self {
+    fn new<T>(term: &'a Term<T>, selection: Option<SelectionRange>) -> Self {
         Self {
             display_iter: term.grid().display_iter(),
             display_offset: term.grid().display_offset(),
             cursor: RenderableCursor::new(term),
-            selection: term.selection.as_ref().and_then(|s| s.to_range(term)),
+            selection,
             colors: &term.colors,
             mode: *term.mode(),
         }
@@ -2763,10 +2813,7 @@ mod tests {
         term.input('e');
         let right = term.grid.cursor.point.column.0;
 
-        let mut damaged_lines = match term.damage(None) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(None);
         assert_eq!(damaged_lines.next(), Some(LineDamageBounds { line: 0, left, right }));
         assert_eq!(damaged_lines.next(), None);
         term.reset_damage();
@@ -2781,10 +2828,7 @@ mod tests {
         selection.update(Point::new(Line(line), Column(5)), Side::Left);
         let selection_range = selection.to_range(&term);
 
-        let mut damaged_lines = match term.damage(selection_range) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(selection_range);
         let line = line as usize;
         // Skip cursor damage information, since we're just testing selection.
         damaged_lines.next();
@@ -2794,10 +2838,7 @@ mod tests {
 
         // Check that existing selection gets damaged when it is removed.
 
-        let mut damaged_lines = match term.damage(None) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(None);
         // Skip cursor damage information, since we're just testing selection clearing.
         damaged_lines.next();
         assert_eq!(damaged_lines.next(), Some(LineDamageBounds { line, left, right }));
@@ -2815,10 +2856,7 @@ mod tests {
         let line = vi_cursor_point.line.0 as usize;
         let left = vi_cursor_point.column.0 as usize;
         let right = left;
-        let mut damaged_lines = match term.damage(None) {
-            TermDamage::Full => panic!("Expected partial damage, however got Full"),
-            TermDamage::Partial(damaged_lines) => damaged_lines,
-        };
+        let mut damaged_lines = term.damage(None);
         // Skip cursor damage information, since we're just testing Vi cursor.
         damaged_lines.next();
         assert_eq!(damaged_lines.next(), Some(LineDamageBounds { line, left, right }));


### PR DESCRIPTION
This commit makes uses of buffer age extension and recent
alacritty_terminal damage tracking to perform partial redraws on
platforms supporting `GLX_EXT_buffer_age` and `EGL_EXT_buffer_age`.

The alacritty_terminal damage tracking was enhanced in a way that it
reports damage only up to `occ`, so partial redraws during scrolling
are possible.

Fixes #5843.