### PR TITLE
Audit and simplifying of dirty fields

### DIFF
--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -6,7 +6,6 @@ use alacritty_terminal::ansi::{Color, CursorShape, NamedColor};
 use alacritty_terminal::event::EventListener;
 use alacritty_terminal::grid::Indexed;
 use alacritty_terminal::index::{Column, Line, Point};
-use alacritty_terminal::selection::SelectionRange;
 use alacritty_terminal::term::cell::{Cell, Flags, Hyperlink};
 use alacritty_terminal::term::color::{CellRgb, Rgb};
 use alacritty_terminal::term::search::{Match, RegexSearch};
@@ -100,10 +99,6 @@ impl<'a> RenderableContent<'a> {
     /// Get the RGB value for a color index.
     pub fn color(&self, color: usize) -> Rgb {
         self.terminal_content.colors[color].unwrap_or(self.colors[color])
-    }
-
-    pub fn selection_range(&self) -> Option<SelectionRange> {
-        self.terminal_content.selection
     }
 
     /// Assemble the information required to render the terminal cursor.

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -999,7 +999,7 @@ impl Display {
         if highlighted_hint.is_some() {
             // If mouse changed the line, we should update the hyperlink preview, since the
             // highlighted hint could be disrupted by the old preview.
-            dirty = self.hint_mouse_point.map(|p| p.line != point.line).unwrap_or(false);
+            dirty |= self.hint_mouse_point.map(|p| p.line != point.line).unwrap_or(false);
             self.hint_mouse_point = Some(point);
             self.window.set_mouse_cursor(CursorIcon::Hand);
         } else if self.highlighted_hint.is_some() {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -708,6 +708,9 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
                 }
 
                 self.terminal.vi_goto_point(*hint_bounds.start());
+
+                // The vi cursor might have moved onto a hint.
+                self.mouse_mut().hint_highlight_dirty = true;
             },
         }
     }
@@ -1166,7 +1169,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     WindowEvent::MouseInput { state, button, .. } => {
                         self.ctx.window().set_mouse_visible(true);
                         self.mouse_input(state, button);
-                        *self.ctx.dirty = true;
                     },
                     WindowEvent::CursorMoved { position, .. } => {
                         self.ctx.window().set_mouse_visible(true);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1173,6 +1173,9 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     },
                     WindowEvent::Focused(is_focused) => {
                         self.ctx.terminal.is_focused = is_focused;
+
+                        // The cursor shape can change with the focus state, see
+                        // RenderableContent::new.
                         *self.ctx.dirty = true;
 
                         if is_focused {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -235,8 +235,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             let point = self.mouse.point(&self.size_info(), display_offset);
             self.update_selection(point, self.mouse.cell_side);
         }
-
-        *self.dirty = true;
     }
 
     // Copy text selection.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1074,9 +1074,11 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     // Disable blinking after timeout reached.
                     let timer_id = TimerId::new(Topic::BlinkCursor, self.ctx.display.window.id());
                     self.ctx.scheduler.unschedule(timer_id);
-                    self.ctx.display.cursor_hidden = false;
                     *self.ctx.cursor_blink_timed_out = true;
-                    *self.ctx.dirty = true;
+                    if self.ctx.display.cursor_hidden {
+                        self.ctx.display.cursor_hidden = false;
+                        *self.ctx.dirty = true;
+                    }
                 },
                 EventType::Message(message) => {
                     self.ctx.message_buffer.push(message);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -656,7 +656,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             self.mouse.block_hint_launcher = false;
             self.trigger_hint(&hint);
         }
