### PR TITLE
Derive Eq for the PartialEq-deriving types

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -174,7 +174,7 @@ fn parse_class(input: &str) -> Result<Class, String> {
 }
 
 /// Terminal specific cli options which can be passed to new windows via IPC.
-#[derive(Serialize, Deserialize, Args, Default, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Args, Default, Debug, Clone, PartialEq, Eq)]
 pub struct TerminalOptions {
     /// Start the shell in the specified working directory.
     #[clap(long)]
@@ -225,7 +225,7 @@ impl From<TerminalOptions> for PtyConfig {
 }
 
 /// Window specific cli options which can be passed to new windows via IPC.
-#[derive(Serialize, Deserialize, Args, Default, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Args, Default, Debug, Clone, PartialEq, Eq)]
 pub struct WindowIdentity {
     /// Defines the window title [default: Alacritty].
     #[clap(short, long)]
@@ -270,14 +270,14 @@ pub struct MessageOptions {
 
 /// Available socket messages.
 #[cfg(unix)]
-#[derive(Subcommand, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Subcommand, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum SocketMessage {
     /// Create a new window in the same Alacritty process.
     CreateWindow(WindowOptions),
 }
 
 /// Subset of options that we pass to a 'create-window' subcommand.
-#[derive(Serialize, Deserialize, Args, Default, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Args, Default, Clone, Debug, PartialEq, Eq)]
 pub struct WindowOptions {
     /// Terminal options which can be passed via IPC.
     #[clap(flatten)]

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -144,7 +144,7 @@ impl UiConfig {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 struct KeyBindings(Vec<KeyBinding>);
 
 impl Default for KeyBindings {
@@ -162,7 +162,7 @@ impl<'de> Deserialize<'de> for KeyBindings {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 struct MouseBindings(Vec<MouseBinding>);
 
 impl Default for MouseBindings {

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -106,7 +106,7 @@ impl WindowConfig {
     }
 }
 
-#[derive(ConfigDeserialize, Debug, Clone, PartialEq)]
+#[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Identity {
     /// Window title.
     pub title: String,

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -164,7 +164,7 @@ impl HintState {
 }
 
 /// Hint match which was selected by the user.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HintMatch {
     /// Action for handling the text.
     pub action: HintAction,

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -293,7 +293,7 @@ impl TermDimensions for SizeInfo {
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct DisplayUpdate {
     pub dirty: bool,
 

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -33,7 +33,7 @@ pub struct Config {
     pub pty_config: PtyConfig,
 }
 
-#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Default)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq, Default)]
 pub struct PtyConfig {
     /// Path to a shell program to run on startup.
     pub shell: Option<Program>,

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -16,7 +16,7 @@ use crate::term::cell::{Cell, Flags};
 use crate::term::Term;
 
 /// A Point and side within that point.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct Anchor {
     point: Point,
     side: Side,
@@ -89,7 +89,7 @@ impl SelectionRange {
 }
 
 /// Different kinds of selection.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SelectionType {
     Simple,
     Block,
@@ -115,7 +115,7 @@ pub enum SelectionType {
 /// [`semantic`]: enum.Selection.html#method.semantic
 /// [`lines`]: enum.Selection.html#method.lines
 /// [`update`]: enum.Selection.html#method.update
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Selection {
     pub ty: SelectionType,
     region: Range<Anchor>,

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -39,7 +39,7 @@ pub trait EventedReadWrite {
 }
 
 /// Events concerning TTY child processes.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ChildEvent {
     /// Indicates the child has exited.
     Exited,


### PR DESCRIPTION
Making Clippy happy by following its [suggestion](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) to add Eq trait to some structs and enums.