### PR TITLE
Add support for GL_EXT_blend_func_extended in GLES2 renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "log",
  "notify",
  "objc",
+ "once_cell",
  "parking_lot",
  "png",
  "raw-window-handle",
@@ -1191,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "os_str_bytes"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2"
 unicode-width = "0.1"
 bitflags = "1"
 dirs = "3.0.1"
+once_cell = "1.12"
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/alacritty/res/glsl3/text.f.glsl
+++ b/alacritty/res/glsl3/text.f.glsl
@@ -1,64 +1,72 @@
-#ifdef GLES2_RENDERER
+#if defined(GLES2_RENDERER)
+// Require extension for dual source blending to work on GLES2.
 #extension GL_EXT_blend_func_extended: require
-#define MEDIUMP mediump
-#define COLORED 1
+
+#define int_t highp int
+#define float_t highp float
+#define vec3_t mediump vec3
+#define texture texture2D
+
 varying mediump vec2 TexCoords;
 varying mediump vec3 fg;
 varying highp float colored;
 varying mediump vec4 bg;
 
-uniform highp int renderingPass;
-
 #define FRAG_COLOR gl_FragColor
 #define ALPHA_MASK gl_SecondaryFragColorEXT
-#define texture texture2D
 #else
-#define MEDIUMP
-#define COLORED 2
+
+#define int_t int
+#define float_t float
+#define vec3_t vec3
+
 in vec2 TexCoords;
 flat in vec4 fg;
 flat in vec4 bg;
-uniform int backgroundPass;
 
 layout(location = 0, index = 0) out vec4 color;
 layout(location = 0, index = 1) out vec4 alphaMask;
+
 #define FRAG_COLOR color
 #define ALPHA_MASK alphaMask
 #endif
