### PR TITLE
Overline (SGR 53/55) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for OpenGL ES 2.0
 - Escape sequence to set underline color (`CSI 58 : 2 : Ps : Ps : Ps m`/`CSI 58 : 5 : Ps m`)
 - Escape sequence to reset underline color (`CSI 59 m`)
+- Escape sequences for overlines (`CSI 53 m` / `CSI 55 m`)
 
 ### Changed
 

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -274,7 +274,7 @@ impl RenderableCell {
         self.bg_alpha == 0.
             && self.character == ' '
             && self.zerowidth.is_none()
-            && !self.flags.intersects(Flags::ALL_UNDERLINES | Flags::STRIKEOUT)
+            && !self.flags.intersects(Flags::ALL_UNDERLINES | Flags::STRIKEOUT | Flags::OVERLINE)
     }
 
     /// Apply [`CellRgb`] colors to the cell's colors.

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -108,6 +108,11 @@ impl RenderLine {
             Flags::STRIKEOUT => {
                 (metrics.strikeout_position, metrics.strikeout_thickness, RectKind::Normal)
             },
+            Flags::OVERLINE => (
+                (size.cell_height() + metrics.descent).floor(),
+                metrics.underline_thickness,
+                RectKind::Normal,
+            ),
             _ => unimplemented!("Invalid flag for cell line drawing specified"),
         };
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -787,6 +787,8 @@ pub enum Attr {
     Hidden,
     /// Strikeout text.
     Strike,
+    /// Overlined text.
+    Overline,
     /// Cancel bold.
     CancelBold,
     /// Cancel bold and dim.
@@ -803,6 +805,8 @@ pub enum Attr {
     CancelHidden,
     /// Cancel strikeout.
     CancelStrike,
+    /// Cancel overline.
+    CancelOverline,
     /// Set indexed foreground color.
     Foreground(Color),
     /// Set indexed background color.
@@ -1385,6 +1389,8 @@ fn attrs_from_sgr_parameters(params: &mut ParamsIter<'_>) -> Vec<Option<Attr>> {
             },
             [48, params @ ..] => handle_colon_rgb(params).map(Attr::Background),
             [49] => Some(Attr::Background(Color::Named(NamedColor::Background))),
+            [53] => Some(Attr::Overline),
+            [55] => Some(Attr::CancelOverline),
             [58] => {
                 let mut iter = params.map(|param| param[0]);
                 parse_sgr_color(&mut iter).map(|color| Attr::UnderlineColor(Some(color)))

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -27,6 +27,7 @@ bitflags! {
         const UNDERCURL                 = 0b0001_0000_0000_0000;
         const DOTTED_UNDERLINE          = 0b0010_0000_0000_0000;
         const DASHED_UNDERLINE          = 0b0100_0000_0000_0000;
+        const OVERLINE                  = 0b1000_0000_0000_0000;
         const ALL_UNDERLINES            = Self::UNDERLINE.bits | Self::DOUBLE_UNDERLINE.bits
                                         | Self::UNDERCURL.bits | Self::DOTTED_UNDERLINE.bits
                                         | Self::DASHED_UNDERLINE.bits;

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1727,6 +1727,8 @@ impl<T: EventListener> Handler for Term<T> {
             Attr::CancelHidden => cursor.template.flags.remove(Flags::HIDDEN),
             Attr::Strike => cursor.template.flags.insert(Flags::STRIKEOUT),
             Attr::CancelStrike => cursor.template.flags.remove(Flags::STRIKEOUT),
+            Attr::Overline => cursor.template.flags.insert(Flags::OVERLINE),
+            Attr::CancelOverline => cursor.template.flags.remove(Flags::OVERLINE),
             _ => {
                 debug!("Term got unhandled attr: {:?}", attr);
             },

--- a/docs/ansicode.txt
+++ b/docs/ansicode.txt
@@ -568,6 +568,8 @@ Oct Hex  *  	(* marks function used in DEC VT series or LA series terminals)
 	 *	[36m = Write with cyan,    [46m = Set background to cyan
 	 *	[37m = Write with white,   [47m = Set background to white
 		[38m, [39m, [48m, [49m are reserved
+		[53m = Overline
+		[55m = Cancel overline attribute only
 156 6E n * DSR - Device Status Report
 	 *	[0n = Terminal is ready, no malfunctions detected
 		[1n = Terminal is busy, retry later


### PR DESCRIPTION
The overline attribute (SGR code 53 to enable / 55 to disable) is currently unsupported by Alacritty. This PR adds support for those codes.

---

While overlines are properly drawn by this commit if they are switched to be (e.g.) SGR 1, for some reason if SGR 53 or 55 is passed, they are not present in the parameter list passed to `csi_dispatch`, so this commit is non-functional at present. As I do not know Rust, any help in figuring this bug out would be appreciated.