### PR TITLE
[docs] use curl instead of local files if possible

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -292,10 +292,12 @@ infocmp alacritty
 ```
 
 If it is not present already, you can install it globally with the following
-command:
+command. You can also use a local `extra/alacritty.info` instead of the `<(curl ...)`:
 
 ```
-sudo tic -xe alacritty,alacritty-direct extra/alacritty.info
+sudo -i
+tic -xe alacritty,alacritty-direct <(curl https://raw.githubusercontent.com/alacritty/alacritty/master/extra/alacritty.info)
+exit
 ```
 
 ### Desktop Entry


### PR DESCRIPTION
Some commands could be done using the in-memory temporary files instead of requiring users to clone the repo.  This way alacritty can be installed with `cargo install`, and the terminfo can be updated without any `git clone.  Although it might be worth while to set up a separate installation section for these tricks?