### PR TITLE
Use DeviceId/WindowId::dummy in tests

### DIFF
--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -978,7 +978,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 mod tests {
     use super::*;
 
-    use glutin::event::{Event as GlutinEvent, VirtualKeyCode, WindowEvent};
+    use glutin::event::{Event as GlutinEvent, VirtualKeyCode, WindowEvent, DeviceId};
+    use glutin::window::WindowId;
 
     use alacritty_terminal::event::Event as TerminalEvent;
 
@@ -1190,10 +1191,10 @@ mod tests {
             event: WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Left,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
+                device_id: unsafe { DeviceId::dummy() },
                 modifiers: ModifiersState::default(),
             },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
+            window_id: unsafe { WindowId::dummy() },
         },
         end_state: ClickState::Click,
     }
@@ -1206,10 +1207,10 @@ mod tests {
             event: WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Right,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
+                device_id: unsafe { DeviceId::dummy() },
                 modifiers: ModifiersState::default(),
             },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
+            window_id: unsafe { WindowId::dummy() },
         },
         end_state: ClickState::Click,
     }
@@ -1222,10 +1223,10 @@ mod tests {
             event: WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Middle,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
+                device_id: unsafe { DeviceId::dummy() },
                 modifiers: ModifiersState::default(),
             },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
+            window_id: unsafe { WindowId::dummy() },
         },
         end_state: ClickState::Click,
     }
@@ -1238,10 +1239,10 @@ mod tests {
             event: WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Left,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
+                device_id: unsafe { DeviceId::dummy() },
                 modifiers: ModifiersState::default(),
             },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
+            window_id: unsafe { WindowId::dummy() },
         },
         end_state: ClickState::DoubleClick,
     }
@@ -1254,10 +1255,10 @@ mod tests {
             event: WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Left,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
+                device_id: unsafe { DeviceId::dummy() },
                 modifiers: ModifiersState::default(),
             },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
+            window_id: unsafe { WindowId::dummy() },
         },
         end_state: ClickState::TripleClick,
     }
@@ -1270,10 +1271,10 @@ mod tests {
             event: WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Right,
-                device_id: unsafe { std::mem::transmute_copy(&0) },
+                device_id: unsafe { DeviceId::dummy() },
                 modifiers: ModifiersState::default(),
             },
-            window_id: unsafe { std::mem::transmute_copy(&0) },
+            window_id: unsafe { WindowId::dummy() },
         },
         end_state: ClickState::Click,
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -978,7 +978,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 mod tests {
     use super::*;
 
-    use glutin::event::{Event as GlutinEvent, VirtualKeyCode, WindowEvent, DeviceId};
+    use glutin::event::{DeviceId, Event as GlutinEvent, VirtualKeyCode, WindowEvent};
     use glutin::window::WindowId;
 
     use alacritty_terminal::event::Event as TerminalEvent;


### PR DESCRIPTION
The use of transmute_copy here is UB because a `0` defaults to `i32`, which has size 4 bytes, and (on my platform), a `glutin::event::DeviceId` is 8 bytes, as it is an enum with 2 variants with the `X11` holding a `c_int`, which is another `i32`. Therefore, the `transmute_copy` reads out of bounds of the input pointer.

I just changed it to use the dummy function. Which is still unsafe, but it has the same effect as the transmute_copy does, making a DeviceId with value 0.

WindowId is similar, but holds a u64 or a usize depending on X11/Wayland. Same fix, made it use `dummy`.

In https://github.com/rust-lang/rust/pull/98839 we're making transmute_copy panic at runtime if `U` is larger than `T`.
