### PR TITLE
Fix a selection range move after leaves vi-mode

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -771,6 +771,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             // If we had search running when leaving Vi mode we should mark terminal fully damaged
             // to cleanup highlighted results.
             if self.search_state.dfas().is_some() {
+                self.search_state.dfas = None;
                 self.terminal.mark_fully_damaged();
             } else {
                 // Damage line indicator and Vi cursor.
@@ -781,7 +782,10 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             self.clear_selection();
         }
 
-        self.cancel_search();
+        if self.search_active() {
+            self.cancel_search();
+        }
+
         self.terminal.toggle_vi_mode();
 
         *self.dirty = true;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -770,8 +770,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         if self.terminal.mode().contains(TermMode::VI) {
             // If we had search running when leaving Vi mode we should mark terminal fully damaged
             // to cleanup highlighted results.
-            if self.search_state.dfas().is_some() {
-                self.search_state.dfas = None;
+            if self.search_state.dfas.take().is_some() {
                 self.terminal.mark_fully_damaged();
             } else {
                 // Damage line indicator and Vi cursor.


### PR DESCRIPTION
This patch fixes that the right point of the selection range moves to another point when leaves vi-mode with a selection by ToggleViMode. The cause is that always moves a vi-mode cursor to a search origin whether or not the current search is active.

This problem is a regression which is introduced by #5945.


https://user-images.githubusercontent.com/12132068/166694319-e0a1c16c-ebb8-420d-b7c0-cf34b381f1b2.mp4