### PR TITLE
Account for absolute WAYLAND_DISPLAY paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Buili-in font arcs alignment
 - Repeated permission prompts on M1 macs
 - Colors being slightly off when using `colors.transparent_background_colors`
+- Creating the IPC socket failing if WAYLAND_DISPLAY contains an absolute path
 
 ## 0.10.0
 

--- a/alacritty/src/ipc.rs
+++ b/alacritty/src/ipc.rs
@@ -152,7 +152,7 @@ fn find_socket(socket_path: Option<PathBuf>) -> IoResult<UnixStream> {
 #[cfg(not(target_os = "macos"))]
 fn socket_prefix() -> String {
     let display = env::var("WAYLAND_DISPLAY").or_else(|_| env::var("DISPLAY")).unwrap_or_default();
-    format!("Alacritty-{}", display)
+    format!("Alacritty-{}", display.replace('/', "-"))
 }
 
 /// File prefix matching all available sockets.


### PR DESCRIPTION
If WAYLAND_DISPLAY contains a '/', we have to replace with with another
character before using WAYLAND_DISPLAY as a path component.