### PR TITLE
Fix crash when searching during reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Creating the IPC socket failing if WAYLAND_DISPLAY contains an absolute path
+- Crash when resetting the terminal while in vi mode
 
 ## 0.10.1
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -853,10 +853,9 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
         }
 
         // Reset display offset and cursor position.
+        self.terminal.vi_mode_cursor.point = self.search_state.origin;
         self.terminal.scroll_display(Scroll::Delta(self.search_state.display_offset_delta));
         self.search_state.display_offset_delta = 0;
-        self.terminal.vi_mode_cursor.point =
-            self.search_state.origin.grid_clamp(self.terminal, Boundary::Grid);
 
         *self.dirty = true;
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1795,6 +1795,7 @@ impl<T: EventListener> Handler for Term<T> {
         self.title_stack = Vec::new();
         self.title = None;
         self.selection = None;
+        self.vi_mode_cursor = Default::default();
 
         // Preserve vi mode across resets.
         self.mode &= TermMode::VI;


### PR DESCRIPTION
This fixes a crash which would occur when the terminal was reset while
searching, causing the vi mode cursor to be outside of the visible area.

This also fixes an issue where the search state reset would incorrectly
clamp the vi mode cursor to the grid, rather than the absolute viewport
position.

While this fix does resolve all crashes when searching while running
`cat /dev/urandom`, it does raise the question if manually clamping the
vi mode cursor in every location where it is modified is the right
choice.

I personally would recommend not applying this patch but instead
clamping the vi mode cursor when it is acquired for rendering, then
removing all the logic that tries to clamp it in other locations.

Fixes #5942.