### PR TITLE
Fix warnings when building only with Wayland feature

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -33,7 +33,7 @@ tasks:
       cargo clippy --all-targets
   - feature-wayland: |
       cd alacritty/alacritty
-      cargo test --no-default-features --features=wayland
+      RUSTFLAGS="-D warnings" cargo test --no-default-features --features=wayland
   - feature-x11: |
       cd alacritty/alacritty
-      cargo test --no-default-features --features=x11
+      RUSTFLAGS="-D warnings" cargo test --no-default-features --features=x11

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -36,7 +36,7 @@ tasks:
       cargo clippy --all-targets
   - feature-wayland: |
       cd alacritty/alacritty
-      cargo test --no-default-features --features=wayland
+      RUSTFLAGS="-D warnings" cargo test --no-default-features --features=wayland
   - feature-x11: |
       cd alacritty/alacritty
-      cargo test --no-default-features --features=x11
+      RUSTFLAGS="-D warnings" cargo test --no-default-features --features=x11

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -20,7 +20,7 @@ use std::string::ToString;
 use std::{fs, process};
 
 use glutin::event_loop::EventLoop as GlutinEventLoop;
-#[cfg(not(any(target_os = "macos", windows)))]
+#[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
 use glutin::platform::unix::EventLoopWindowTargetExtUnix;
 use log::info;
 #[cfg(windows)]


### PR DESCRIPTION
This commit also makes our CI fail hard when warning encountered when
building only for either Wayland or X11.
