### PR TITLE
Add support for drawing dashed and dotted underlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Option `font.builtin_box_drawing` to disable the built-in font for drawing box characters
 - Track and report surface damage information to Wayland compositors
-- Escape sequence for undercurl (`CSI 4 : 3 m`)
+- Escape sequence for undercurl, dotted and dashed underlines (`CSI 4 : [3-5] m`)
 
 ### Changed
 

--- a/alacritty/res/rect.f.glsl
+++ b/alacritty/res/rect.f.glsl
@@ -9,46 +9,121 @@ flat in vec4 color;
 
 out vec4 FragColor;
 
-uniform int isUndercurl;
+uniform int rectKind;
 
 uniform float cellWidth;
 uniform float cellHeight;
 uniform float paddingY;
 uniform float paddingX;
 
-uniform float undercurlThickness;
+uniform float underlinePosition;
+uniform float underlineThickness;
+
 uniform float undercurlPosition;
+
+#define UNDERCURL 1
+#define DOTTED 2
+#define DASHED 3
 
 #define PI 3.1415926538
 
-void main()
-{
-    if (isUndercurl == 0) {
-        FragColor = color;
-        return;
+vec4 draw_undercurl(int x, int y) {
+  // We use `undercurlPosition` as an amplitude, since it's half of the descent
+  // value.
+  float undercurl =
+      -1. * undercurlPosition / 2. * cos(float(x) * 2 * PI / cellWidth) +
+      cellHeight - undercurlPosition;
+
+  float undercurlTop = undercurl + max((underlineThickness - 1), 0);
+  float undercurlBottom = undercurl - max((underlineThickness - 1), 0);
+
+  // Compute resulted alpha based on distance from `gl_FragCoord.y` to the
+  // cosine curve.
+  float alpha = 1.;
+  if (y > undercurlTop || y < undercurlBottom) {
+    alpha = 1. - min(abs(undercurlTop - y), abs(undercurlBottom - y));
+  }
+
+  // The result is an alpha mask on a rect, which leaves only curve opaque.
+  return vec4(color.rgb, alpha);
+}
+
+// When the dot size increases we can use AA to make spacing look even and the
+// dots rounded.
+vec4 draw_dotted_aliased(float x, float y) {
+  int dotNumber = int(x / underlineThickness);
+
+  float radius = underlineThickness / 2.;
+  float centerY = cellHeight - underlinePosition;
+
+  float leftCenter = (dotNumber - dotNumber % 2) * underlineThickness + radius;
+  float rightCenter = leftCenter + 2 * underlineThickness;
+
+  float distanceLeft = sqrt(pow(x - leftCenter, 2) + pow(y - centerY, 2));
+  float distanceRight = sqrt(pow(x - rightCenter, 2) + pow(y - centerY, 2));
+
+  float alpha = max(1 - (min(distanceLeft, distanceRight) - radius), 0);
+  return vec4(color.rgb, alpha);
+}
+
+/// Draw dotted line when dot is just a single pixel.
+vec4 draw_dotted(int x, int y) {
+  int cellEven = 0;
+
+  // Since the size of the dot and its gap combined is 2px we should ensure that
+  // spacing will be even. If the cellWidth is even it'll work since we start
+  // with dot and end with gap. However if cellWidth is odd, the cell will start
+  // and end with a dot, creating a dash. To resolve this issue, we invert the
+  // pattern every two cells.
+  if (int(cellWidth) % 2 != 0) {
+    cellEven = int((gl_FragCoord.x - paddingX) / cellWidth) % 2;
+  }
+
+  // Since we use the entire descent area for dotted underlines, we limit its
+  // height to a single pixel so we don't draw bars instead of dots.
+  float alpha = 1. - abs(round(cellHeight - underlinePosition) - y);
+  if (x % 2 != cellEven) {
+    alpha = 0;
+  }
+
+  return vec4(color.rgb, alpha);
+}
+
+vec4 draw_dashed(int x) {
+  // Since dashes of adjacent cells connect with each other our dash length is
+  // half of the desired total length.
+  int halfDashLen = int(cellWidth) / 4;
+
+  float alpha = 1.;
+
+  // Check if `x` coordinate is where we should draw gap.
+  if (x > halfDashLen && x < cellWidth - halfDashLen - 1) {
+    alpha = 0.;
+  }
+
+  return vec4(color.rgb, alpha);
+}
+
+void main() {
+  int x = int(gl_FragCoord.x - paddingX) % int(cellWidth);
+  int y = int(gl_FragCoord.y - paddingY) % int(cellHeight);
+
+  switch (rectKind) {
+  case UNDERCURL:
+    FragColor = draw_undercurl(x, y);
+    break;
+  case DOTTED:
+    if (underlineThickness < 2) {
+      FragColor = draw_dotted(x, y);
+    } else {
+      FragColor = draw_dotted_aliased(x, y);
     }
-
-    int x = int(gl_FragCoord.x - paddingX) % int(cellWidth);
-    int y = int(gl_FragCoord.y - paddingY) % int(cellHeight);
-
-    // We use `undercurlPosition` as amplitude, since it's half of the descent
-    // value.
-    float undercurl = -1. * undercurlPosition / 2.
-        * cos(float(x) * 2 * PI / float(cellWidth))
-        + cellHeight - undercurlPosition;
-
-    // We subtract one, since curve is already 1px thick.
-    float undercurl_top = undercurl + max((undercurlThickness - 1), 0);
-    float undercurl_bottom = undercurl - max((undercurlThickness - 1), 0);
-
-
-    // Compute resulted alpha based on distance from `gl_FragCoord.y` to the
-    // cosine curve.
-    float alpha = 1.;
-    if (y > undercurl_top || y < undercurl_bottom) {
-        alpha = 1. - min(abs(undercurl_top - y), abs(undercurl_bottom - y));
-    }
-
-    // The result is an alpha mask on a rect, which leaves only curve opaque.
-    FragColor = vec4(color.xyz, alpha);
+    break;
+  case DASHED:
+    FragColor = draw_dashed(x);
+    break;
+  default:
+    FragColor = color;
+    break;
+  }
 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -772,6 +772,10 @@ pub enum Attr {
     DoubleUnderline,
     /// Undercurled text.
     Undercurl,
+    /// Dotted underlined text.
+    DottedUnderline,
+    /// Dashed underlined text.
+    DashedUnderline,
     /// Blink cursor slowly.
     BlinkSlow,
     /// Blink cursor fast.
@@ -1332,6 +1336,8 @@ fn attrs_from_sgr_parameters(params: &mut ParamsIter<'_>) -> Vec<Option<Attr>> {
             [4, 0] => Some(Attr::CancelUnderline),
             [4, 2] => Some(Attr::DoubleUnderline),
             [4, 3] => Some(Attr::Undercurl),
+            [4, 4] => Some(Attr::DottedUnderline),
+            [4, 5] => Some(Attr::DashedUnderline),
             [4, ..] => Some(Attr::Underline),
             [5] => Some(Attr::BlinkSlow),
             [6] => Some(Attr::BlinkFast),

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -25,7 +25,11 @@ bitflags! {
         const LEADING_WIDE_CHAR_SPACER  = 0b0000_0100_0000_0000;
         const DOUBLE_UNDERLINE          = 0b0000_1000_0000_0000;
         const UNDERCURL                 = 0b0001_0000_0000_0000;
-        const ALL_UNDERLINES            = Self::UNDERLINE.bits | Self::DOUBLE_UNDERLINE.bits | Self::UNDERCURL.bits;
+        const DOTTED_UNDERLINE          = 0b0010_0000_0000_0000;
+        const DASHED_UNDERLINE          = 0b0100_0000_0000_0000;
+        const ALL_UNDERLINES            = Self::UNDERLINE.bits | Self::DOUBLE_UNDERLINE.bits
+                                        | Self::UNDERCURL.bits | Self::DOTTED_UNDERLINE.bits
+                                        | Self::DASHED_UNDERLINE.bits;
     }
 }
 
@@ -119,9 +123,7 @@ impl GridCell for Cell {
             && self.fg == Color::Named(NamedColor::Foreground)
             && !self.flags.intersects(
                 Flags::INVERSE
-                    | Flags::UNDERLINE
-                    | Flags::DOUBLE_UNDERLINE
-                    | Flags::UNDERCURL
+                    | Flags::ALL_UNDERLINES
                     | Flags::STRIKEOUT
                     | Flags::WRAPLINE
                     | Flags::WIDE_CHAR_SPACER

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1850,6 +1850,14 @@ impl<T: EventListener> Handler for Term<T> {
                 cursor.template.flags.remove(Flags::ALL_UNDERLINES);
                 cursor.template.flags.insert(Flags::UNDERCURL);
             },
+            Attr::DottedUnderline => {
+                cursor.template.flags.remove(Flags::ALL_UNDERLINES);
+                cursor.template.flags.insert(Flags::DOTTED_UNDERLINE);
+            },
+            Attr::DashedUnderline => {
+                cursor.template.flags.remove(Flags::ALL_UNDERLINES);
+                cursor.template.flags.insert(Flags::DASHED_UNDERLINE);
+            },
             Attr::CancelUnderline => cursor.template.flags.remove(Flags::ALL_UNDERLINES),
             Attr::Hidden => cursor.template.flags.insert(Flags::HIDDEN),
             Attr::CancelHidden => cursor.template.flags.remove(Flags::HIDDEN),


### PR DESCRIPTION
This finishes implementation of underline styles provided by
`CSI 4 : [1-5] m` escape sequence.

--

I should still update ref test (it doesn't include dotted and dashed lines). Also I'll experiment how we could approach the structure in `alacritty`. For now just look at them visually and what you'd prefer @chrisduerr. I kind of like dashed, but not sure what to do about dotted.

![picture](https://user-images.githubusercontent.com/27620401/153454895-8380532b-0741-460a-861e-e8cabc0ec8cf.png)

