### PR TITLE
Add `cursor.blink_timeout` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Escape sequence to reset underline color (`CSI 59 m`)
 - Vi mode keybinding (z) to center view around vi mode cursor
 - Accept hexadecimal values starting with `0x` for `--embed`
+- Config option `cursor.blink_timeout` to timeout cursor blinking after inactivity
 
 ### Changed
 
 - The `--help` output was reworked with a new colorful syntax
 - OSC 52 is now disabled on unfocused windows
 - `SpawnNewInstance` no longer inherits initial `--command`
+- Blinking cursor will timeout after `5` seconds by default
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -412,6 +412,11 @@
   # Cursor blinking interval in milliseconds.
   #blink_interval: 750
 
+  # Time after which cursor stops blinking, in seconds.
+  #
+  # Specifying '0' will disable timeout for blinking.
+  #blink_timeout: 5
+
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.
   #unfocused_hollow: true

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -27,6 +27,7 @@ pub enum Topic {
     SelectionScrolling,
     DelayedSearch,
     BlinkCursor,
+    BlinkTimeout,
 }
 
 /// Event scheduled to be emitted at a specific time.

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -43,6 +43,7 @@ pub struct WindowContext {
     pub display: Display,
     event_queue: Vec<GlutinEvent<'static, Event>>,
     terminal: Arc<FairMutex<Term<EventProxy>>>,
+    cursor_blink_timed_out: bool,
     modifiers: ModifiersState,
     search_state: SearchState,
     received_count: usize,
@@ -151,6 +152,7 @@ impl WindowContext {
             master_fd,
             #[cfg(not(windows))]
             shell_pid,
+            cursor_blink_timed_out: Default::default(),
             suppress_chars: Default::default(),
             message_buffer: Default::default(),
             received_count: Default::default(),
@@ -267,6 +269,7 @@ impl WindowContext {
         let old_is_searching = self.search_state.history_index.is_some();
 
         let context = ActionContext {
+            cursor_blink_timed_out: &mut self.cursor_blink_timed_out,
             message_buffer: &mut self.message_buffer,
             received_count: &mut self.received_count,
             suppress_chars: &mut self.suppress_chars,

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp::max;
+use std::cmp;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -13,6 +13,7 @@ use crate::ansi::{CursorShape, CursorStyle};
 pub use crate::config::scrolling::{Scrolling, MAX_SCROLLBACK_LINES};
 
 pub const LOG_TARGET_CONFIG: &str = "alacritty_config_derive";
+
 const MIN_BLINK_INTERVAL: u64 = 10;
 
 /// Top-level config type.
@@ -75,6 +76,7 @@ pub struct Cursor {
 
     thickness: Percentage,
     blink_interval: u64,
+    blink_timeout: u8,
 }
 
 impl Default for Cursor {
@@ -83,6 +85,7 @@ impl Default for Cursor {
             thickness: Percentage(0.15),
             unfocused_hollow: true,
             blink_interval: 750,
+            blink_timeout: 5,
             style: Default::default(),
             vi_mode_style: Default::default(),
         }
@@ -107,7 +110,18 @@ impl Cursor {
 
     #[inline]
     pub fn blink_interval(self) -> u64 {
-        max(self.blink_interval, MIN_BLINK_INTERVAL)
+        cmp::max(self.blink_interval, MIN_BLINK_INTERVAL)
+    }
+
+    #[inline]
+    pub fn blink_timeout(self) -> u64 {
+        const MILLIS_IN_SECOND: u64 = 1000;
+        match self.blink_timeout {
+            0 => 0,
+            blink_timeout => {
+                cmp::max(self.blink_interval * 5 / MILLIS_IN_SECOND, blink_timeout as u64)
+            },
+        }
     }
 }
 


### PR DESCRIPTION
This option should prevent extensive power usage due to cursor blinking
when there's no user activity being performed.

Fixes #5992.

--

I'm not quite sure when we should restart blinking and how we should handle defaults that doesn't make sense, e.g. when timeout is lower than blinking interval. Also, should we update cursor blinking when mouse moves, etc?