### PR TITLE
Fix general and instance class set on window

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -335,7 +335,7 @@ impl Window {
 
         let builder = WindowBuilder::new()
             .with_title(&identity.title)
-            .with_name(&identity.class.instance, &identity.class.general)
+            .with_name(&identity.class.general, &identity.class.instance)
             .with_visible(false)
             .with_transparent(true)
             .with_decorations(window_config.decorations != Decorations::None)


### PR DESCRIPTION
This fixes a regression introduced in 7d708d5, which caused the general
and instance class to be swapped.