### PR TITLE
Fix icon decoding on X11

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -324,7 +324,8 @@ impl Window {
     pub fn get_platform_window(identity: &Identity, window_config: &WindowConfig) -> WindowBuilder {
         #[cfg(feature = "x11")]
         let icon = {
-            let decoder = Decoder::new(Cursor::new(WINDOW_ICON));
+            let mut decoder = Decoder::new(Cursor::new(WINDOW_ICON));
+            decoder.set_transformations(png::Transformations::normalize_to_color8());
             let mut reader = decoder.read_info().expect("invalid embedded icon");
             let mut buf = vec![0; reader.output_buffer_size()];
             let _ = reader.next_frame(&mut buf);

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -330,6 +330,7 @@ impl Window {
             let mut buf = vec![0; reader.output_buffer_size()];
             let _ = reader.next_frame(&mut buf);
             Icon::from_rgba(buf, reader.info().width, reader.info().height)
+                .expect("invalid embedded icon format")
         };
 
         let builder = WindowBuilder::new()
@@ -342,7 +343,7 @@ impl Window {
             .with_fullscreen(window_config.fullscreen());
 
         #[cfg(feature = "x11")]
-        let builder = builder.with_window_icon(icon.ok());
+        let builder = builder.with_window_icon(Some(icon));
 
         #[cfg(feature = "x11")]
         let builder = match window_config.decorations_theme_variant() {


### PR DESCRIPTION
glutin is waiting for a RGBA with 8-bit depth, but our icon is 16-bit depth. Normalize the color data when decoding the icon.

Without this, I had a `winit::icon::BadIcon::DimensionsVsPixelCount` when loading the icon on Linux/X11.