### PR TITLE
Mention the `--config-file` flag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ following locations:
 3. `$HOME/.config/alacritty/alacritty.yml`
 4. `$HOME/.alacritty.yml`
 
+Alternatively, you can specify a custom config file with the `--config-file` option.
+
 ### Windows
 
 On Windows, the config file should be located at:


### PR DESCRIPTION
I was trying to find a documented way of specifying a custom config file. However, I was not able to find anything in the documentation.

Now, of course, when you run `alacritty --help`, the option is right there, but I only found it after some digging. However, I wish this had been mentioned in a more obvious location.