-        *self.dirty = true;
     }
 
     /// Trigger a hint action.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -642,15 +642,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[inline]
     fn on_typing_start(&mut self) {
         // Disable cursor blinking.
-        let timer_id = TimerId::new(Topic::BlinkCursor, self.display.window.id());
-        if self.scheduler.unschedule(timer_id).is_some() {
-            self.schedule_blinking();
-            self.display.cursor_hidden = false;
-        } else if *self.cursor_blink_timed_out {
-            self.update_cursor_blinking();
-        }
-
-        *self.dirty = true;
+        self.update_cursor_blinking();
 
         // Hide mouse cursor.
         if self.config.mouse.hide_when_typing {
@@ -958,7 +950,9 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
         if blinking && self.terminal.is_focused {
             self.schedule_blinking();
             self.schedule_blinking_timeout();
-        } else {
+        }
+
+        if self.display.cursor_hidden {
             self.display.cursor_hidden = false;
             *self.dirty = true;
         }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1195,10 +1195,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     },
                     WindowEvent::CursorLeft { .. } => {
                         self.ctx.mouse.inside_text_area = false;
-
-                        if self.ctx.display().highlighted_hint.is_some() {
-                            *self.ctx.dirty = true;
-                        }
+                        self.ctx.mouse.hint_highlight_dirty = true;
                     },
                     WindowEvent::KeyboardInput { is_synthetic: true, .. }
                     | WindowEvent::TouchpadPressure { .. }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -791,7 +791,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         self.terminal.toggle_vi_mode();
 
-        *self.dirty = true;
+        self.mouse_mut().hint_highlight_dirty = true;
     }
 
     fn message(&self) -> Option<&Message> {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -257,7 +257,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
     fn clear_selection(&mut self) {
         self.terminal.selection = None;
-        *self.dirty = true;
     }
 
     fn update_selection(&mut self, mut point: Point, side: Side) {
@@ -279,12 +278,10 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
 
         self.terminal.selection = Some(selection);
-        *self.dirty = true;
     }
 
     fn start_selection(&mut self, ty: SelectionType, point: Point, side: Side) {
         self.terminal.selection = Some(Selection::new(ty, point, side));
-        *self.dirty = true;
 
         self.copy_selection(ClipboardType::Selection);
     }
@@ -296,7 +293,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             },
             Some(selection) if !selection.is_empty() => {
                 selection.ty = ty;
-                *self.dirty = true;
 
                 self.copy_selection(ClipboardType::Selection);
             },

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -217,6 +217,9 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         self.terminal.scroll_display(scroll);
 
+        // The cursor might have moved onto a hint.
+        self.mouse_mut().hint_highlight_dirty = true;
+
         // Keep track of manual display offset changes during search.
         if self.search_active() {
             let display_offset = self.terminal.grid().display_offset();
@@ -1062,6 +1065,8 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     display_update_pending.set_dimensions(PhysicalSize::new(width, height));
 
                     self.ctx.window().scale_factor = scale_factor;
+                    // Possible layout change so the hint highlight must be updated.
+                    self.ctx.mouse_mut().hint_highlight_dirty = true;
                     *self.ctx.dirty = true;
                 },
                 EventType::SearchNext => self.ctx.goto_match(None),
@@ -1084,6 +1089,8 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     self.ctx.message_buffer.push(message);
                     self.ctx.display.pending_update.dirty = true;
                     *self.ctx.dirty = true;
