### PR TITLE
Fix IPC config overriding previous values

### DIFF
--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -15,15 +15,27 @@ use std::{env, process};
 use glutin::event_loop::EventLoopProxy;
 use log::{self, Level, LevelFilter};
 
+use alacritty_terminal::config::LOG_TARGET_CONFIG;
+
 use crate::cli::Options;
 use crate::event::{Event, EventType};
 use crate::message_bar::{Message, MessageType};
 
+/// Logging target for IPC config error messages.
+pub const LOG_TARGET_IPC_CONFIG: &str = "alacritty_log_ipc_config";
+
 /// Name for the environment variable containing the log file's path.
 const ALACRITTY_LOG_ENV: &str = "ALACRITTY_LOG";
+
 /// List of targets which will be logged by Alacritty.
-const ALLOWED_TARGETS: [&str; 4] =
-    ["alacritty_terminal", "alacritty_config_derive", "alacritty", "crossfont"];
+const ALLOWED_TARGETS: &[&str] = &[
+    LOG_TARGET_IPC_CONFIG,
+    LOG_TARGET_CONFIG,
+    "alacritty_config_derive",
+    "alacritty_terminal",
+    "alacritty",
+    "crossfont",
+];
 
 pub fn initialize(
     options: &Options,

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -12,6 +12,7 @@ use crate::ansi::{CursorShape, CursorStyle};
 
 pub use crate::config::scrolling::{Scrolling, MAX_SCROLLBACK_LINES};
 
+/// Logging target for config error messages.
 pub const LOG_TARGET_CONFIG: &str = "alacritty_config_derive";
 
 const MIN_BLINK_INTERVAL: u64 = 10;


### PR DESCRIPTION
Before this patch whenever changing the IPC configuration, all previous configuration options would be discarded. This was the case even when the new option was invalid.

This patch ensures that the IPC config is only ever cleared when the `--reset` flag is passed. Invalid IPC config options are logged and discarded.

Additionally whenever a new IPC config message is sent, all previous IPC error messages are cleared.

Closes #6330.