### PR TITLE
[noop] Fmt: order trait impl members same as in trait

### DIFF
--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -150,11 +150,11 @@ impl<'de> Deserialize<'de> for Size {
                 f.write_str("f64 or u64")
             }
 
-            fn visit_f64<E: de::Error>(self, value: f64) -> Result<Self::Value, E> {
+            fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
                 Ok(Size(FontSize::new(value as f32)))
             }
 
-            fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+            fn visit_f64<E: de::Error>(self, value: f64) -> Result<Self::Value, E> {
                 Ok(Size(FontSize::new(value as f32)))
             }
         }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -278,8 +278,8 @@ impl SizeInfo<f32> {
 
 impl TermDimensions for SizeInfo {
     #[inline]
-    fn columns(&self) -> usize {
-        self.columns
+    fn total_lines(&self) -> usize {
+        self.screen_lines()
     }
 
     #[inline]
@@ -288,8 +288,8 @@ impl TermDimensions for SizeInfo {
     }
 
     #[inline]
-    fn total_lines(&self) -> usize {
-        self.screen_lines()
+    fn columns(&self) -> usize {
+        self.columns
     }
 }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -994,45 +994,12 @@ mod tests {
     }
 
     impl<'a, T: EventListener> super::ActionContext<T> for ActionContext<'a, T> {
-        fn search_next(
-            &mut self,
-            _origin: Point,
-            _direction: Direction,
-            _side: Side,
-        ) -> Option<Match> {
-            None
-        }
-
-        fn search_direction(&self) -> Direction {
-            Direction::Right
-        }
-
-        fn search_active(&self) -> bool {
-            false
-        }
-
-        fn terminal(&self) -> &Term<T> {
-            self.terminal
-        }
-
-        fn terminal_mut(&mut self) -> &mut Term<T> {
-            self.terminal
-        }
-
         fn size_info(&self) -> SizeInfo {
             *self.size_info
         }
 
         fn selection_is_empty(&self) -> bool {
             true
-        }
-
-        fn scroll(&mut self, scroll: Scroll) {
-            self.terminal.scroll_display(scroll);
-        }
-
-        fn mouse_mode(&self) -> bool {
-            false
         }
 
         #[inline]
@@ -1057,12 +1024,24 @@ mod tests {
             &mut self.modifiers
         }
 
+        fn scroll(&mut self, scroll: Scroll) {
+            self.terminal.scroll_display(scroll);
+        }
+
         fn window(&mut self) -> &mut Window {
             unimplemented!();
         }
 
         fn display(&mut self) -> &mut Display {
             unimplemented!();
+        }
+
+        fn terminal(&self) -> &Term<T> {
+            self.terminal
+        }
+
+        fn terminal_mut(&mut self) -> &mut Term<T> {
+            self.terminal
         }
 
         fn pop_message(&mut self) {
@@ -1077,16 +1056,37 @@ mod tests {
             self.config
         }
 
-        fn clipboard_mut(&mut self) -> &mut Clipboard {
-            self.clipboard
-        }
-
         fn event_loop(&self) -> &EventLoopWindowTarget<Event> {
             unimplemented!();
         }
 
+        fn mouse_mode(&self) -> bool {
+            false
+        }
+
+        fn clipboard_mut(&mut self) -> &mut Clipboard {
+            self.clipboard
+        }
+
         fn scheduler_mut(&mut self) -> &mut Scheduler {
             unimplemented!();
+        }
+
+        fn search_next(
+            &mut self,
+            _origin: Point,
+            _direction: Direction,
+            _side: Side,
+        ) -> Option<Match> {
+            None
+        }
+
+        fn search_direction(&self) -> Direction {
+            Direction::Right
+        }
+
+        fn search_active(&self) -> bool {
+            false
         }
     }
 

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -158,8 +158,12 @@ impl<'a> TextRenderer<'a> for Gles2Renderer {
     type RenderBatch = Batch;
     type Shader = TextShaderProgram;
 
-    fn program(&self) -> &Self::Shader {
-        &self.program
+    fn loader_api(&mut self) -> LoaderApi<'_> {
+        LoaderApi {
+            active_tex: &mut self.active_tex,
+            atlas: &mut self.atlas,
+            current_atlas: &mut self.current_atlas,
+        }
     }
 
     fn with_api<'b: 'a, F, T>(&'b mut self, _: &'b SizeInfo, func: F) -> T
@@ -193,12 +197,8 @@ impl<'a> TextRenderer<'a> for Gles2Renderer {
         res
     }
 
-    fn loader_api(&mut self) -> LoaderApi<'_> {
-        LoaderApi {
-            active_tex: &mut self.active_tex,
-            atlas: &mut self.atlas,
-            current_atlas: &mut self.current_atlas,
-        }
+    fn program(&self) -> &Self::Shader {
+        &self.program
     }
 }
 
@@ -242,8 +242,8 @@ impl Batch {
 
 impl TextRenderBatch for Batch {
     #[inline]
-    fn tex(&self) -> GLuint {
-        self.tex
+    fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     #[inline]
@@ -252,8 +252,8 @@ impl TextRenderBatch for Batch {
     }
 
     #[inline]
-    fn is_empty(&self) -> bool {
-        self.len() == 0
+    fn tex(&self) -> GLuint {
+        self.tex
     }
 
     fn add_item(&mut self, cell: &RenderableCell, glyph: &Glyph, size_info: &SizeInfo) {

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -151,6 +151,14 @@ impl<'a> TextRenderer<'a> for Glsl3Renderer {
     type RenderBatch = Batch;
     type Shader = TextShaderProgram;
 
+    fn loader_api(&mut self) -> LoaderApi<'_> {
+        LoaderApi {
+            active_tex: &mut self.active_tex,
+            atlas: &mut self.atlas,
+            current_atlas: &mut self.current_atlas,
+        }
+    }
+
     fn with_api<'b: 'a, F, T>(&'b mut self, size_info: &'b SizeInfo, func: F) -> T
     where
         F: FnOnce(Self::RenderApi) -> T,
@@ -186,14 +194,6 @@ impl<'a> TextRenderer<'a> for Glsl3Renderer {
 
     fn program(&self) -> &Self::Shader {
         &self.program
-    }
-
-    fn loader_api(&mut self) -> LoaderApi<'_> {
-        LoaderApi {
-            active_tex: &mut self.active_tex,
-            atlas: &mut self.atlas,
-            current_atlas: &mut self.current_atlas,
-        }
     }
 }
 
@@ -326,8 +326,8 @@ pub struct Batch {
 
 impl TextRenderBatch for Batch {
     #[inline]
-    fn tex(&self) -> GLuint {
-        self.tex
+    fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     #[inline]
@@ -336,8 +336,8 @@ impl TextRenderBatch for Batch {
     }
 
     #[inline]
-    fn is_empty(&self) -> bool {
-        self.len() == 0
+    fn tex(&self) -> GLuint {
+        self.tex
     }
 
     fn add_item(&mut self, cell: &RenderableCell, glyph: &Glyph, _: &SizeInfo) {

--- a/alacritty_config_derive/tests/config.rs
+++ b/alacritty_config_derive/tests/config.rs
@@ -131,6 +131,10 @@ struct Logger {
 }
 
 impl Log for Logger {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
     fn log(&self, record: &Record<'_>) {
         assert_eq!(record.target(), env!("CARGO_PKG_NAME"));
 
@@ -145,10 +149,6 @@ impl Log for Logger {
             },
             _ => unreachable!(),
         }
-    }
-
-    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
-        true
     }
 
     fn flush(&self) {}

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -1530,25 +1530,25 @@ mod tests {
     }
 
     impl Handler for MockHandler {
-        fn terminal_attribute(&mut self, attr: Attr) {
-            self.attr = Some(attr);
-        }
-
-        fn configure_charset(&mut self, index: CharsetIndex, charset: StandardCharset) {
-            self.index = index;
-            self.charset = charset;
-        }
-
-        fn set_active_charset(&mut self, index: CharsetIndex) {
-            self.index = index;
-        }
-
         fn identify_terminal(&mut self, _intermediate: Option<char>) {
             self.identity_reported = true;
         }
 
         fn reset_state(&mut self) {
             *self = Self::default();
+        }
+
+        fn terminal_attribute(&mut self, attr: Attr) {
+            self.attr = Some(attr);
+        }
+
+        fn set_active_charset(&mut self, index: CharsetIndex) {
+            self.index = index;
+        }
+
+        fn configure_charset(&mut self, index: CharsetIndex, charset: StandardCharset) {
+            self.index = index;
+            self.charset = charset;
         }
 
         fn set_color(&mut self, _: usize, c: Rgb) {

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -148,6 +148,11 @@ impl GridCell for Cell {
     }
 
     #[inline]
+    fn reset(&mut self, template: &Self) {
+        *self = Cell { bg: template.bg, ..Cell::default() };
+    }
+
+    #[inline]
     fn flags(&self) -> &Flags {
         &self.flags
     }
@@ -155,11 +160,6 @@ impl GridCell for Cell {
     #[inline]
     fn flags_mut(&mut self) -> &mut Flags {
         &mut self.flags
-    }
-
-    #[inline]
-    fn reset(&mut self, template: &Self) {
-        *self = Cell { bg: template.bg, ..Cell::default() };
     }
 }
 

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -317,6 +317,11 @@ impl EventedReadWrite for Pty {
 
 impl EventedPty for Pty {
     #[inline]
+    fn child_event_token(&self) -> mio::Token {
+        self.signals_token
+    }
+
+    #[inline]
     fn next_child_event(&mut self) -> Option<ChildEvent> {
         self.signals.pending().next().and_then(|signal| {
             if signal != sigconsts::SIGCHLD {
@@ -332,11 +337,6 @@ impl EventedPty for Pty {
                 Ok(_) => Some(ChildEvent::Exited),
             }
         })
-    }
-
-    #[inline]
-    fn child_event_token(&self) -> mio::Token {
-        self.signals_token
     }
 }
 


### PR DESCRIPTION
This is purely a formatting change:  for consistency, order all trait implementations to be in the same order as declared in the trait itself.

Note that trait type definitions are still orderered according to `fmt` rules.