### PR TITLE
Implement WheelUp and WheelDown actions (simulate wheel rolls)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Config option `cursor.blink_timeout` to timeout cursor blinking after inactivity
 - Escape sequence to set hyperlinks (`OSC 8 ; params ; URI ST`)
 - Config `hints.enabled.hyperlinks` for hyperlink escape sequence hint highlight
+- Added WheelUp and WheelDown actions to scroll by multiple lines as if the mouse wheel was rolled
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -104,7 +104,8 @@
   # Specifying '0' will disable scrolling.
   #history: 10000
 
-  # Scrolling distance multiplier.
+  # Scrolling distance multiplier for the mouse wheel rolls and for
+  # WheelUp / WheelDown.
   #multiplier: 3
 
 # Font configuration
@@ -604,6 +605,12 @@
 #   - ScrollLineDown
 #   - ScrollToTop
 #   - ScrollToBottom
+#   - WheelUp
+#       Scroll up a few lines as if the mouse wheel was rolled once.
+#       (Number of lines scrolled = value of the "multiplier" option, which see)
+#   - WheelDown
+#       Scroll down a few lines as if the mouse wheel was rolled once.
+#       (Number of lines scrolled = value of the "multiplier" option, which see)
 #   - ClearHistory
 #       Remove the terminal's scrollback history.
 #   - Hide

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -158,6 +158,12 @@ pub enum Action {
     /// Scroll all the way to the bottom.
     ScrollToBottom,
 
+    /// Act similarly to mouse wheel up.
+    WheelUp,
+
+    /// Act similarly to mouse wheel down.
+    WheelDown,
+
     /// Clear the display buffer(s) to remove history.
     ClearHistory,
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -340,6 +340,14 @@ impl<T: EventListener> Execute<T> for Action {
                 term.vi_motion(ViMotion::FirstOccupied);
                 ctx.mark_dirty();
             },
+            Action::WheelUp => {
+                let multiplier = ctx.config().terminal_config.scrolling.multiplier;
+                ctx.scroll(Scroll::Delta(multiplier as i32));
+            },
+            Action::WheelDown => {
+                let multiplier = ctx.config().terminal_config.scrolling.multiplier;
+                ctx.scroll(Scroll::Delta(-(multiplier as i32)));
+            },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
             Action::ClearLogNotice => ctx.pop_message(),
             Action::SpawnNewInstance => ctx.spawn_new_instance(),


### PR DESCRIPTION
Alacritty is my main terminal emulator but I've always been finding its Scroll actions overly speedy - even the ScrollHalfPageUp / ScrollHalfPageDown ones. The mouse wheel shows just the right scrolling speed but there is no equivalent keyboard action. So this commit brings in WheelUp / WheelDown actions which are simulating the mouse wheel rolls. The scrolling speed for those can be controlled via the "multiplier" setting so "multiplier" now affects both the wheel and WheelUp / WheelDown. Action names are subject to discussion.