### PR TITLE
On macOS and X11 do not render when the window is occluded for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- No longer renders to macos and x11 windows that are fully occluded / not directly visible
 - The `--help` output was reworked with a new colorful syntax
 - OSC 52 is now disabled on unfocused windows
 - `SpawnNewInstance` no longer inherits initial `--command`

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1204,10 +1204,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     },
                     WindowEvent::Occluded(occluded) => {
                         *self.ctx.occluded = occluded;
-                        if !occluded {
-                            // Render as soon as the window is visible once again.
-                            *self.ctx.dirty = true;
-                        }
                     },
                     WindowEvent::DroppedFile(path) => {
                         let path: String = path.to_string_lossy().into();

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -192,6 +192,7 @@ pub struct ActionContext<'a, N, T> {
     pub search_state: &'a mut SearchState,
     pub font_size: &'a mut Size,
     pub dirty: &'a mut bool,
+    pub occluded: &'a mut bool,
     pub preserve_title: bool,
     #[cfg(not(windows))]
     pub master_fd: RawFd,
@@ -1201,6 +1202,13 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         self.ctx.update_cursor_blinking();
                         self.on_focus_change(is_focused);
                     },
+                    WindowEvent::Occluded(occluded) => {
+                        *self.ctx.occluded = occluded;
+                        if !occluded {
+                            // Render as soon as the window is visible once again.
+                            *self.ctx.dirty = true;
+                        }
+                    },
                     WindowEvent::DroppedFile(path) => {
                         let path: String = path.to_string_lossy().into();
                         self.ctx.write_to_pty((path + " ").into_bytes());
@@ -1229,7 +1237,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     | WindowEvent::ThemeChanged(_)
                     | WindowEvent::HoveredFile(_)
                     | WindowEvent::Touch(_)
-                    | WindowEvent::Occluded(_)
                     | WindowEvent::Moved(_) => (),
                 }
             },

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -52,6 +52,7 @@ pub struct WindowContext {
     font_size: Size,
     mouse: Mouse,
     dirty: bool,
+    occluded: bool,
     preserve_title: bool,
     #[cfg(not(windows))]
     master_fd: RawFd,
@@ -161,6 +162,7 @@ impl WindowContext {
             modifiers: Default::default(),
             mouse: Default::default(),
             dirty: Default::default(),
+            occluded: Default::default(),
         })
     }
 
@@ -276,6 +278,7 @@ impl WindowContext {
             display: &mut self.display,
             mouse: &mut self.mouse,
             dirty: &mut self.dirty,
+            occluded: &mut self.occluded,
             terminal: &mut terminal,
             #[cfg(not(windows))]
             master_fd: self.master_fd,
@@ -324,7 +327,7 @@ impl WindowContext {
             return;
         }
 
-        if self.dirty {
+        if self.dirty && !self.occluded {
             // Force the display to process any pending display update.
             self.display.process_renderer_update();
 


### PR DESCRIPTION
Rendering when the window is not visible due to it being closed, minimised, occluded by other windows, etc; is extremely cpu/gpu intensive with no benefit to the user.

By implementing occlusion detection, my simple bash script that prints numbers every 0.1 seconds went from ~10% cpu usage to about ~0.4% cpu usage when in the background. I've submitted a winit pull request but I thought I might as well get in early to show off the performance/efficiency benefits.