### PR TITLE
Use org.alacritty instead of io.alacritty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Packaging
 
 - Minimum Rust version has been bumped to 1.57.0
+- Renamed `io.alacritty.Alacritty.appdata.xml` to `org.alacritty.Alacritty.appdata.xml`
+- Renamed `io.alacritty` to `org.alacritty` for `Alacritty.app`
 
 ### Added
 

--- a/extra/linux/org.alacritty.Alacritty.appdata.xml
+++ b/extra/linux/org.alacritty.Alacritty.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2016-2019 Joe Wilm, The Alacritty Project Contributors -->
+<!-- Copyright 2016-2022 Joe Wilm, The Alacritty Project Contributors -->
 <component type="desktop-application">
-  <id>io.alacritty.Alacritty</id>
+  <id>org.alacritty.Alacritty</id>
   <!-- Translators: The application name -->
   <name>Alacritty</name>
   <project_license>APACHE-2.0</project_license>

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleExecutable</key>
   <string>alacritty</string>
   <key>CFBundleIdentifier</key>
-  <string>io.alacritty</string>
+  <string>org.alacritty</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>


### PR DESCRIPTION
The common naming is reverse DNS, and given that alacritty is using
alacritty.org it makes more sense to use org.alacritty instead of
old io.alacritty.