### PR TITLE
Fix clippy errors with rust 1.59.0

### DIFF
--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -75,11 +75,10 @@ impl Scheduler {
         let deadline = Instant::now() + interval;
 
         // Get insert position in the schedule.
-        let index = self
-            .timers
-            .iter()
-            .position(|timer| timer.deadline > deadline)
-            .unwrap_or_else(|| self.timers.len());
+        // FIXME once MSRV is bumped to 1.59.0 inline `self.timers.len()`.
+        let num_timers = self.timers.len();
+        let index =
+            self.timers.iter().position(|timer| timer.deadline > deadline).unwrap_or(num_timers);
 
         // Set the automatic event repeat rate.
         let interval = if repeat { Some(interval) } else { None };


### PR DESCRIPTION
Rust 1.59.0 forces to use `unwrap_or` for closure, however the previous
version suggests `unwrap_or_else`, given that access to `len` is contant
`unwrap_or` makes sense, however fixes this clippy error results in
clippy failures with MSRV
