### PR TITLE
dimensions: warn if only one of lines, columns is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Blinking cursor will timeout after `5` seconds by default
 - Deprecated `colors.search.bar`, use `colors.footer_bar` instead
 - On macOS, Alacritty now reads `AppleFontSmoothing` from user defaults to control font smoothing
-- Show warning when either `columns` or `lines` is set, but not both
 - Warn when either `columns` or `lines` is non-zero, but not both
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Blinking cursor will timeout after `5` seconds by default
 - Deprecated `colors.search.bar`, use `colors.footer_bar` instead
 - On macOS, Alacritty now reads `AppleFontSmoothing` from user defaults to control font smoothing
+- Show warning when either `columns` or `lines` is set, but not both
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deprecated `colors.search.bar`, use `colors.footer_bar` instead
 - On macOS, Alacritty now reads `AppleFontSmoothing` from user defaults to control font smoothing
 - Show warning when either `columns` or `lines` is set, but not both
+- Warn when either `columns` or `lines` is non-zero, but not both
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -27,9 +27,9 @@
   # Window dimensions (changes require restart)
   #
   # Number of lines/columns (not pixels) in the terminal. Both lines and columns
-  # must be non-zero for this to take effect. The number of columns must be at least `2`,
-  # while using a value of `0` for columns and lines will fall back to the
-  # window manager's recommended size. 
+  # must be non-zero for this to take effect. The number of columns must be at
+  # least `2`, while using a value of `0` for columns and lines will fall back
+  # to the window manager's recommended size
   #dimensions:
   #  columns: 0
   #  lines: 0

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -27,7 +27,7 @@
   # Window dimensions (changes require restart)
   #
   # Number of lines/columns (not pixels) in the terminal. Both lines and columns
-  # must be set for this to take effect. The number of columns must be at least `2`,
+  # must be non-zero for this to take effect. The number of columns must be at least `2`,
   # while using a value of `0` for columns and lines will fall back to the
   # window manager's recommended size. 
   #dimensions:

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -26,10 +26,10 @@
 #window:
   # Window dimensions (changes require restart)
   #
-  # Number of lines/columns (not pixels) in the terminal. The number of columns
-  # must be at least `2`, while using a value of `0` for columns and lines will
-  # fall back to the window manager's recommended size. Both lines and columns
-  # must be set for this to take effect
+  # Number of lines/columns (not pixels) in the terminal. Both lines and columns
+  # must be set for this to take effect. The number of columns must be at least `2`,
+  # while using a value of `0` for columns and lines will fall back to the
+  # window manager's recommended size. 
   #dimensions:
   #  columns: 0
   #  lines: 0

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -28,7 +28,8 @@
   #
   # Number of lines/columns (not pixels) in the terminal. The number of columns
   # must be at least `2`, while using a value of `0` for columns and lines will
