### PR TITLE
Be less aggressive when copying selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Failure when running on 10-bit color system
 - The colors being slightly different when using srgb displays on macOS
 - Vi cursor blinking not reset when navigating in search
+- Scrolling and middle-clicking modifying the primary selection
 
 ## 0.10.1
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -233,7 +233,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             let point = self.mouse.point(&self.size_info(), display_offset);
             self.update_selection(point, self.mouse.cell_side);
         }
-        self.copy_selection(ClipboardType::Selection);
 
         *self.dirty = true;
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -614,8 +614,10 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let timer_id = TimerId::new(Topic::SelectionScrolling, self.ctx.window().id());
         self.ctx.scheduler_mut().unschedule(timer_id);
 
-        // Copy selection on release, to prevent flooding the display server.
-        self.ctx.copy_selection(ClipboardType::Selection);
+        if let MouseButton::Left | MouseButton::Right = button {
+            // Copy selection on release, to prevent flooding the display server.
+            self.ctx.copy_selection(ClipboardType::Selection);
+        }
     }
 
     pub fn mouse_wheel_input(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {


### PR DESCRIPTION
1. Don't copy the selection when scrolling: The action of scrolling
   itself should not modify the primary selection. If the left/right
   mouse button is pressed while scrolling, the overall selected text
   will be copied when the button is released.

   Previously this caused the following unexpected behavior: When trying
   to paste text into alacritty, scrolling before pasting, e.g. because
   the user had scrolled up, would cause the to-be-pasted text to be
   replaced by whatever was currently selected in alacritty.

   Significantly, since the middle mouse button is usually a scroll
   wheel, it would not be unexpected for the user to accidentally scroll
   while trying to press the middle mouse button to paste text into
   alacritty.

2. Don't copy the selection upon button release unless the button is the
   left or right button.

   Previously this caused the following unexpected behavier: Pasting
   text into an alacritty window by pressing the middle mouse button
   would replace the primary selection with whatever was currently
   selected in alacritty.