### PR TITLE
Fix window layout on macOS when create window

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -37,6 +37,7 @@ use alacritty_terminal::term::{ClipboardType, SizeInfo, Term, TermMode};
 use crate::cli::{Options as CliOptions, WindowOptions};
 use crate::clipboard::Clipboard;
 use crate::config::ui_config::{HintAction, HintInternalAction};
+use crate::config::window::StartupMode;
 use crate::config::{self, UiConfig};
 #[cfg(not(windows))]
 use crate::daemon::foreground_process_path;
@@ -1223,6 +1224,13 @@ impl Processor {
         proxy: EventLoopProxy<Event>,
         options: WindowOptions,
     ) -> Result<(), Box<dyn Error>> {
+        // On macOS, when current window is Fullscreen, new window should be Windowed,
+        // otherwise the creation of the window is chaotic.
+        #[cfg(target_os = "macos")]
+        if !self.windows.is_empty() 
+            && self.config.window.startup_mode == StartupMode::Fullscreen {
+            self.config.window.startup_mode = StartupMode::Windowed;
+        }
         let window_context = WindowContext::new(
             &self.config,
             &options,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -37,6 +37,7 @@ use alacritty_terminal::term::{ClipboardType, SizeInfo, Term, TermMode};
 use crate::cli::{Options as CliOptions, WindowOptions};
 use crate::clipboard::Clipboard;
 use crate::config::ui_config::{HintAction, HintInternalAction};
+#[cfg(target_os = "macos")]
 use crate::config::window::StartupMode;
 use crate::config::{self, UiConfig};
 #[cfg(not(windows))]
@@ -1227,8 +1228,7 @@ impl Processor {
         // On macOS, when current window is Fullscreen, new window should be Windowed,
         // otherwise the creation of the window is chaotic.
         #[cfg(target_os = "macos")]
-        if !self.windows.is_empty() 
-            && self.config.window.startup_mode == StartupMode::Fullscreen {
+        if !self.windows.is_empty() && self.config.window.startup_mode == StartupMode::Fullscreen {
             self.config.window.startup_mode = StartupMode::Windowed;
         }
         let window_context = WindowContext::new(


### PR DESCRIPTION
On macOS, when current window is Fullscreen, new window should be Windowed. Otherwise it will create two fullscreen window and a tab bar on the top each window, and the window cannot be closed correctly.
If current window is fullscreen, and new window is windowed, they will tile on the same window as tab. I think this is the best way to arrange windows.