### PR TITLE
Show the history line indicator also when scrolled

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -775,6 +775,9 @@ impl Display {
         } else if search_state.regex().is_some() {
             // Show current display offset in vi-less search to indicate match position.
             self.draw_line_indicator(config, &size_info, total_lines, None, display_offset);
+        } else if display_offset != 0 {
+            // Also show the current display offset if the user scrolled.
+            self.draw_line_indicator(config, &size_info, total_lines, None, display_offset);
         }
 
         // Draw cursor.


### PR DESCRIPTION
There is currently no scrollbar, but also not any kind of visual
indication when the user scrolled the buffer into the history.

There is however the numerical line indicator that is drawn when in
search mode or in vi cursor mode.
This changes also draws the indicator any time where the current
display offset is non-zero.

Related to #775