### PR TITLE
Disallow OSC 52 for unfocused window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - The `--help` output was reworked with a new colorful syntax
+- OSC 52 is now disabled on unfocused windows
 
 ### Fixed
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1078,11 +1078,15 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         }
                     },
                     TerminalEvent::ClipboardStore(clipboard_type, content) => {
-                        self.ctx.clipboard.store(clipboard_type, content);
+                        if self.ctx.terminal.is_focused {
+                            self.ctx.clipboard.store(clipboard_type, content);
+                        }
                     },
                     TerminalEvent::ClipboardLoad(clipboard_type, format) => {
-                        let text = format(self.ctx.clipboard.load(clipboard_type).as_str());
-                        self.ctx.write_to_pty(text.into_bytes());
+                        if self.ctx.terminal.is_focused {
+                            let text = format(self.ctx.clipboard.load(clipboard_type).as_str());
+                            self.ctx.write_to_pty(text.into_bytes());
+                        }
                     },
                     TerminalEvent::ColorRequest(index, format) => {
                         let color = self.ctx.terminal().colors()[index]


### PR DESCRIPTION
This leads to issues on macOS, since if we store clipboard at the same
time it could error out. Also, on e.g. Wayland the clipboard store for
unfocused window won't work anyway.

--

I've verified that it resolves the issue on macOS.