### PR TITLE
Bump dirs to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
  "cocoa",
  "copypasta",
  "crossfont",
- "dirs 3.0.2",
+ "dirs",
  "embed-resource",
  "fnv",
  "gl_generator",
@@ -62,7 +62,7 @@ dependencies = [
  "alacritty_config_derive",
  "base64",
  "bitflags",
- "dirs 3.0.2",
+ "dirs",
  "libc",
  "log",
  "mio 0.6.23",
@@ -441,15 +441,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "dirs"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
-dependencies = [
- "dirs-sys",
 ]
 
 [[package]]
@@ -2058,7 +2049,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
 dependencies = [
- "dirs 4.0.0",
+ "dirs",
 ]
 
 [[package]]

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -33,7 +33,7 @@ copypasta = { version = "0.8.0", default-features = false }
 libc = "0.2"
 unicode-width = "0.1"
 bitflags = "1"
-dirs = "3.0.1"
+dirs = "4.0.0"
 once_cell = "1.12"
 
 [build-dependencies]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 unicode-width = "0.1"
 base64 = "0.13.0"
 regex-automata = "0.1.9"
-dirs = "3.0.1"
+dirs = "4.0.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.22.0"


### PR DESCRIPTION
This is to remove dependencies on multiple versions of dirs crate.

There is no breaking change affects alacritty.

https://github.com/dirs-dev/dirs-rs#changelog