### PR TITLE
Use round instead of ceil for underline position

### DIFF
--- a/alacritty/res/rect.f.glsl
+++ b/alacritty/res/rect.f.glsl
@@ -87,7 +87,7 @@ color_t draw_dotted(float_t x, float_t y) {
 
   // Since we use the entire descent area for dotted underlines, we limit its
   // height to a single pixel so we don't draw bars instead of dots.
-  float_t alpha = 1. - abs(floor(underlinePosition - 0.5) - y);
+  float_t alpha = 1. - abs(floor(underlinePosition) - y);
   if (int(mod(x, 2.)) != int(cellEven)) {
     alpha = 0.;
   }

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -137,7 +137,7 @@ impl RenderLine {
         let line_bottom = (start.line as f32 + 1.) * size.cell_height();
         let baseline = line_bottom + descent;
 
-        let mut y = (baseline - position - thickness / 2.).ceil();
+        let mut y = (baseline - position - thickness / 2.).round();
         let max_y = line_bottom - thickness;
         if y > max_y {
             y = max_y;


### PR DESCRIPTION
Ceiling underline position results in strikeout text being lower than
it should.

--

I've rechecked the original issue with the font provided there and it doesn't cause any issues.

