### PR TITLE
Fix OSC 4 color response format

### DIFF
--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -430,8 +430,8 @@ pub trait Handler {
     /// Set an indexed color value.
     fn set_color(&mut self, _: usize, _: Rgb) {}
 
-    /// Write a foreground/background color escape sequence with the current color.
-    fn dynamic_color_sequence(&mut self, _: u8, _: usize, _: &str) {}
+    /// Respond to a color query escape sequence.
+    fn dynamic_color_sequence(&mut self, _: String, _: usize, _: &str) {}
 
     /// Reset an indexed color to original value.
     fn reset_color(&mut self, _: usize) {}
@@ -997,7 +997,8 @@ where
                     if let Some(c) = xparse_color(chunk[1]) {
                         self.handler.set_color(index as usize, c);
                     } else if chunk[1] == b"?" {
-                        self.handler.dynamic_color_sequence(index, index as usize, terminator);
+                        let prefix = format!("4;{}", index);
+                        self.handler.dynamic_color_sequence(prefix, index as usize, terminator);
                     } else {
                         unhandled(params);
                     }
@@ -1023,7 +1024,7 @@ where
                                 self.handler.set_color(index, color);
                             } else if param == b"?" {
                                 self.handler.dynamic_color_sequence(
-                                    dynamic_code,
+                                    dynamic_code.to_string(),
                                     index,
                                     terminator,
                                 );

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1630,10 +1630,10 @@ impl<T: EventListener> Handler for Term<T> {
         self.colors[index] = Some(color);
     }
 
-    /// Write a foreground/background color escape sequence with the current color.
+    /// Respond to a color query escape sequence.
     #[inline]
-    fn dynamic_color_sequence(&mut self, code: u8, index: usize, terminator: &str) {
-        trace!("Requested write of escape sequence for color code {}: color[{}]", code, index);
+    fn dynamic_color_sequence(&mut self, prefix: String, index: usize, terminator: &str) {
+        trace!("Requested write of escape sequence for color code {}: color[{}]", prefix, index);
 
         let terminator = terminator.to_owned();
         self.event_proxy.send_event(Event::ColorRequest(
@@ -1641,7 +1641,7 @@ impl<T: EventListener> Handler for Term<T> {
             Arc::new(move |color| {
                 format!(
                     "\x1b]{};rgb:{1:02x}{1:02x}/{2:02x}{2:02x}/{3:02x}{3:02x}{4}",
-                    code, color.r, color.g, color.b, terminator
+                    prefix, color.r, color.g, color.b, terminator
                 )
             }),
         ));


### PR DESCRIPTION
The commit 60ef17e introduced support for the color query response
escape for OSC 4, however it did omit the `4;` prefix and started the
OSC with just the color index.

This patch fixes this bug and correctly responds to queries with full
OSC 4 format, including prefix plus color index.

Fixes #5981.