### PR TITLE
Add inline input method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Escape sequence to set hyperlinks (`OSC 8 ; params ; URI ST`)
 - Config `hints.enabled.hyperlinks` for hyperlink escape sequence hint highlight
 - `window.decorations_theme_variant` to control both Wayland CSD and GTK theme variant on X11
+- Support for inline input method
 
 ### Changed
 
@@ -42,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Config option `window.gtk_theme_variant`, you should use `window.decorations_theme_variant` instead
 - `--class` now sets both class part of WM_CLASS property and instance
 - `--class`'s `general` and `instance` options were swapped
+- Search bar is now respecting cursor thickness
+- On X11 the IME popup window is stuck at the bottom of the window due to Xlib limitations
+- IME no longer works in Vi mode when moving around
 
 ### Fixed
 

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -51,6 +51,7 @@ impl<'a> RenderableContent<'a> {
         let cursor_shape = if terminal_content.cursor.shape == CursorShape::Hidden
             || display.cursor_hidden
             || search_state.regex().is_some()
+            || display.ime.preedit().is_some()
         {
             CursorShape::Hidden
         } else if !term.is_focused && config.terminal_config.cursor.unfocused_hollow {
@@ -394,6 +395,10 @@ impl RenderableCursor {
 }
 
 impl RenderableCursor {
+    pub fn new(point: Point<usize>, shape: CursorShape, cursor_color: Rgb, is_wide: bool) -> Self {
+        Self { shape, cursor_color, text_color: cursor_color, is_wide, point }
+    }
+
     pub fn color(&self) -> Rgb {
         self.cursor_color
     }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -460,10 +460,14 @@ impl Window {
         self.wayland_surface.as_ref()
     }
 
+    pub fn set_ime_allowed(&self, allowed: bool) {
+        self.windowed_context.window().set_ime_allowed(allowed);
+    }
+
     /// Adjust the IME editor position according to the new location of the cursor.
-    pub fn update_ime_position(&self, point: Point, size: &SizeInfo) {
+    pub fn update_ime_position(&self, point: Point<usize>, size: &SizeInfo) {
         let nspot_x = f64::from(size.padding_x() + point.column.0 as f32 * size.cell_width());
-        let nspot_y = f64::from(size.padding_y() + (point.line.0 + 1) as f32 * size.cell_height());
+        let nspot_y = f64::from(size.padding_y() + (point.line + 1) as f32 * size.cell_height());
 
         self.window().set_ime_position(PhysicalPosition::new(nspot_x, nspot_y));
     }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -754,6 +754,11 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
     /// Process key input.
     pub fn key_input(&mut self, input: KeyboardInput) {
+        // IME input will be applied on commit and shouldn't trigger key bindings.
+        if self.ctx.display().ime.preedit().is_some() {
+            return;
+        }
+
         // All key bindings are disabled while a hint is being selected.
         if self.ctx.display().hint_state.active() {
             *self.ctx.suppress_chars() = false;
@@ -800,6 +805,11 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     /// Process a received character.
     pub fn received_char(&mut self, c: char) {
         let suppress_chars = *self.ctx.suppress_chars();
+
+        // Don't insert chars when we have IME running.
+        if self.ctx.display().ime.preedit().is_some() {
+            return;
+        }
 
         // Handle hint selection over anything else.
         if self.ctx.display().hint_state.active() && !suppress_chars {

--- a/alacritty/src/string.rs
+++ b/alacritty/src/string.rs
@@ -5,7 +5,7 @@ use std::str::Chars;
 use unicode_width::UnicodeWidthChar;
 
 /// The action performed by [`StrShortener`].
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextAction {
     /// Yield a spacer.
     Spacer,
@@ -93,7 +93,7 @@ impl<'a> StrShortener<'a> {
         let num_chars = iter.last().map_or(offset, |(idx, _)| idx + 1);
         let skip_chars = num_chars - offset;
 
-        let text_action = if num_chars <= max_width || shortener.is_none() {
+        let text_action = if current_len < max_width || shortener.is_none() {
             TextAction::Char
         } else {
             TextAction::Shortener
@@ -203,8 +203,8 @@ mod tests {
             &StrShortener::new(s, len * 2, ShortenDirection::Left, Some('.')).collect::<String>()
         );
 
-        let s = "こJんにちはP";
-        let len = 2 + 1 + 2 + 2 + 2 + 2 + 1;
+        let s = "ちはP";
+        let len = 2 + 2 + 1;
         assert_eq!(
             ".",
             &StrShortener::new(s, 1, ShortenDirection::Right, Some('.')).collect::<String>()
@@ -226,7 +226,7 @@ mod tests {
         );
 
         assert_eq!(
-            "こ .",
+            "ち .",
             &StrShortener::new(s, 3, ShortenDirection::Right, Some('.')).collect::<String>()
         );
 
@@ -236,12 +236,12 @@ mod tests {
         );
 
         assert_eq!(
-            "こ Jん に ち は P",
+            "ち は P",
             &StrShortener::new(s, len * 2, ShortenDirection::Left, Some('.')).collect::<String>()
         );
 
         assert_eq!(
-            "こ Jん に ち は P",
+            "ち は P",
             &StrShortener::new(s, len * 2, ShortenDirection::Right, Some('.')).collect::<String>()
         );
     }


### PR DESCRIPTION
This commit adds support for inline IME handling. It also makes the
search bar use underline cursor instead of using '_' character.

Fixes #1613.