### PR TITLE
Fix clippy unnecessary closure used to substitute value for `Option::None`

### DIFF
--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -79,7 +79,7 @@ impl Scheduler {
             .timers
             .iter()
             .position(|timer| timer.deadline > deadline)
-            .unwrap_or_else(|| self.timers.len());
+            .unwrap_or(self.timers.len());
 
         // Set the automatic event repeat rate.
         let interval = if repeat { Some(interval) } else { None };


### PR DESCRIPTION
I was not able to run `cargo clippy` successfully on the repo, perhaps because of rust 1.61?