-  # fall back to the window manager's recommended size.
+  # fall back to the window manager's recommended size. Both lines and columns
+  # must be set for this to take effect
   #dimensions:
   #  columns: 0
   #  lines: 0

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -78,14 +78,14 @@ impl WindowConfig {
         let is_lines_set = self.dimensions.lines != 0;
 
         // Throw warning if only one of columns, lines is set
-        if is_lines_set ^ is_columns_set && self.startup_mode != StartupMode::Maximized {
+        if is_lines_set ^ is_columns_set {
             warn!(
                 target: LOG_TARGET_CONFIG,
                 "Both lines and columns must be set for window.dimensions to take effect"
             );
         }
 
-        if is_columns_set && is_lines_set && self.startup_mode != StartupMode::Maximized {
+        if is_columns_set && is_lines_set {
             Some(self.dimensions)
         } else {
             None

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -75,15 +75,14 @@ impl WindowConfig {
     #[inline]
     pub fn dimensions(&self) -> Option<Dimensions> {
         let (lines, columns) = (self.dimensions.lines, self.dimensions.columns.0);
-        let (lines_is_none_zero, columns_is_non_zero) = (lines != 0, columns != 0);
+        let (lines_is_non_zero, columns_is_non_zero) = (lines != 0, columns != 0);
 
-        // return dimensions if both `lines` and `columns` is non-zero
-        if lines_is_none_zero && columns_is_non_zero {
+        if lines_is_non_zero && columns_is_non_zero {
+            // return dimensions if both `lines` and `columns` is non-zero
             Some(self.dimensions)
-        }
-        // Warn if either `columns` or `lines` is non-zero
-        else if lines_is_none_zero || columns_is_non_zero {
-            let (zero_key, key, value) = if lines_is_none_zero {
+        } else if lines_is_non_zero || columns_is_non_zero {
+            // Warn if either `columns` or `lines` is non-zero
+            let (zero_key, non_zero_key, non_zero_value) = if lines_is_non_zero {
                 ("columns", "lines", lines)
             } else {
                 ("lines", "columns", columns)
@@ -94,8 +93,8 @@ impl WindowConfig {
                 "Both `lines` and `columns` must be non-zero for `window.dimensions` to take effect. \
                     Configured value of `{}` is 0 while that of `{}` is {}",
                 zero_key,
-                key,
-                value,
+                non_zero_key,
+                non_zero_value,
             );
 
             None

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -78,7 +78,7 @@ impl WindowConfig {
         let is_lines_set = self.dimensions.lines != 0;
 
         // Throw warning if only one of columns, lines is set
-        if (is_lines_set) ^ (is_columns_set) {
+        if is_lines_set ^ is_columns_set {
             warn!(
                 target: LOG_TARGET_CONFIG,
                 "Both lines and columns must be set for window.dimensions to take effect"

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -78,7 +78,7 @@ impl WindowConfig {
         let is_lines_set = self.dimensions.lines != 0;
 
         // Throw warning if only one of columns, lines is set
-        if is_lines_set ^ is_columns_set {
+        if is_lines_set ^ is_columns_set && self.startup_mode != StartupMode::Maximized {
             warn!(
                 target: LOG_TARGET_CONFIG,
                 "Both lines and columns must be set for window.dimensions to take effect"

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -82,7 +82,7 @@ impl WindowConfig {
             Some(self.dimensions)
         } else if lines_is_non_zero || columns_is_non_zero {
             // Warn if either `columns` or `lines` is non-zero.
-            
+
             let (zero_key, non_zero_key, non_zero_value) = if lines_is_non_zero {
                 ("columns", "lines", lines)
             } else {
@@ -91,8 +91,8 @@ impl WindowConfig {
 
             warn!(
                 target: LOG_TARGET_CONFIG,
-                "Both `lines` and `columns` must be non-zero for `window.dimensions` to take effect. \
-                    Configured value of `{}` is 0 while that of `{}` is {}",
+                "Both `lines` and `columns` must be non-zero for `window.dimensions` to take \
+                 effect. Configured value of `{}` is 0 while that of `{}` is {}",
                 zero_key,
                 non_zero_key,
                 non_zero_value,

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -78,10 +78,11 @@ impl WindowConfig {
         let (lines_is_non_zero, columns_is_non_zero) = (lines != 0, columns != 0);
 
         if lines_is_non_zero && columns_is_non_zero {
-            // return dimensions if both `lines` and `columns` is non-zero
+            // Return dimensions if both `lines` and `columns` are non-zero.
             Some(self.dimensions)
         } else if lines_is_non_zero || columns_is_non_zero {
-            // Warn if either `columns` or `lines` is non-zero
+            // Warn if either `columns` or `lines` is non-zero.
+            
             let (zero_key, non_zero_key, non_zero_value) = if lines_is_non_zero {
                 ("columns", "lines", lines)
             } else {

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -74,18 +74,24 @@ impl Default for WindowConfig {
 impl WindowConfig {
     #[inline]
     pub fn dimensions(&self) -> Option<Dimensions> {
-        let is_columns_set = self.dimensions.columns.0 != 0;
-        let is_lines_set = self.dimensions.lines != 0;
+        // Warn if one of columns, lines is non-zero but not both
+        if (self.dimensions.lines != 0) ^ (self.dimensions.columns.0 != 0) {
+            let (zero_key, key, value) = match self.dimensions.lines != 0 {
+                true => ("columns", "lines", self.dimensions.lines),
+                false => ("lines", "columns", self.dimensions.columns.0),
+            };
 
-        // Throw warning if only one of columns, lines is set
-        if is_lines_set ^ is_columns_set {
             warn!(
                 target: LOG_TARGET_CONFIG,
-                "Both lines and columns must be set for window.dimensions to take effect"
+                "Both lines and columns must be non-zero for window.dimensions to take effect. \
+                Configured value of {} is 0 while that of {} is {}",
+                zero_key,
+                key,
+                value,
             );
         }
 
-        if is_columns_set && is_lines_set {
+        if (self.dimensions.lines != 0) && (self.dimensions.columns.0 != 0) {
             Some(self.dimensions)
         } else {
             None

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -74,25 +74,31 @@ impl Default for WindowConfig {
 impl WindowConfig {
     #[inline]
     pub fn dimensions(&self) -> Option<Dimensions> {
-        // Warn if one of columns, lines is non-zero but not both
-        if (self.dimensions.lines != 0) ^ (self.dimensions.columns.0 != 0) {
-            let (zero_key, key, value) = match self.dimensions.lines != 0 {
-                true => ("columns", "lines", self.dimensions.lines),
-                false => ("lines", "columns", self.dimensions.columns.0),
+        let (lines, columns) = (self.dimensions.lines, self.dimensions.columns.0);
+        let (lines_is_none_zero, columns_is_non_zero) = (lines != 0, columns != 0);
+
+        // return dimensions if both `lines` and `columns` is non-zero
+        if lines_is_none_zero && columns_is_non_zero {
+            Some(self.dimensions)
+        }
+        // Warn if either `columns` or `lines` is non-zero
+        else if lines_is_none_zero || columns_is_non_zero {
+            let (zero_key, key, value) = if lines_is_none_zero {
+                ("columns", "lines", lines)
+            } else {
+                ("lines", "columns", columns)
             };
 
             warn!(
                 target: LOG_TARGET_CONFIG,
-                "Both lines and columns must be non-zero for window.dimensions to take effect. \
-                Configured value of {} is 0 while that of {} is {}",
+                "Both `lines` and `columns` must be non-zero for `window.dimensions` to take effect. \
+                    Configured value of `{}` is 0 while that of `{}` is {}",
                 zero_key,
                 key,
                 value,
             );
-        }
 
-        if (self.dimensions.lines != 0) && (self.dimensions.columns.0 != 0) {
-            Some(self.dimensions)
+            None
         } else {
             None
         }


### PR DESCRIPTION
This commit will add a warning when either `window.dimensions.columns` or `window.dimensions.lines` is set but not both