### PR TITLE
Fix gap in builtin box drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The colors being slightly different when using srgb displays on macOS
 - Vi cursor blinking not reset when navigating in search
 - Scrolling and middle-clicking modifying the primary selection
+- Bottom gap for certain builtin box drawing characters
 
 ## 0.10.1
 

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -412,7 +412,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
             };
 
             // Fix `y` coordinates.
-            y = height - y;
+            y = (height - y).round();
 
             // Ensure that resulted glyph will be visible and also round sizes instead of straight
             // flooring them.


### PR DESCRIPTION
Builtin box drawing glyphs in range from '\u{2580}' to `\u{2587}`
could have gap due to missing rounding. Previously height was rounded,
however not the `y` offset. This commit fixes it.