### PR TITLE
Fix error when opening in root of drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Character mappings in the DEC special graphics character set (line drawing)
 - Window flickering on resize on Wayland
 - Unnecessary config reload when using `/dev/null` as a config file
+- Windows `Open Alacritty Here` on root of drive displaying error
 
 ## 0.10.1
 

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -53,7 +53,7 @@
             <!-- Add context menu -->
             <Component Id="ContextMenu" Guid="449f9121-f7b9-41fe-82da-52349ea8ff91">
                 <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here\command">
-                    <RegistryValue Type="string" Value="[AlacrittyProgramFiles]alacritty.exe --working-directory &quot;%V&quot;" KeyPath="yes"/>
+                    <RegistryValue Type="string" Value="[AlacrittyProgramFiles]alacritty.exe" KeyPath="yes"/>
                 </RegistryKey>
                 <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here">
                     <RegistryValue Type="string" Name="Icon" Value="[AlacrittyProgramFiles]alacritty.exe"/>


### PR DESCRIPTION
Fixes #4882 more elegently than in my previous #6110

When opening root drives eg A:\ C:\ Z:\ etc
an error will appear
![image](https://user-images.githubusercontent.com/14964651/178124623-d6f8cc5f-c5ae-43bc-bccb-d3c6b3a97387.png)

The above Log File
```
[0.003076400s] [ERROR] [alacritty] Invalid working directory: "Z:\""
```

When running the registry command it appears to escape the " duplicating it

I made a simple test app that just prints the command line args to confirm this and this is the output of the command on the root of the A:\
`--working-directory "A:\""`
An extra " is created 
This appears to be an issue with cmd only which is what the registry seems to run as running this command in cmd does the same thing
![image](https://user-images.githubusercontent.com/14964651/178124743-40b38b29-f31b-4897-a9b1-921bf8b94540.png)

powershell works fine
![image](https://user-images.githubusercontent.com/14964651/178124813-52b75b5f-0140-4202-ac36-fe3cfe9d8646.png)

After trying all that I just removed the commandline arg and it worked fine
as it appears windows sets the working directory to the correct place anyways meaning the arg was redundant and just causing parsing/escape issues i also confirmed this with a test application and it sets the working dir with out having %V

I tested this by just opening registry editor and manually changing it in my currently installed alacritty
![image](https://user-images.githubusercontent.com/14964651/178124939-29a20751-1b34-4906-ae4d-6f84c792cd45.png)

both the root dir and folders with spaces still work
![image](https://user-images.githubusercontent.com/14964651/178124965-4c26b61b-84c5-47ff-9b03-8c375dd47c90.png)
