### PR TITLE
Updated INSTALL.md with Wayland and X11 build info

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ Please refer to the [Dependencies](#dependencies) section.
         16. [Windows](#windows)
         17. [Other](#other)
 2. [Building](#building)
-    1. [Linux/Windows](#linux--windows)
+    1. [Linux/Windows/BSD](#linux--windows--bsd)
     2. [macOS](#macos)
 3. [Post Build](#post-build)
     1. [Terminfo](#terminfo)
@@ -236,14 +236,14 @@ filling in this section of the README.
 
 ## Building
 
-### Linux / Windows
+### Linux / Windows / BSD
 
 ```sh
 cargo build --release
 ```
 
-On Linux/BSD, if it is desired to build Alacritty without support for either the X11 or Wayland
-rendering backend the following commands can be used.
+On Linux/BSD, if it is desired to build Alacritty without support for either the
+X11 or Wayland rendering backend the following commands can be used.
 
 ```sh
 # Force support for only Wayland

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -242,6 +242,17 @@ filling in this section of the README.
 cargo build --release
 ```
 
+On Linux, if it is desired to build Alacritty without support for either the X11
+rendering backend the following commands can be used.
+
+```sh
+# Force support for only Wayland
+cargo build --release --no-default-features --features=wayland
+
+# Force support for only X11
+cargo build --release --no-default-features --features=x11
+```
+
 If all goes well, this should place a binary at `target/release/alacritty`.
 
 ### macOS

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -242,7 +242,7 @@ filling in this section of the README.
 cargo build --release
 ```
 
-On Linux, if it is desired to build Alacritty without support for either the X11
+On Linux/BSD, if it is desired to build Alacritty without support for either the X11 or Wayland
 rendering backend the following commands can be used.
 
 ```sh


### PR DESCRIPTION
I added to the documentation to outline how Linux users can go about building Alacritty with support for only one rendering backend.  This addresses issue #5792 "Document in INSTALL.md how to build with/without wayland/x11."  There were no code changes so I did not do any performance tests, I tried both build commands and they work.