### PR TITLE
Fix builtin box-drawing glyphs for U+2567 and U+2568

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Vi cursor blinking not reset when navigating in search
 - Scrolling and middle-clicking modifying the primary selection
 - Bottom gap for certain builtin box drawing characters
+- Incorrect buili-in glyphs for `U+2567` and `U+2568`
 
 ## 0.10.1
 

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -274,7 +274,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
                 '\u{2561}'..='\u{2563}' | '\u{256a}' | '\u{256c}' => {
                     (v_left_bounds.1, v_left_bounds.1)
                 },
-                '\u{2564}'..='\u{2566}' => (canvas.x_center(), v_left_bounds.1),
+                '\u{2564}'..='\u{2568}' => (canvas.x_center(), v_left_bounds.1),
                 '\u{2569}'..='\u{2569}' => (v_left_bounds.1, canvas.x_center()),
                 _ => (0., 0.),
             };
@@ -297,13 +297,13 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
             // Top vertical part.
             let (left_top_size, right_top_size) = match character {
                 '\u{2551}' | '\u{256a}' => (canvas.y_center(), canvas.y_center()),
-                '\u{2558}'..='\u{255c}' | '\u{2567}' | '\u{2568}' => {
-                    (h_bot_bounds.1, h_top_bounds.1)
-                },
+                '\u{2558}'..='\u{255c}' | '\u{2568}' => (h_bot_bounds.1, h_top_bounds.1),
                 '\u{255d}' => (h_top_bounds.1, h_bot_bounds.1),
                 '\u{255e}'..='\u{2560}' => (canvas.y_center(), h_top_bounds.1),
                 '\u{2561}'..='\u{2563}' => (h_top_bounds.1, canvas.y_center()),
-                '\u{2569}' | '\u{256b}' | '\u{256c}' => (h_top_bounds.1, h_top_bounds.1),
+                '\u{2567}' | '\u{2569}' | '\u{256b}' | '\u{256c}' => {
+                    (h_top_bounds.1, h_top_bounds.1)
+                },
                 _ => (0., 0.),
             };
 


### PR DESCRIPTION
I noticed following two characters are rendered incorrectly.

- U+2567 (BOX DRAWINGS UP SINGLE AND HORIZONTAL DOUBLE)
- U+2568 (BOX DRAWINGS UP DOUBLE AND HORIZONTAL SINGLE)

Screenshot taken in the master branch: 
![master](https://user-images.githubusercontent.com/20703163/169463916-e67198c7-9087-4093-a3bf-aa891b024f90.png)

This PR makes these characters be rendered correctly.
Screenshot taken after applying this patch: 
![fix-builtin-font](https://user-images.githubusercontent.com/20703163/169463935-72c2762f-f282-4bb2-b660-3031263a99d7.png)

`test.sh` I used in the above screenshots:
```
#!/bin/bash
echo -e 'U+2558: \u2558'
echo -e 'U+2559: \u2559'
echo -e 'U+2567: \u2567'
echo -e 'U+2568: \u2568'
```

Reference: http://www.unicode.org/charts/PDF/U2500.pdf