### PR TITLE
Fixes #2166 and #6336: application icon with correct relative path

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -59,7 +59,7 @@ use crate::gl;
 
 /// Window icon for `_NET_WM_ICON` property.
 #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
-static WINDOW_ICON: &[u8] = include_bytes!("../../extra/logo/compat/alacritty-term.png");
+static WINDOW_ICON: &[u8] = include_bytes!("../../../extra/logo/compat/alacritty-term+scanlines.png");
 
 /// This should match the definition of IDI_ICON from `alacritty.rc`.
 #[cfg(windows)]


### PR DESCRIPTION
The original alacritty-term.png does not show up.  Thus changed it to alacritty-term+scanlines.png.