### PR TITLE
Fix alpha when using `colors.transparent_background_colors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `font.glyph_offset` is no longer applied on builtin font
 - Buili-in font arcs alignment
 - Repeated permission prompts on M1 macs
+- Colors being slightly off when using `colors.transparent_background_colors`
 
 ## 0.10.0
 

--- a/alacritty/res/text.f.glsl
+++ b/alacritty/res/text.f.glsl
@@ -18,7 +18,9 @@ void main() {
         }
 
         alphaMask = vec4(1.0);
-        color = vec4(bg.rgb, bg.a);
+
+        // Premultiply background color by alpha.
+        color = vec4(bg.rgb * bg.a, bg.a);
     } else if ((int(fg.a) & COLORED) != 0) {
         // Color glyphs, like emojis.
         vec4 glyphColor = texture(mask, TexCoords);


### PR DESCRIPTION
The alpha is expected to be premultiplied from the text shader, so
we should apply it to the background color.
