### PR TITLE
Use timer based rendering instead of vsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CPU usage spikes due to mouse movements for unfocused windows on X11/Windows
 - First window on macOS not tabbed with system prefer tabs setting
 - Window being treaten as focused by default on Wayland
+- Low frame rate when multiple windows render at the same time
+- Redraw hanging until a keypress on X11 in rare cases
 
 ### Removed
 

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -28,6 +28,7 @@ pub enum Topic {
     DelayedSearch,
     BlinkCursor,
     BlinkTimeout,
+    Frame,
 }
 
 /// Event scheduled to be emitted at a specific time.


### PR DESCRIPTION
Given that alacritty handles all the windows on the main thread using
vsync will result in sequential locks on swap buffers for each window
it'll try to draw at the given time, reducing the frame rate by the
amount of windows being drawn.

Timer based solution solves this since there's no more blocking
involved.