### PR TITLE
Rework `--class` CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Warn when either `columns` or `lines` is non-zero, but not both
 - Client side decorations should have proper text rendering now on Wayland
 - Config option `window.gtk_theme_variant`, you should use `window.decorations_theme_variant` instead
+- `--class` now sets both class part of WM_CLASS property and instance
+- `--class`'s `general` and `instance` options were swapped
 
 ### Fixed
 

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -203,13 +203,19 @@ pub struct Dimensions {
 /// Window class hint.
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Class {
-    pub instance: String,
     pub general: String,
+    pub instance: String,
+}
+
+impl Class {
+    pub fn new(general: impl ToString, instance: impl ToString) -> Self {
+        Self { general: general.to_string(), instance: instance.to_string() }
+    }
 }
 
 impl Default for Class {
     fn default() -> Self {
-        Self { instance: DEFAULT_NAME.into(), general: DEFAULT_NAME.into() }
+        Self::new(DEFAULT_NAME, DEFAULT_NAME)
     }
 }
 

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -32,10 +32,12 @@ Increases the level of verbosity (the max level is \fB\-vvv\fR)
 Prints version information
 .SH "OPTIONS"
 .TP
-\fB\-\-class\fR <instance> | <instance>,<general>
+\fB\-\-class\fR <general> | <general>,<instance>
 Defines the window class hint on Linux [default: Alacritty,Alacritty]
 
-On Wayland the instance class sets the `app_id`, while the general class is ignored.
+When only the general class is passed, instance will be set to the same value.
+
+On Wayland the general class sets the `app_id`, while the instance class is ignored.
 .TP
 \fB\-e\fR, \fB\-\-command\fR <command>...
 Command and args to execute (must be last argument)


### PR DESCRIPTION
This commit swaps the order of `general` and `instance` arguments
and also sets `instance` to `general` when only one argument was
provided. This should make this option behave like in other terminals
on X11, since they set either both or general by default, but
not instance like alacritty.

Fixes #6279.