### PR TITLE
Remove unneeded closures

### DIFF
--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -116,7 +116,7 @@ impl WindowConfig {
     pub fn decorations_theme_variant(&self) -> Option<&str> {
         self.gtk_theme_variant
             .as_ref()
-            .or_else(|| self.decorations_theme_variant.as_ref())
+            .or(self.decorations_theme_variant.as_ref())
             .map(|theme| theme.as_str())
     }
 

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -80,7 +80,7 @@ impl Scheduler {
             .timers
             .iter()
             .position(|timer| timer.deadline > deadline)
-            .unwrap_or_else(|| self.timers.len());
+            .unwrap_or(self.timers.len());
 
         // Set the automatic event repeat rate.
         let interval = if repeat { Some(interval) } else { None };


### PR DESCRIPTION
Running `cargo clippy` yields these 2 suggestions removing unneeded closures. 😃 