### PR TITLE
Register shells launched by Alacritty as tty sessions on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Windows `Open Alacritty Here` on root of drive displaying error
 - On macOS, `font.use_thin_strokes` did not work since Big Sur
 - On macOS, trying to load a disabled font would crash
+- On macOS, Alacritty sessions did not appear in the list of tty sessions for `w` and `who`
 
 ### Removed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -434,8 +434,7 @@
 # shell.
 #
 # Default:
-#   - (macOS) /bin/bash --login
-#   - (Linux/BSD) user login shell
+#   - (Linux/BSD/macOS) `$SHELL` or the user's login shell, if `$SHELL` is unset
 #   - (Windows) powershell
 #shell:
 #  program: /bin/bash


### PR DESCRIPTION
Unless the `shell` config is specified, launch the user's shell with:

```sh
login -flp $USER /bin/sh -c "exec -a -shell /path/to/shell"
```

On macOS, just running a shell prefixed by `-` is not sufficient to be
registered as a login session for things like `w` and `logname`.
However, using the `login` command changes the directory to `$HOME`
before running the program by default, which is not desired. The `-l`
flag disables this behavior, but also skips prepending `-` to the
executed program, so shells will not run as login shells. Instead we
just do this part ourselves with `exec -a`. The result is login shells
that run in the intended directory and are registered as tty sessions.

Update `alacritty.yml` to reflect that Alacritty will use `$SHELL` or
the user's login shell on Linux, BSD, and macOS.

Fixes #3420