### PR TITLE
Clear damage rects right after drawing

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -573,7 +573,6 @@ impl Display {
         let vi_mode_cursor = if vi_mode { Some(terminal.vi_mode_cursor) } else { None };
 
         if self.collect_damage() {
-            self.damage_rects.clear();
             self.update_damage(&mut terminal, selection_range, search_state);
         }
 
@@ -740,6 +739,8 @@ impl Display {
                 api.finish();
             });
         }
+
+        self.damage_rects.clear();
     }
 
     /// Update to a new configuration.


### PR DESCRIPTION
Since we could queue damage before we get into the actual rendering
we should clear it after drawing not before.