### PR TITLE
Added action to either copy selection to clipboard or paste from clipb.

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -125,6 +125,9 @@ pub enum Action {
     /// Paste contents of selection buffer.
     PasteSelection,
 
+    /// Paste clipboard if nothing is selected, or copy selection to clipboard and clear selection.
+    CopySelectionOrPasteClipboard,
+
     /// Increase font size.
     IncreaseFontSize,
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -270,6 +270,15 @@ impl<T: EventListener> Execute<T> for Action {
                 let text = ctx.clipboard_mut().load(ClipboardType::Selection);
                 ctx.paste(&text);
             },
+            Action::CopySelectionOrPasteClipboard => {
+                if ctx.selection_is_empty() {
+                    let clipboard = ctx.clipboard_mut().load(ClipboardType::Clipboard);
+                    ctx.paste(&clipboard);
+                } else {
+                    ctx.copy_selection(ClipboardType::Clipboard);
+                    ctx.clear_selection();
+                }
+            },
             Action::ToggleFullscreen => ctx.window().toggle_fullscreen(),
             Action::ToggleMaximized => ctx.window().toggle_maximized(),
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
Added an action similar to the right click behavior in Windows terminal/cmd

With configuration setting

```yml
 mouse_bindings:
  - { mouse: Right,                 action: CopySelectionOrPasteClipboard }
```

Right-click on a selection, copies selection to clipboard (does not paste) and deselects
Right-click without selection, pastes from clipboard