+
+#define COLORED 1
+
+uniform int_t renderingPass;
 uniform sampler2D mask;
 
 void main() {
-#ifdef GLES2_RENDERER
     if (renderingPass == 0) {
-#else
-    if (backgroundPass != 0) {
-#endif
         if (bg.a == 0.0) {
             discard;
         }
 
         ALPHA_MASK = vec4(1.0);
-
         // Premultiply background color by alpha.
         FRAG_COLOR = vec4(bg.rgb * bg.a, bg.a);
-#ifdef GLES2_RENDERER
-    } else if (int(colored) == COLORED) {
-#else
-    } else if ((int(fg.a) & COLORED) != 0) {
+        return;
+    }
+
+#if !defined(GLES2_RENDERER)
+    float_t colored = fg.a;
 #endif
+
+    // The wide char information is already stripped, so it's safe to check for equality here.
+    if (int(colored) == COLORED) {
         // Color glyphs, like emojis.
-        MEDIUMP vec4 glyphColor = texture(mask, TexCoords);
-        ALPHA_MASK = vec4(glyphColor.a);
+        FRAG_COLOR = texture(mask, TexCoords);
+        ALPHA_MASK = vec4(FRAG_COLOR.a);
 
         // Revert alpha premultiplication.
-        if (glyphColor.a != 0.0) {
-            glyphColor.rgb = vec3(glyphColor.rgb / glyphColor.a);
+        if (FRAG_COLOR.a != 0.0) {
+            FRAG_COLOR.rgb = vec3(FRAG_COLOR.rgb / FRAG_COLOR.a);
         }
 
-        FRAG_COLOR = vec4(glyphColor.rgb, 1.0);
+        FRAG_COLOR = vec4(FRAG_COLOR.rgb, 1.0);
     } else {
         // Regular text glyphs.
-        MEDIUMP vec3 textColor = texture(mask, TexCoords).rgb;
+        vec3_t textColor = texture(mask, TexCoords).rgb;
         ALPHA_MASK = vec4(textColor, textColor.r);
         FRAG_COLOR = vec4(fg.rgb, 1.0);
     }

--- a/alacritty/res/glsl3/text.f.glsl
+++ b/alacritty/res/glsl3/text.f.glsl
@@ -1,3 +1,20 @@
+#ifdef GLES2_RENDERER
+#extension GL_EXT_blend_func_extended: require
+#define MEDIUMP mediump
+#define COLORED 1
+varying mediump vec2 TexCoords;
+varying mediump vec3 fg;
+varying highp float colored;
+varying mediump vec4 bg;
+
+uniform highp int renderingPass;
+
+#define FRAG_COLOR gl_FragColor
+#define ALPHA_MASK gl_SecondaryFragColorEXT
+#define texture texture2D
+#else
+#define MEDIUMP
+#define COLORED 2
 in vec2 TexCoords;
 flat in vec4 fg;
 flat in vec4 bg;
@@ -5,36 +22,44 @@ uniform int backgroundPass;
 
 layout(location = 0, index = 0) out vec4 color;
 layout(location = 0, index = 1) out vec4 alphaMask;
-
+#define FRAG_COLOR color
+#define ALPHA_MASK alphaMask
+#endif
 uniform sampler2D mask;
 
-#define COLORED 2
-
 void main() {
+#ifdef GLES2_RENDERER
+    if (renderingPass == 0) {
+#else
     if (backgroundPass != 0) {
+#endif
         if (bg.a == 0.0) {
             discard;
         }
 
-        alphaMask = vec4(1.0);
+        ALPHA_MASK = vec4(1.0);
 
         // Premultiply background color by alpha.
-        color = vec4(bg.rgb * bg.a, bg.a);
+        FRAG_COLOR = vec4(bg.rgb * bg.a, bg.a);
+#ifdef GLES2_RENDERER
+    } else if (int(colored) == COLORED) {
+#else
     } else if ((int(fg.a) & COLORED) != 0) {
+#endif
         // Color glyphs, like emojis.
-        vec4 glyphColor = texture(mask, TexCoords);
-        alphaMask = vec4(glyphColor.a);
+        MEDIUMP vec4 glyphColor = texture(mask, TexCoords);
+        ALPHA_MASK = vec4(glyphColor.a);
 
         // Revert alpha premultiplication.
-        if (glyphColor.a != 0) {
+        if (glyphColor.a != 0.0) {
             glyphColor.rgb = vec3(glyphColor.rgb / glyphColor.a);
         }
 
-        color = vec4(glyphColor.rgb, 1.0);
+        FRAG_COLOR = vec4(glyphColor.rgb, 1.0);
     } else {
         // Regular text glyphs.
-        vec3 textColor = texture(mask, TexCoords).rgb;
-        alphaMask = vec4(textColor, textColor.r);
-        color = vec4(fg.rgb, 1.0);
+        MEDIUMP vec3 textColor = texture(mask, TexCoords).rgb;
+        ALPHA_MASK = vec4(textColor, textColor.r);
+        FRAG_COLOR = vec4(fg.rgb, 1.0);
     }
 }

--- a/alacritty/res/glsl3/text.v.glsl
+++ b/alacritty/res/glsl3/text.v.glsl
@@ -25,7 +25,7 @@ uniform vec4 projection;
 
 uniform int renderingPass;
 
-#define HAS_WIDE_CHAR 2
+#define WIDE_CHAR 2
 
 void main() {
     vec2 projectionOffset = projection.xy;
@@ -43,13 +43,13 @@ void main() {
     bg = backgroundColor / 255.0;
 
     float occupiedCells = 1;
-    if ((int(fg.a) >= HAS_WIDE_CHAR)) {
+    if ((int(fg.a) >= WIDE_CHAR)) {
         // Update wide char x dimension so it'll cover the following spacer.
         occupiedCells = 2;
 
         // Since we don't perform bitwise operations due to limitations of
-        // other renderers we subtract wide char bits keeping only colored.
-        fg.a = round(fg.a - HAS_WIDE_CHAR);
+        // the GLES2 renderer,we subtract wide char bits keeping only colored.
+        fg.a = round(fg.a - WIDE_CHAR);
     }
 
     if (renderingPass == 0) {

--- a/alacritty/res/glsl3/text.v.glsl
+++ b/alacritty/res/glsl3/text.v.glsl
@@ -40,11 +40,12 @@ void main() {
     vec2 cellPosition = cellDim * gridCoords;
 
     fg = vec4(textColor.rgb / 255.0, textColor.a);
+    bg = backgroundColor / 255.0;
 
-    float occupiesCells = 1;
+    float occupiedCells = 1;
     if ((int(fg.a) >= HAS_WIDE_CHAR)) {
         // Update wide char x dimension so it'll cover the following spacer.
-        occupiesCells *= 2;
+        occupiedCells = 2;
 
         // Since we don't perform bitwise operations due to limitations of
         // other renderers we subtract wide char bits keeping only colored.
@@ -53,7 +54,7 @@ void main() {
 
     if (renderingPass == 0) {
         vec2 backgroundDim = cellDim;
-        backgroundDim.x *= occupiesCells;
+        backgroundDim.x *= occupiedCells;
 
         vec2 finalPosition = cellPosition + backgroundDim * position;
         gl_Position =
@@ -73,6 +74,4 @@ void main() {
         vec2 uvSize = uv.zw;
         TexCoords = uvOffset + position * uvSize;
     }
-
-    bg = backgroundColor / 255.0;
 }

--- a/alacritty/res/glsl3/text.v.glsl
+++ b/alacritty/res/glsl3/text.v.glsl
@@ -23,9 +23,9 @@ flat out vec4 bg;
 uniform vec2 cellDim;
 uniform vec4 projection;
 
-uniform int backgroundPass;
+uniform int renderingPass;
 
-#define WIDE_CHAR 1
+#define HAS_WIDE_CHAR 2
 
 void main() {
     vec2 projectionOffset = projection.xy;
@@ -39,12 +39,22 @@ void main() {
     // Position of cell from top-left
     vec2 cellPosition = cellDim * gridCoords;
 
-    if (backgroundPass != 0) {
+    fg = vec4(textColor.rgb / 255.0, textColor.a);
+
+    float occupiesCells = 1;
+    if ((int(fg.a) >= HAS_WIDE_CHAR)) {
+        // Update wide char x dimension so it'll cover the following spacer.
+        occupiesCells *= 2;
+
+        // Since we don't perform bitwise operations due to limitations of
+        // other renderers we subtract wide char bits keeping only colored.
+        fg.a = round(fg.a - HAS_WIDE_CHAR);
+    }
+
+    if (renderingPass == 0) {
         vec2 backgroundDim = cellDim;
-        if ((int(textColor.a) & WIDE_CHAR) != 0) {
-            // Update wide char x dimension so it'll cover the following spacer.
-            backgroundDim.x *= 2;
-        }
+        backgroundDim.x *= occupiesCells;
+
         vec2 finalPosition = cellPosition + backgroundDim * position;
         gl_Position =
             vec4(projectionOffset + projectionScale * finalPosition, 0.0, 1.0);
@@ -65,5 +75,4 @@ void main() {
     }
 
     bg = backgroundColor / 255.0;
-    fg = vec4(textColor.rgb / 255.0, textColor.a);
 }

--- a/alacritty/res/rect.f.glsl
+++ b/alacritty/res/rect.f.glsl
@@ -7,7 +7,6 @@ varying color_t color;
 
 #else
 #define float_t float
-#define int_t int
 #define color_t vec4
 
 out vec4 FragColor;

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1,5 +1,6 @@
 use std::ffi::CStr;
 use std::fmt;
+use std::str::Utf8Error;
 
 use crossfont::Metrics;
 use log::info;
@@ -216,5 +217,57 @@ impl Renderer {
             TextRendererProvider::Gles2(renderer) => renderer.resize(size_info),
             TextRendererProvider::Glsl3(renderer) => renderer.resize(size_info),
         }
+    }
+}
+
+struct GlExtensions {
+    extensions: Box<dyn Iterator<Item = Result<&'static str, Utf8Error>>>,
+}
+
+impl GlExtensions {
+    fn new() -> Self {
+        unsafe {
+            let extensions = gl::GetString(gl::EXTENSIONS);
+            if extensions.is_null() {
+                // We're on the core profile, query extension one by one.
+                Self::from_core_profile()
+            } else {
+                Self::from_compatible_profile()
+            }
+        }
+    }
+
+    unsafe fn from_core_profile() -> Self {
+        let mut extensions_number = 0;
+        gl::GetIntegerv(gl::NUM_EXTENSIONS, &mut extensions_number);
+
+        let extensions = (0..extensions_number as gl::types::GLuint).map(|i| {
+            let extension = CStr::from_ptr(gl::GetStringi(gl::EXTENSIONS, i) as *mut _);
+            extension.to_str()
+        });
+
+        GlExtensions { extensions: Box::new(extensions) }
+    }
+
+    unsafe fn from_compatible_profile() -> Self {
+        // SAFETY: OpenGL returns a pointer to a `static` string, so using static lifetime.
+        let extensions = gl::GetString(gl::EXTENSIONS);
+        let extensions: Box<dyn Iterator<Item = Result<&'static str, Utf8Error>>> =
+            match std::mem::transmute::<Result<&'_ str, Utf8Error>, Result<&'static str, Utf8Error>>(
+                CStr::from_ptr(extensions as *mut _).to_str(),
+            ) {
+                Ok(ext) => Box::new(ext.split_whitespace().map(Ok)),
+                Err(err) => Box::new(std::iter::once(Err(err))),
+            };
+
+        GlExtensions { extensions }
+    }
+}
+
+impl Iterator for GlExtensions {
+    type Item = Result<&'static str, Utf8Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.extensions.next()
     }
 }

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -40,10 +40,8 @@ impl Gles2Renderer {
     pub fn new() -> Result<Self, Error> {
         info!("Using OpenGL ES 2.0 renderer");
 
-        let dual_source_blending = GlExtensions::new()
-            .into_iter()
-            .flatten()
-            .any(|extension| extension.ends_with("_blend_func_extended"));
+        let dual_source_blending = GlExtensions::contains("GL_EXT_blend_func_extended")
+            || GlExtensions::contains("GL_ARB_blend_func_extended");
 
         if dual_source_blending {
             info!("Using dual source blending");

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -406,7 +406,7 @@ impl<'a> TextRenderApi<Batch> for RenderApi<'a> {
                 gl::BlendFuncSeparate(gl::ONE_MINUS_DST_ALPHA, gl::ONE, gl::ZERO, gl::ONE);
                 gl::DrawElements(gl::TRIANGLES, num_indices, gl::UNSIGNED_SHORT, ptr::null());
 
-                // Third pass.
+                // Third text rendering pass.
                 self.program.set_rendering_pass(RenderingPass::SubpixelPass3);
                 gl::BlendFuncSeparate(gl::ONE, gl::ONE, gl::ONE, gl::ONE_MINUS_SRC_ALPHA);
             }
@@ -458,7 +458,7 @@ pub struct TextShaderProgram {
 
     /// Rendering pass.
     ///
-    /// For dual source blending, there're 2 passes, one for background, another for text,
+    /// For dual source blending, there are 2 passes; one for background, another for text,
     /// similar to the GLSL3 renderer.
     ///
     /// If GL_EXT_blend_func_extended is not available, the rendering is split into 4 passes.

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -15,7 +15,7 @@ use crate::renderer::{cstr, Error, GlExtensions};
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
-    Glyph, LoadGlyph, LoaderApi, RenderingGlyphFlags, RenderingPass, TextRenderApi,
+    glsl3, Glyph, LoadGlyph, LoaderApi, RenderingGlyphFlags, RenderingPass, TextRenderApi,
     TextRenderBatch, TextRenderer, TextShader,
 };
 
@@ -218,7 +218,7 @@ impl<'a> TextRenderer<'a> for Gles2Renderer {
 /// Maximum items to be drawn in a batch.
 ///
 /// We use the closest number to `u16::MAX` dividable by 4 (amount of vertices we push for a glyph),
-/// since it's the maximum possible index in `glDrawElements` in gles2.
+/// since it's the maximum possible index in `glDrawElements` in GLES2.
 const BATCH_MAX: usize = (u16::MAX - u16::MAX % 4) as usize;
 
 #[derive(Debug)]
@@ -461,7 +461,7 @@ pub struct TextShaderProgram {
     /// Rendering pass.
     ///
     /// For dual source blending, there're 2 passes, one for background, another for text,
-    /// similar to GLES3 renderer.
+    /// similar to the GLSL3 renderer.
     ///
     /// If GL_EXT_blend_func_extended is not available, the rendering is split into 4 passes.
     /// One is used for the background and the rest to perform subpixel text rendering according to
@@ -474,7 +474,7 @@ pub struct TextShaderProgram {
 impl TextShaderProgram {
     pub fn new(shader_version: ShaderVersion, dual_source_blending: bool) -> Result<Self, Error> {
         let fragment_shader =
-            if dual_source_blending { &super::glsl3::TEXT_SHADER_F } else { &TEXT_SHADER_F };
+            if dual_source_blending { &glsl3::TEXT_SHADER_F } else { &TEXT_SHADER_F };
 
         let program = ShaderProgram::new(shader_version, TEXT_SHADER_V, fragment_shader)?;
 

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -20,7 +20,7 @@ use super::{
 };
 
 // Shader source.
-pub(super) static TEXT_SHADER_F: &str = include_str!("../../../res/glsl3/text.f.glsl");
+pub static TEXT_SHADER_F: &str = include_str!("../../../res/glsl3/text.f.glsl");
 static TEXT_SHADER_V: &str = include_str!("../../../res/glsl3/text.v.glsl");
 
 /// Maximum items to be drawn in a batch.

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -15,12 +15,12 @@ use crate::renderer::{cstr, Error};
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
-    Glyph, LoadGlyph, LoaderApi, RenderingGlyphFlags, TextRenderApi, TextRenderBatch, TextRenderer,
-    TextShader,
+    Glyph, LoadGlyph, LoaderApi, RenderingGlyphFlags, RenderingPass, TextRenderApi,
+    TextRenderBatch, TextRenderer, TextShader,
 };
 
 // Shader source.
-static TEXT_SHADER_F: &str = include_str!("../../../res/glsl3/text.f.glsl");
+pub(super) static TEXT_SHADER_F: &str = include_str!("../../../res/glsl3/text.f.glsl");
 static TEXT_SHADER_V: &str = include_str!("../../../res/glsl3/text.v.glsl");
 
 /// Maximum items to be drawn in a batch.
@@ -240,7 +240,7 @@ impl<'a> TextRenderApi<Batch> for RenderApi<'a> {
         }
 
         unsafe {
-            self.program.set_background_pass(true);
+            self.program.set_rendering_pass(RenderingPass::Background);
             gl::DrawElementsInstanced(
                 gl::TRIANGLES,
                 6,
@@ -248,7 +248,7 @@ impl<'a> TextRenderApi<Batch> for RenderApi<'a> {
                 ptr::null(),
                 self.batch.len() as GLsizei,
             );
-            self.program.set_background_pass(false);
+            self.program.set_rendering_pass(RenderingPass::SubpixelPass1);
             gl::DrawElementsInstanced(
                 gl::TRIANGLES,
                 6,
@@ -419,8 +419,8 @@ pub struct TextShaderProgram {
 
     /// Background pass flag.
     ///
-    /// Rendering is split into two passes; 1 for backgrounds, and one for text.
-    u_background: GLint,
+    /// Rendering is split into two passes; one for backgrounds, and one for text.
+    u_rendering_pass: GLint,
 }
 
 impl TextShaderProgram {
@@ -429,7 +429,7 @@ impl TextShaderProgram {
         Ok(Self {
             u_projection: program.get_uniform_location(cstr!("projection"))?,
             u_cell_dim: program.get_uniform_location(cstr!("cellDim"))?,
-            u_background: program.get_uniform_location(cstr!("backgroundPass"))?,
+            u_rendering_pass: program.get_uniform_location(cstr!("renderingPass"))?,
             program,
         })
     }
@@ -440,11 +440,14 @@ impl TextShaderProgram {
         }
     }
 
-    fn set_background_pass(&self, background_pass: bool) {
-        let value = if background_pass { 1 } else { 0 };
+    fn set_rendering_pass(&self, rendering_pass: RenderingPass) {
+        let value = match rendering_pass {
+            RenderingPass::Background | RenderingPass::SubpixelPass1 => rendering_pass as i32,
+            _ => unreachable!("provided pass is not supported in glsl3 renderer"),
+        };
 
         unsafe {
-            gl::Uniform1i(self.u_background, value);
+            gl::Uniform1i(self.u_rendering_pass, value);
         }
     }
 }

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -443,7 +443,7 @@ impl TextShaderProgram {
     fn set_rendering_pass(&self, rendering_pass: RenderingPass) {
         let value = match rendering_pass {
             RenderingPass::Background | RenderingPass::SubpixelPass1 => rendering_pass as i32,
-            _ => unreachable!("provided pass is not supported in glsl3 renderer"),
+            _ => unreachable!("provided pass is not supported in GLSL3 renderer"),
         };
 
         unsafe {

--- a/alacritty/src/renderer/text/mod.rs
+++ b/alacritty/src/renderer/text/mod.rs
@@ -29,24 +29,19 @@ bitflags! {
     }
 }
 
-// NOTE: the passes are shared between gles2 and glsl3 renderers.
+// NOTE: the passes are shared between GLES2 and GLSL3 renderers.
 #[repr(u8)]
 enum RenderingPass {
     /// Rendering pass used to render background color in text shaders.
     Background = 0,
 
-    /// The first pass to render text. This pass is shared between dual source blending and
-    /// gles2 rendering.
+    /// The first pass to render text with both GLES2 and GLSL3 renderers.
     SubpixelPass1 = 1,
 
-    /// The second pass to render text.
-    ///
-    /// This pass isn't used for dual source blending.
+    /// The second pass to render text with GLES2 renderer.
     SubpixelPass2 = 2,
 
-    /// The third pass to render text.
-    ///
-    /// This pass isn't used for dual source blending.
+    /// The third pass to render text with GLES2 renderer.
     SubpixelPass3 = 3,
 }
 

--- a/alacritty/src/renderer/text/mod.rs
+++ b/alacritty/src/renderer/text/mod.rs
@@ -24,9 +24,30 @@ use glyph_cache::{Glyph, LoadGlyph};
 bitflags! {
     #[repr(C)]
     struct RenderingGlyphFlags: u8 {
-        const WIDE_CHAR = 0b0000_0001;
-        const COLORED   = 0b0000_0010;
+        const COLORED   = 0b0000_0001;
+        const WIDE_CHAR = 0b0000_0010;
     }
+}
+
+// NOTE: the passes are shared between gles2 and glsl3 renderers.
+#[repr(u8)]
+enum RenderingPass {
+    /// Rendering pass used to render background color in text shaders.
+    Background = 0,
+
+    /// The first pass to render text. This pass is shared between dual source blending and
+    /// gles2 rendering.
+    SubpixelPass1 = 1,
+
+    /// The second pass to render text.
+    ///
+    /// This pass isn't used for dual source blending.
+    SubpixelPass2 = 2,
+
+    /// The third pass to render text.
+    ///
+    /// This pass isn't used for dual source blending.
+    SubpixelPass3 = 3,
 }
 
 pub trait TextRenderer<'a> {

--- a/alacritty/src/renderer/text/mod.rs
+++ b/alacritty/src/renderer/text/mod.rs
@@ -29,7 +29,7 @@ bitflags! {
     }
 }
 
-// NOTE: the passes are shared between GLES2 and GLSL3 renderers.
+/// Rendering passes, for both GLES2 and GLSL3 renderer.
 #[repr(u8)]
 enum RenderingPass {
     /// Rendering pass used to render background color in text shaders.

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -78,7 +78,8 @@ impl Scheduler {
         let index = self
             .timers
             .iter()
-            .position(|timer| timer.deadline > deadline).unwrap_or(self.timers.len());
+            .position(|timer| timer.deadline > deadline)
+            .unwrap_or_else(|| self.timers.len());
 
         // Set the automatic event repeat rate.
         let interval = if repeat { Some(interval) } else { None };

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -78,8 +78,7 @@ impl Scheduler {
         let index = self
             .timers
             .iter()
-            .position(|timer| timer.deadline > deadline)
-            .unwrap_or_else(|| self.timers.len());
+            .position(|timer| timer.deadline > deadline).unwrap_or(self.timers.len());
 
         // Set the automatic event repeat rate.
         let interval = if repeat { Some(interval) } else { None };


### PR DESCRIPTION
GLES2 has GL_EXT_blend_func_extended extension that enables
dual-source blending, so essentially we can use fragment shader
that is very similar to GLSL3 renderer and do 1 rendering pass
instead of 3 for the text.

Tested on Pinebook with lima driver (ARM Mali 400 GPU)