### PR TITLE
Fix Open Alacritty here in root of drive on windows

### DIFF
--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -53,7 +53,7 @@
             <!-- Add context menu -->
             <Component Id="ContextMenu" Guid="449f9121-f7b9-41fe-82da-52349ea8ff91">
                 <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here\command">
-                    <RegistryValue Type="string" Value="[AlacrittyProgramFiles]alacritty.exe --working-directory &quot;%V&quot;" KeyPath="yes"/>
+                    <RegistryValue Type="string" Value="[AlacrittyProgramFiles]alacritty.exe --working-directory &quot;%V" KeyPath="yes"/>
                 </RegistryKey>
                 <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here">
                     <RegistryValue Type="string" Name="Icon" Value="[AlacrittyProgramFiles]alacritty.exe"/>


### PR DESCRIPTION
Before when opening in root of drive
![image](https://user-images.githubusercontent.com/14964651/172021464-c8deff4e-0a30-427e-96d5-0590575c739c.png)

The above Log File
```
[0.003076400s] [ERROR] [alacritty] Invalid working directory: "Z:\""
```

After removing `"` error is gone
![image](https://user-images.githubusercontent.com/14964651/172021477-bf1299fc-48e9-42dd-9e70-8ce5a28c41ff.png)
