### PR TITLE
Prioritize imported configurations

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -201,7 +201,7 @@ fn parse_config(
 
     // Merge config with imports.
     let imports = load_imports(&config, config_paths, recursion_limit);
-    Ok(serde_utils::merge(imports, config))
+    Ok(serde_utils::merge(config, imports))
 }
 
 /// Load all referenced configuration files.


### PR DESCRIPTION
This should make the imported settings be prioritized such that they will always replace any previous settings.
For example:
`~/.config/alacritty.yml`:
```yml
font:
    size: 12
import:
    - ~/.config/alacritty_override.yml
```

`~/.config/alacritty_override.yml`:
```yml
font:
    size: 10
```

Currently because imported configurations are not prioritized `size: 10` in `alacritty_override.yml` would not have any effect font size would be set to 12.
Imo opinion this hurts usability because it hinders you from setting default values to settings.