### PR TITLE
Bump development version to 0.12.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.11.0-dev
+## 0.12.0-dev
 
 ### Packaging
 

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.11.0-dev"
+version = "0.12.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"
@@ -11,16 +11,16 @@ rust-version = "1.57.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.17.0-dev"
+version = "0.17.1-dev"
 default-features = false
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"
-version = "0.1.0"
+version = "0.2.1-dev"
 
 [dependencies.alacritty_config]
 path = "../alacritty_config"
-version = "0.1.0"
+version = "0.1.1-dev"
 
 [dependencies]
 clap = { version = "3.0.0", features = ["derive", "env"] }

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Alacritty" Id="*" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.11.0-dev" Manufacturer="Alacritty">
+    <Product Name="Alacritty" Id="*" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.12.0-dev" Manufacturer="Alacritty">
         <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine"/>
         <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed."/>
         <Icon Id="AlacrittyIco" SourceFile=".\extra\windows\alacritty.ico"/>

--- a/alacritty_config/Cargo.toml
+++ b/alacritty_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_config"
-version = "0.1.0"
+version = "0.1.1-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT/Apache-2.0"
 description = "Alacritty configuration abstractions"

--- a/alacritty_config_derive/Cargo.toml
+++ b/alacritty_config_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_config_derive"
-version = "0.1.0"
+version = "0.2.1-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT/Apache-2.0"
 description = "Failure resistant deserialization derive"
@@ -18,7 +18,7 @@ quote = "1.0.7"
 
 [dev-dependencies.alacritty_config]
 path = "../alacritty_config"
-version = "0.1.0"
+version = "0.1.1-dev"
 
 [dev-dependencies]
 serde = { version = "1.0.117", features = ["derive"] }

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.17.0-dev"
+version = "0.17.1-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"
@@ -11,11 +11,11 @@ rust-version = "1.57.0"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"
-version = "0.1.0"
+version = "0.2.1-dev"
 
 [dependencies.alacritty_config]
 path = "../alacritty_config"
-version = "0.1.0"
+version = "0.1.1-dev"
 
 [dependencies]
 libc = "0.2"

--- a/extra/alacritty-msg.man
+++ b/extra/alacritty-msg.man
@@ -1,4 +1,4 @@
-.TH ALACRITTY-MSG "1" "October 2021" "alacritty 0.11.0-dev" "User Commands"
+.TH ALACRITTY-MSG "1" "October 2021" "alacritty 0.12.0-dev" "User Commands"
 .SH NAME
 alacritty-msg \- Send messages to Alacritty
 .SH "SYNOPSIS"

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -1,4 +1,4 @@
-.TH ALACRITTY "1" "August 2018" "alacritty 0.11.0-dev" "User Commands"
+.TH ALACRITTY "1" "August 2018" "alacritty 0.12.0-dev" "User Commands"
 .SH NAME
 Alacritty \- A fast, cross-platform, OpenGL terminal emulator
 .SH "SYNOPSIS"

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.11.0-dev</string>
+  <string>0.12.0-dev</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>


### PR DESCRIPTION
This is only an update to the development version and does not represent
a stable release.