### PR TITLE
Update supported escape code list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The `--help` output was reworked with a new colorful syntax
 - OSC 52 is now disabled on unfocused windows
 - `SpawnNewInstance` no longer inherits initial `--command`
+- Updated `doc/escape_support.md` to more accurately reflect supported escape codes
 
 ### Fixed
 

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -65,7 +65,9 @@ brevity.
 | `CSI l`    | PARTIAL     | See `CSI h` for supported modes                   |
 | `CSI ? l`  | PARTIAL     | See `CSI ? h` for supported modes                 |
 | `CSI M`    | IMPLEMENTED |                                                   |
-| `CSI m`    | IMPLEMENTED |                                                   |
+| `CSI m`    | PARTIAL     | `0..9`, `21..25`, `27..49`, `58`, `59`, `90..97`, |
+|            |             | `100..107`                                        |
+|            | REJECTED    | `53`, `55`                                        |
 | `CSI n`    | IMPLEMENTED |                                                   |
 | `CSI P`    | IMPLEMENTED |                                                   |
 | `CSI SP q` | IMPLEMENTED |                                                   |

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -65,8 +65,9 @@ brevity.
 | `CSI l`    | PARTIAL     | See `CSI h` for supported modes                   |
 | `CSI ? l`  | PARTIAL     | See `CSI ? h` for supported modes                 |
 | `CSI M`    | IMPLEMENTED |                                                   |
-| `CSI m`    | PARTIAL     | `0..9`, `21..25`, `27..49`, `58`, `59`, `90..97`, |
-|            |             | `100..107`                                        |
+| `CSI m`    | PARTIAL     | Supported parameters:                             |
+|            |             |   `0`-`9`, `21`-`25`, `27`-`49`, `58`, `59`       |
+|            |             |   `90`-`97`, `100`-`107`                          |
 |            | REJECTED    | `53`, `55`                                        |
 | `CSI n`    | IMPLEMENTED |                                                   |
 | `CSI P`    | IMPLEMENTED |                                                   |


### PR DESCRIPTION
Overlines (SGR 53/55) are, according to #1647, #5988, and #6122, expressly unsupported by Alacritty (i.e. not only do they not work, but support for them will never be merged). This PR updates the documentation to reflect this.