### PR TITLE
Remove redundant dirty updates

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -217,16 +217,17 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         self.terminal.scroll_display(scroll);
 
+        let lines_changed = old_offset - self.terminal.grid().display_offset() as i32;
+
         // Keep track of manual display offset changes during search.
         if self.search_active() {
-            let display_offset = self.terminal.grid().display_offset();
-            self.search_state.display_offset_delta += old_offset - display_offset as i32;
+            self.search_state.display_offset_delta += lines_changed;
         }
 
+        let vi_mode = self.terminal.mode().contains(TermMode::VI);
+
         // Update selection.
-        if self.terminal.mode().contains(TermMode::VI)
-            && self.terminal.selection.as_ref().map_or(true, |s| !s.is_empty())
-        {
+        if vi_mode && self.terminal.selection.as_ref().map_or(false, |s| !s.is_empty()) {
             self.update_selection(self.terminal.vi_mode_cursor.point, Side::Right);
         } else if self.mouse.left_button_state == ElementState::Pressed
             || self.mouse.right_button_state == ElementState::Pressed
@@ -236,7 +237,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             self.update_selection(point, self.mouse.cell_side);
         }
 
-        *self.dirty = true;
+        // Update dirty if actually scrolled or we're in the Vi mode.
+        *self.dirty |= lines_changed != 0 || vi_mode;
     }
 
     // Copy text selection.
@@ -258,8 +260,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     }
 
     fn clear_selection(&mut self) {
-        self.terminal.selection = None;
-        *self.dirty = true;
+        *self.dirty |= self.terminal.selection.take().map_or(false, |s| !s.is_empty());
     }
 
     fn update_selection(&mut self, mut point: Point, side: Side) {
@@ -286,9 +287,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
     fn start_selection(&mut self, ty: SelectionType, point: Point, side: Side) {
         self.terminal.selection = Some(Selection::new(ty, point, side));
-        *self.dirty = true;
-
         self.copy_selection(ClipboardType::Selection);
+        *self.dirty = true;
     }
 
     fn toggle_selection(&mut self, ty: SelectionType, point: Point, side: Side) {
@@ -421,13 +421,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         *self.font_size = max(*self.font_size + delta, Size::new(FONT_SIZE_STEP));
         let font = self.config.font.clone().with_size(*self.font_size);
         self.display.pending_update.set_font(font);
-        *self.dirty = true;
     }
 
     fn reset_font_size(&mut self) {
         *self.font_size = self.config.font.size();
         self.display.pending_update.set_font(self.config.font.clone());
-        *self.dirty = true;
     }
 
     #[inline]
@@ -435,7 +433,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         if !self.message_buffer.is_empty() {
             self.display.pending_update.dirty = true;
             self.message_buffer.pop();
-            *self.dirty = true;
         }
     }
 
@@ -471,7 +468,6 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
 
         self.display.pending_update.dirty = true;
-        *self.dirty = true;
     }
 
     #[inline]
@@ -651,12 +647,12 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         let timer_id = TimerId::new(Topic::BlinkCursor, self.display.window.id());
         if self.scheduler.unschedule(timer_id).is_some() {
             self.schedule_blinking();
-            self.display.cursor_hidden = false;
+            if mem::replace(&mut self.display.cursor_hidden, false) {
+                *self.dirty = true;
+            }
         } else if *self.cursor_blink_timed_out {
             self.update_cursor_blinking();
         }
-
-        *self.dirty = true;
 
         // Hide mouse cursor.
         if self.config.mouse.hide_when_typing {
@@ -716,6 +712,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
                 self.terminal.vi_goto_point(*hint_bounds.start());
             },
         }
+
+        self.mark_dirty();
     }
 
     /// Expand the selection to the current mouse cursor position.
@@ -930,7 +928,6 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
     fn exit_search(&mut self) {
         self.display.pending_update.dirty = true;
         self.search_state.history_index = None;
-        *self.dirty = true;
 
         // Clear focused match.
         self.search_state.focused_match = None;
@@ -1072,7 +1069,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     display_update_pending.set_dimensions(PhysicalSize::new(width, height));
 
                     self.ctx.window().scale_factor = scale_factor;
-                    *self.ctx.dirty = true;
                 },
                 EventType::SearchNext => self.ctx.goto_match(None),
                 EventType::Scroll(scroll) => self.ctx.scroll(scroll),
@@ -1084,14 +1080,13 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     // Disable blinking after timeout reached.
                     let timer_id = TimerId::new(Topic::BlinkCursor, self.ctx.display.window.id());
                     self.ctx.scheduler.unschedule(timer_id);
-                    self.ctx.display.cursor_hidden = false;
                     *self.ctx.cursor_blink_timed_out = true;
+                    self.ctx.display.cursor_hidden = false;
                     *self.ctx.dirty = true;
                 },
                 EventType::Message(message) => {
                     self.ctx.message_buffer.push(message);
                     self.ctx.display.pending_update.dirty = true;
-                    *self.ctx.dirty = true;
                 },
                 EventType::Terminal(event) => match event {
                     TerminalEvent::Title(title) => {
@@ -1162,7 +1157,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         }
 
                         self.ctx.display.pending_update.set_dimensions(size);
-                        *self.ctx.dirty = true;
                     },
                     WindowEvent::KeyboardInput { input, is_synthetic: false, .. } => {
                         self.key_input(input);
@@ -1172,7 +1166,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     WindowEvent::MouseInput { state, button, .. } => {
                         self.ctx.window().set_mouse_visible(true);
                         self.mouse_input(state, button);
-                        *self.ctx.dirty = true;
                     },
                     WindowEvent::CursorMoved { position, .. } => {
                         self.ctx.window().set_mouse_visible(true);
@@ -1184,7 +1177,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     },
                     WindowEvent::Focused(is_focused) => {
                         self.ctx.terminal.is_focused = is_focused;
-                        *self.ctx.dirty = true;
 
                         if is_focused {
                             self.ctx.window().set_urgent(false);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -224,10 +224,10 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             self.search_state.display_offset_delta += lines_changed;
         }
 
-        let vi_mode = self.terminal.mode().contains(TermMode::VI);
-
         // Update selection.
-        if vi_mode && self.terminal.selection.as_ref().map_or(false, |s| !s.is_empty()) {
+        if self.terminal.mode().contains(TermMode::VI)
+            && self.terminal.selection.as_ref().map_or(false, |s| !s.is_empty())
+        {
             self.update_selection(self.terminal.vi_mode_cursor.point, Side::Right);
         } else if self.mouse.left_button_state == ElementState::Pressed
             || self.mouse.right_button_state == ElementState::Pressed
@@ -238,7 +238,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
 
         // Update dirty if actually scrolled or we're in the Vi mode.
-        *self.dirty |= lines_changed != 0 || vi_mode;
+        *self.dirty |= lines_changed != 0;
     }
 
     // Copy text selection.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1185,7 +1185,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
 
                         // When the unfocused hollow is used we must redraw on focus change.
                         if self.ctx.config.terminal_config.cursor.unfocused_hollow {
-                            *self.ctx.dirty = false;
+                            *self.ctx.dirty = true;
                         }
 
                         if is_focused {

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -305,6 +305,7 @@ impl WindowContext {
                 old_is_searching,
                 config,
             );
+            self.dirty = true;
         }
 
         if self.dirty || self.mouse.hint_highlight_dirty {


### PR DESCRIPTION
In some cases dirty was set without any ui update leading
to extra redraws, this commit resolves this.

Co-authored-by: Greg Depoire--Ferrer <greg@gregdf.com>

cc @greg904 