### PR TITLE
Fix Vi cursor not being damaged on scroll

### DIFF
--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -11,12 +11,12 @@ use alacritty_terminal::selection::SelectionRange;
 use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::term::color::{CellRgb, Rgb};
 use alacritty_terminal::term::search::{Match, RegexIter, RegexSearch};
-use alacritty_terminal::term::{RenderableContent as TerminalContent, Term, TermMode};
+use alacritty_terminal::term::{self, RenderableContent as TerminalContent, Term, TermMode};
 
 use crate::config::UiConfig;
 use crate::display::color::{List, DIM_FACTOR};
 use crate::display::hint::HintState;
-use crate::display::{self, Display, MAX_SEARCH_LINES};
+use crate::display::{Display, MAX_SEARCH_LINES};
 use crate::event::SearchState;
 
 /// Minimum contrast between a fixed cursor color and the cell's background.
@@ -63,7 +63,7 @@ impl<'a> RenderableContent<'a> {
         // Convert terminal cursor point to viewport position.
         let cursor_point = terminal_content.cursor.point;
         let display_offset = terminal_content.display_offset;
-        let cursor_point = display::point_to_viewport(display_offset, cursor_point).unwrap();
+        let cursor_point = term::point_to_viewport(display_offset, cursor_point).unwrap();
 
         let hint = if display.hint_state.active() {
             display.hint_state.update_matches(term);
@@ -250,7 +250,7 @@ impl RenderableCell {
 
         // Convert cell point to viewport position.
         let cell_point = cell.point;
-        let point = display::point_to_viewport(display_offset, cell_point).unwrap();
+        let point = term::point_to_viewport(display_offset, cell_point).unwrap();
 
         let flags = cell.flags;
         let underline = cell

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -32,7 +32,7 @@ use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Boundary, Column, Direction, Line, Point, Side};
 use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::term::search::{Match, RegexSearch};
-use alacritty_terminal::term::{ClipboardType, Term, TermMode};
+use alacritty_terminal::term::{self, ClipboardType, Term, TermMode};
 
 use crate::cli::{Options as CliOptions, WindowOptions};
 use crate::clipboard::Clipboard;
@@ -43,7 +43,7 @@ use crate::daemon::foreground_process_path;
 use crate::daemon::spawn_daemon;
 use crate::display::hint::HintMatch;
 use crate::display::window::Window;
-use crate::display::{self, Display, SizeInfo};
+use crate::display::{Display, SizeInfo};
 use crate::input::{self, ActionContext as _, FONT_SIZE_STEP};
 use crate::message_bar::{Message, MessageBuffer};
 use crate::scheduler::{Scheduler, TimerId, Topic};
@@ -1020,7 +1020,7 @@ impl Mouse {
         let line = self.y.saturating_sub(size.padding_y() as usize) / (size.cell_height() as usize);
         let line = min(line, size.bottommost_line().0 as usize);
 
-        display::viewport_to_point(display_offset, Point::new(line, col))
+        term::viewport_to_point(display_offset, Point::new(line, col))
     }
 }
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -778,8 +778,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             if self.search_state.dfas.take().is_some() {
                 self.terminal.mark_fully_damaged();
             } else {
-                // Damage line indicator and Vi cursor.
-                self.terminal.damage_vi_cursor();
+                // Damage line indicator.
                 self.terminal.damage_line(0, 0, self.terminal.columns() - 1);
             }
         } else {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -149,6 +149,9 @@ struct TermDamageState {
     /// Old terminal cursor point.
     last_cursor: Point,
 
+    /// Last Vi cursor point.
+    last_vi_cursor_point: Option<Point<usize>>,
+
     /// Old selection range.
     last_selection: Option<SelectionRange>,
 }
@@ -162,6 +165,7 @@ impl TermDamageState {
             is_fully_damaged: true,
             lines,
             last_cursor: Default::default(),
+            last_vi_cursor_point: Default::default(),
             last_selection: Default::default(),
         }
     }
