### PR TITLE
Reuse Rasterizer in Display::new

### DIFF
--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -404,10 +404,12 @@ impl GlyphCache {
     }
 
     /// Calculate font metrics without access to a glyph cache.
-    pub fn static_metrics(font: Font, dpr: f64) -> Result<crossfont::Metrics, crossfont::Error> {
-        let mut rasterizer = crossfont::Rasterizer::new(dpr as f32, font.use_thin_strokes)?;
+    pub fn static_metrics(
+        rasterizer: &mut crossfont::Rasterizer,
+        font: Font,
+    ) -> Result<crossfont::Metrics, crossfont::Error> {
         let regular_desc = GlyphCache::make_desc(font.normal(), Slant::Normal, Weight::Normal);
-        let regular = Self::load_regular_font(&mut rasterizer, &regular_desc, font.size())?;
+        let regular = Self::load_regular_font(rasterizer, &regular_desc, font.size())?;
         rasterizer.get_glyph(GlyphKey { font_key: regular, character: 'm', size: font.size() })?;
 
         rasterizer.metrics(regular, font.size())


### PR DESCRIPTION
Instead of creating a `Rasterizer` to guess the window dimensions,
dropping it and then creating a new one for the glyph cache, reuse the
same `Rasterizer`.

This prevents the font from being loaded twice during startup.