### PR TITLE
Reset blinking on search bindings in Vi mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `font.glyph_offset` not live reloading
 - Failure when running on 10-bit color system
 - The colors being slightly different when using srgb displays on macOS
+- Vi cursor blinking not reset when navigating in search
 
 ## 0.10.1
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -181,6 +181,8 @@ impl<T: EventListener> Execute<T> for Action {
                 ctx.display().vi_highlighted_hint = hint;
             },
             Action::Vi(ViAction::SearchNext) => {
+                ctx.on_typing_start();
+
                 let terminal = ctx.terminal();
                 let direction = ctx.search_direction();
                 let vi_point = terminal.vi_mode_cursor.point;
@@ -195,6 +197,8 @@ impl<T: EventListener> Execute<T> for Action {
                 }
             },
             Action::Vi(ViAction::SearchPrevious) => {
+                ctx.on_typing_start();
+
                 let terminal = ctx.terminal();
                 let direction = ctx.search_direction().opposite();
                 let vi_point = terminal.vi_mode_cursor.point;


### PR DESCRIPTION
The Vi cursor is used as the current match indicator, however when
it's blinking during search jumps the current match is invisible.

Fixes #5934.

--

I'm not sure if there're other bindings when we should reset the cursor. But from what I can tell this is the most annoying one... Maybe we should just always reset blinking when touching keyboard?