@@ -170,6 +174,7 @@ impl TermDamageState {
     fn resize(&mut self, num_cols: usize, num_lines: usize) {
         // Reset point, so old cursor won't end up outside of the viewport.
         self.last_cursor = Default::default();
+        self.last_vi_cursor_point = None;
         self.last_selection = None;
         self.is_fully_damaged = true;
 
@@ -373,9 +378,17 @@ impl<T> Term<T> {
         self.damage_cursor();
         self.damage.last_cursor = self.grid.cursor.point;
 
+        // Vi mode doesn't update the terminal content, thus only last vi cursor position and a
+        // new one should be damaged.
+        if let Some(last_vi_cursor_point) = self.damage.last_vi_cursor_point.take() {
+            self.damage.damage_point(last_vi_cursor_point)
+        }
+
         // Damage Vi cursor if it's present.
         if self.mode.contains(TermMode::VI) {
-            self.damage_vi_cursor();
+            let vi_cursor_point = self.grid_point_to_viewport(self.vi_mode_cursor.point);
+            self.damage.last_vi_cursor_point = Some(vi_cursor_point);
+            self.damage.damage_point(vi_cursor_point);
         }
 
         if self.damage.last_selection != selection {
@@ -749,9 +762,7 @@ impl<T> Term<T> {
         }
 
         // Move cursor.
-        self.damage_vi_cursor();
         self.vi_mode_cursor = self.vi_mode_cursor.motion(self, motion);
-        self.damage_vi_cursor();
         self.vi_mode_recompute_selection();
     }
 
@@ -761,7 +772,6 @@ impl<T> Term<T> {
     where
         T: EventListener,
     {
-        self.damage_vi_cursor();
         // Move viewport to make point visible.
         self.scroll_to_point(point);
 
@@ -769,7 +779,6 @@ impl<T> Term<T> {
         self.vi_mode_cursor.point = point;
 
         self.vi_mode_recompute_selection();
-        self.damage_vi_cursor();
     }
 
     /// Update the active selection to match the vi mode cursor position.
@@ -927,13 +936,13 @@ impl<T> Term<T> {
         self.damage.damage_point(point);
     }
 
-    /// Damage `Vi` mode cursor.
     #[inline]
-    pub fn damage_vi_cursor(&mut self) {
-        let line = (self.grid.display_offset() as i32 + self.vi_mode_cursor.point.line.0)
-            .clamp(0, self.screen_lines() as i32 - 1) as usize;
-        let vi_point = Point::new(line, self.vi_mode_cursor.point.column);
-        self.damage.damage_point(vi_point);
+    fn grid_point_to_viewport(&self, point: Point) -> Point<usize> {
+        let display_offset = self.grid.display_offset() as i32;
+        let lines = self.screen_lines() as i32 - 1;
+        let line = (display_offset + point.line.0).clamp(0, lines) as usize;
+
+        Point::new(line, point.column)
     }
 }
 
@@ -2698,6 +2707,19 @@ mod tests {
         let line = vi_cursor_point.line.0 as usize;
         let left = vi_cursor_point.column.0 as usize;
         let right = left;
+
+        let mut damaged_lines = match term.damage(None) {
+            TermDamage::Full => panic!("Expected partial damage, however got Full"),
+            TermDamage::Partial(damaged_lines) => damaged_lines,
+        };
+        // Skip cursor damage information, since we're just testing Vi cursor.
+        damaged_lines.next();
+        assert_eq!(damaged_lines.next(), Some(LineDamageBounds { line, left, right }));
+        assert_eq!(damaged_lines.next(), None);
+
+        // Ensure that old Vi cursor got damaged as well.
+        term.reset_damage();
+        term.toggle_vi_mode();
         let mut damaged_lines = match term.damage(None) {
             TermDamage::Full => panic!("Expected partial damage, however got Full"),
             TermDamage::Partial(damaged_lines) => damaged_lines,
@@ -2804,38 +2826,6 @@ mod tests {
         term.reverse_index();
         assert_eq!(term.damage.lines[7], LineDamageBounds { line: 7, left: 8, right: 8 });
         assert_eq!(term.damage.lines[6], LineDamageBounds { line: 6, left: 8, right: 8 });
-    }
-
-    #[test]
-    fn damage_vi_movements() {
-        let size = TermSize::new(10, 10);
-        let mut term = Term::new(&Config::default(), &size, ());
-        let num_cols = term.columns();
-        // Reset terminal for partial damage tests since it's initialized as fully damaged.
-        term.reset_damage();
-
-        // Enable Vi mode.
-        term.toggle_vi_mode();
-
-        // NOTE While we can use `[Term::damage]` to access terminal damage information, in the
-        // following tests we will be accessing `term.damage.lines` directly to avoid adding extra
-        // damage information (like cursor and Vi cursor), which we're not testing.
-
-        term.vi_goto_point(Point::new(Line(5), Column(5)));
-        assert_eq!(term.damage.lines[0], LineDamageBounds { line: 0, left: 0, right: 0 });
-        assert_eq!(term.damage.lines[5], LineDamageBounds { line: 5, left: 5, right: 5 });
-        term.damage.reset(num_cols);
-
-        term.vi_motion(ViMotion::Up);
-        term.vi_motion(ViMotion::Right);
-        term.vi_motion(ViMotion::Up);
-        term.vi_motion(ViMotion::Left);
-        assert_eq!(term.damage.lines[3], LineDamageBounds { line: 3, left: 5, right: 6 });
-        assert_eq!(term.damage.lines[4], LineDamageBounds { line: 4, left: 5, right: 6 });
-        assert_eq!(term.damage.lines[5], LineDamageBounds { line: 5, left: 5, right: 5 });
-
-        // Ensure that we haven't damaged entire terminal during the test.
-        assert!(!term.damage.is_fully_damaged);
     }
 
     #[test]


### PR DESCRIPTION
When scrolling doesn't actually results in scrolling in Vi mode, but
rather in changing Vi cursor position, scrolling functions were changing
the cursor position. This commit fixes it by always damaging old Vi
cursor if it was present.