+                    // Possible layout change so the hint highlight must be updated.
+                    self.ctx.mouse_mut().hint_highlight_dirty = true;
                 },
                 EventType::Terminal(event) => match event {
                     TerminalEvent::Title(title) => {
@@ -1155,6 +1162,8 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
 
                         self.ctx.display.pending_update.set_dimensions(size);
                         *self.ctx.dirty = true;
+                        // Possible layout change so the hint highlight must be updated.
+                        self.ctx.mouse_mut().hint_highlight_dirty = true;
                     },
                     WindowEvent::KeyboardInput { input, is_synthetic: false, .. } => {
                         self.key_input(input);

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -815,6 +815,10 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return;
         }
 
+        // XXX when we're writing keyboard input to pty we must not mark the terminal as dirty
+        // unless there's a need for visual update, like clearing a selection. Or scrolling to
+        // the viewport to bottom.
+
         self.ctx.on_typing_start();
 
         if self.ctx.terminal().grid().display_offset() != 0 {

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -193,7 +193,7 @@ impl<T: EventListener> Execute<T> for Action {
 
                 if let Some(regex_match) = ctx.search_next(origin, direction, Side::Left) {
                     ctx.terminal_mut().vi_goto_point(*regex_match.start());
-                    ctx.mark_dirty();
+                    ctx.mouse_mut().hint_highlight_dirty = true;
                 }
             },
             Action::Vi(ViAction::SearchPrevious) => {
@@ -209,7 +209,7 @@ impl<T: EventListener> Execute<T> for Action {
 
                 if let Some(regex_match) = ctx.search_next(origin, direction, Side::Left) {
                     ctx.terminal_mut().vi_goto_point(*regex_match.start());
-                    ctx.mark_dirty();
+                    ctx.mouse_mut().hint_highlight_dirty = true;
                 }
             },
             Action::Vi(ViAction::SearchStart) => {
@@ -218,7 +218,7 @@ impl<T: EventListener> Execute<T> for Action {
 
                 if let Some(regex_match) = ctx.search_next(origin, Direction::Left, Side::Left) {
                     ctx.terminal_mut().vi_goto_point(*regex_match.start());
-                    ctx.mark_dirty();
+                    ctx.mouse_mut().hint_highlight_dirty = true;
                 }
             },
             Action::Vi(ViAction::SearchEnd) => {
@@ -227,7 +227,7 @@ impl<T: EventListener> Execute<T> for Action {
 
                 if let Some(regex_match) = ctx.search_next(origin, Direction::Right, Side::Right) {
                     ctx.terminal_mut().vi_goto_point(*regex_match.end());
-                    ctx.mark_dirty();
+                    ctx.mouse_mut().hint_highlight_dirty = true;
                 }
             },
             Action::Vi(ViAction::CenterAroundViCursor) => {
@@ -327,7 +327,7 @@ impl<T: EventListener> Execute<T> for Action {
                 let topmost_line = ctx.terminal().topmost_line();
                 ctx.terminal_mut().vi_mode_cursor.point.line = topmost_line;
                 ctx.terminal_mut().vi_motion(ViMotion::FirstOccupied);
-                ctx.mark_dirty();
+                ctx.mouse_mut().hint_highlight_dirty = true;
             },
             Action::ScrollToBottom => {
                 ctx.scroll(Scroll::Bottom);
@@ -339,7 +339,7 @@ impl<T: EventListener> Execute<T> for Action {
                 // Move to beginning twice, to always jump across linewraps.
                 term.vi_motion(ViMotion::FirstOccupied);
                 term.vi_motion(ViMotion::FirstOccupied);
-                ctx.mark_dirty();
+                ctx.mouse_mut().hint_highlight_dirty = true;
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
             Action::ClearLogNotice => ctx.pop_message(),

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -158,7 +158,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ViMotion(motion) => {
                 ctx.on_typing_start();
                 ctx.terminal_mut().vi_motion(*motion);
-                ctx.mark_dirty();
+                ctx.mouse_mut().hint_highlight_dirty = true;
             },
             Action::Vi(ViAction::ToggleNormalSelection) => {
                 Self::toggle_selection(ctx, SelectionType::Simple);

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -311,7 +311,7 @@ impl WindowContext {
             );
         }
 
-        if self.dirty || self.mouse.hint_highlight_dirty {
+        if self.mouse.hint_highlight_dirty {
             self.dirty |= self.display.update_highlighted_hints(
                 &terminal,
                 config,

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -327,7 +327,7 @@ impl WindowContext {
             return;
         }
 
-        if self.dirty {
+        if self.dirty || terminal.has_damage() {
             // Force the display to process any pending display update.
             self.display.process_renderer_update();
 

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -312,8 +312,8 @@ impl WindowContext {
         }
 
         if self.mouse.hint_highlight_dirty {
-            self.dirty |= self.display.update_highlighted_hints(
-                &terminal,
+            self.display.update_highlighted_hints(
+                &mut terminal,
                 config,
                 &self.mouse,
                 self.modifiers,

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -366,12 +366,6 @@ impl<T> Term<T> {
 
     #[must_use]
     pub fn damage(&mut self, selection: Option<SelectionRange>) -> TermDamage<'_> {
-        // Ensure the entire terminal is damaged after entering insert mode.
-        // Leaving is handled in the ansi handler.
-        if self.mode.contains(TermMode::INSERT) {
-            self.mark_fully_damaged();
-        }
-
         // Update tracking of cursor, selection, and vi mode cursor.
 
         let display_offset = self.grid().display_offset();
@@ -1825,10 +1819,7 @@ impl<T: EventListener> Handler for Term<T> {
             ansi::Mode::LineFeedNewLine => self.mode.remove(TermMode::LINE_FEED_NEW_LINE),
             ansi::Mode::Origin => self.mode.remove(TermMode::ORIGIN),
             ansi::Mode::ColumnMode => self.deccolm(),
-            ansi::Mode::Insert => {
-                self.mode.remove(TermMode::INSERT);
-                self.mark_fully_damaged();
-            },
+            ansi::Mode::Insert => self.mode.remove(TermMode::INSERT),
             ansi::Mode::BlinkingCursor => {
                 let style = self.cursor_style.get_or_insert(self.default_cursor_style);
                 style.blinking = false;


### PR DESCRIPTION
This PR simplifies the code related to knowing when the terminal should be redrawn:
* It tries to separate the `dirty` (in `WindowContext`) and the `hint_highlighted_dirty` mechanisms by being more explicit about which is needed.
* It stops setting the `dirty` field when it's not needed, which removes extra redraws that would take place when scrolling, typing and could impact latency (see previous PR #6206) without introducing too much complexity (only simple conditions).
* It tries to remove the usage of the `dirty` field, so that the terminal can act as the source of truth and the code can be simplified. Note that this is not done everywhere. For example, the search functionality is still relying on the `dirty` field.

It should probably be read commit by commit. The commits are very small and I tried to explain what I did in the messages.