### PR TITLE
Fix resize on Wayland when creating new window

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -495,6 +495,16 @@ impl Window {
         self.windowed_context.resize(size);
     }
 
+    pub fn make_not_current(&mut self) {
+        if self.windowed_context.is_current() {
+            self.windowed_context.replace_with(|context| unsafe {
+                // We do ensure that context is current before any rendering operation due to multi
+                // window support, so we don't need extra "type aid" from glutin here.
+                context.make_not_current().expect("context swap").treat_as_current()
+            });
+        }
+    }
+
     pub fn make_current(&mut self) {
         if !self.windowed_context.is_current() {
             self.windowed_context

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1344,6 +1344,13 @@ impl Processor {
                 GlutinEvent::UserEvent(Event {
                     payload: EventType::CreateWindow(options), ..
                 }) => {
+                    // XXX Ensure that no context is current when creating a new window, otherwise
+                    // it may lock the backing buffer of the surface of current context when asking
+                    // e.g. EGL on Wayland to create a new context.
+                    for window_context in self.windows.values_mut() {
+                        window_context.display.window.make_not_current();
+                    }
+
                     if let Err(err) = self.create_window(event_loop, proxy.clone(), options) {
                         error!("Could not open window: {:?}", err);
                     }


### PR DESCRIPTION
This fixes the issue when the window that got `CreateWindow` event
gets resized after creating that new window.

Follow-up to 90552e3.