### PR TITLE
Fix clippy warnings

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -13,7 +13,7 @@ fn main() {
     println!("cargo:rustc-env=VERSION={}", version);
 
     let dest = env::var("OUT_DIR").unwrap();
-    let mut file = File::create(&Path::new(&dest).join("gl_bindings.rs")).unwrap();
+    let mut file = File::create(Path::new(&dest).join("gl_bindings.rs")).unwrap();
 
     Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, ["GL_ARB_blend_func_extended"])
         .write_bindings(GlobalGenerator, &mut file)
@@ -25,7 +25,7 @@ fn main() {
 
 fn commit_hash() -> Option<String> {
     Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short", "HEAD"])
         .output()
         .ok()
         .filter(|output| output.status.success())

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -899,7 +899,7 @@ struct RawBinding {
 }
 
 impl RawBinding {
-    fn into_mouse_binding(self) -> Result<MouseBinding, Self> {
+    fn into_mouse_binding(self) -> Result<MouseBinding, Box<Self>> {
         if let Some(mouse) = self.mouse {
             Ok(Binding {
                 trigger: mouse,
@@ -909,11 +909,11 @@ impl RawBinding {
                 notmode: self.notmode,
             })
         } else {
-            Err(self)
+            Err(Box::new(self))
         }
     }
 
-    fn into_key_binding(self) -> Result<KeyBinding, Self> {
+    fn into_key_binding(self) -> Result<KeyBinding, Box<Self>> {
         if let Some(key) = self.key {
             Ok(KeyBinding {
                 trigger: key,
@@ -923,7 +923,7 @@ impl RawBinding {
                 notmode: self.notmode,
             })
         } else {
-            Err(self)
+            Err(Box::new(self))
         }
     }
 }

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -63,7 +63,7 @@ pub fn watch(mut paths: Vec<PathBuf>, event_proxy: EventLoopProxy<Event>) {
 
         // Watch all configuration file directories.
         for parent in &parents {
-            if let Err(err) = watcher.watch(&parent, RecursiveMode::NonRecursive) {
+            if let Err(err) = watcher.watch(parent, RecursiveMode::NonRecursive) {
                 debug!("Unable to watch config directory {:?}: {}", parent, err);
             }
         }

--- a/alacritty/src/display/cursor.rs
+++ b/alacritty/src/display/cursor.rs
@@ -22,7 +22,7 @@ impl IntoRects for RenderableCursor {
         let mut width = size_info.cell_width();
         let height = size_info.cell_height();
 
-        let thickness = (thickness * width as f32).round().max(1.);
+        let thickness = (thickness * width).round().max(1.);
 
         if self.is_wide() {
             width *= 2.;

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -705,7 +705,7 @@ impl Display {
         // Update number of column/lines in the viewport.
         let message_bar_lines =
             message_buffer.message().map_or(0, |m| m.text(&self.size_info).len());
-        let search_lines = if search_active { 1 } else { 0 };
+        let search_lines = usize::from(search_active);
         self.size_info.reserve_lines(message_bar_lines + search_lines);
 
         // Resize PTY.
@@ -982,7 +982,7 @@ impl Display {
         }
 
         if let Some(message) = message_buffer.message() {
-            let search_offset = if search_state.regex().is_some() { 1 } else { 0 };
+            let search_offset = usize::from(search_state.regex().is_some());
             let text = message.text(&size_info);
 
             // Create a new rectangle for the background.
@@ -1396,7 +1396,7 @@ impl Display {
         let x = size_info.padding_x() + point.column.0 as u32 * size_info.cell_width();
         let y_top = size_info.height() - size_info.padding_y();
         let y = y_top - (point.line as u32 + 1) * size_info.cell_height();
-        let width = len as u32 * size_info.cell_width();
+        let width = len * size_info.cell_width();
         DamageRect { x, y, width, height: size_info.cell_height() }
     }
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -369,8 +369,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let display_offset = self.ctx.terminal().grid().display_offset();
         let old_point = self.ctx.mouse().point(&size_info, display_offset);
 
-        let x = min(max(x, 0), size_info.width() as i32 - 1) as usize;
-        let y = min(max(y, 0), size_info.height() as i32 - 1) as usize;
+        let x = x.clamp(0, size_info.width() as i32 - 1) as usize;
+        let y = y.clamp(0, size_info.height() as i32 - 1) as usize;
         self.ctx.mouse_mut().x = x;
         self.ctx.mouse_mut().y = y;
 
@@ -908,7 +908,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     /// Check mouse icon state in relation to the message bar.
     fn message_bar_cursor_state(&self) -> Option<CursorIcon> {
         // Since search is above the message bar, the button is offset by search's height.
-        let search_height = if self.ctx.search_active() { 1 } else { 0 };
+        let search_height = usize::from(self.ctx.search_active());
 
         // Calculate Y position of the end of the last terminal line.
         let size = self.ctx.size_info();
@@ -977,8 +977,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         };
 
         // Scale number of lines scrolled based on distance to boundary.
-        let delta = delta as i32 / step as i32;
-        let event = Event::new(EventType::Scroll(Scroll::Delta(delta)), Some(window_id));
+        let event = Event::new(EventType::Scroll(Scroll::Delta(delta / step)), Some(window_id));
 
         // Schedule event.
         let timer_id = TimerId::new(Topic::SelectionScrolling, window_id);

--- a/alacritty/src/ipc.rs
+++ b/alacritty/src/ipc.rs
@@ -119,7 +119,7 @@ fn find_socket(socket_path: Option<PathBuf>) -> IoResult<UnixStream> {
     // Handle environment variable.
     if let Ok(path) = env::var(ALACRITTY_SOCKET_ENV) {
         let socket_path = PathBuf::from(path);
-        if let Ok(socket) = UnixStream::connect(&socket_path) {
+        if let Ok(socket) = UnixStream::connect(socket_path) {
             return Ok(socket);
         }
     }

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -333,7 +333,7 @@ impl RectRenderer {
                     continue;
                 }
 
-                self.program.set_rect_kind(rect_kind as u8);
+                self.program.set_rect_kind(rect_kind);
 
                 // Upload accumulated undercurl vertices.
                 gl::BufferData(

--- a/alacritty/src/renderer/text/atlas.rs
+++ b/alacritty/src/renderer/text/atlas.rs
@@ -133,8 +133,8 @@ impl Atlas {
     fn insert_inner(&mut self, glyph: &RasterizedGlyph, active_tex: &mut u32) -> Glyph {
         let offset_y = self.row_baseline;
         let offset_x = self.row_extent;
-        let height = glyph.height as i32;
-        let width = glyph.width as i32;
+        let height = glyph.height;
+        let width = glyph.width;
         let multicolor;
 
         unsafe {
@@ -196,9 +196,9 @@ impl Atlas {
 
     /// Check if there's room in the current row for given glyph.
     pub fn room_in_row(&self, raw: &RasterizedGlyph) -> bool {
-        let next_extent = self.row_extent + raw.width as i32;
+        let next_extent = self.row_extent + raw.width;
         let enough_width = next_extent <= self.width;
-        let enough_height = (raw.height as i32) < (self.height - self.row_baseline);
+        let enough_height = raw.height < (self.height - self.row_baseline);
 
         enough_width && enough_height
     }

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -71,14 +71,14 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
             for stroke_size in 0..2 * stroke_size {
                 let stroke_size = stroke_size as f32 / 2.;
                 if character == '\u{2571}' || character == '\u{2573}' {
-                    let h = y_end - stroke_size as f32;
+                    let h = y_end - stroke_size;
                     let from_y = f_x(from_x, h);
                     let to_y = f_x(to_x, h);
                     canvas.draw_line(from_x, from_y, to_x, to_y);
                 }
                 if character == '\u{2572}' || character == '\u{2573}' {
-                    let from_y = g_x(from_x, stroke_size as f32);
-                    let to_y = g_x(to_x, stroke_size as f32);
+                    let from_y = g_x(from_x, stroke_size);
+                    let to_y = g_x(to_x, stroke_size);
                     canvas.draw_line(from_x, from_y, to_x, to_y);
                 }
             }
@@ -345,7 +345,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
             if character == '\u{256d}' || character == '\u{2570}' {
                 let center = canvas.x_center() as usize;
 
-                let extra_offset = if stroke_size % 2 == width % 2 { 0 } else { 1 };
+                let extra_offset = usize::from(stroke_size % 2 != width % 2);
 
                 let buffer = canvas.buffer_mut();
                 for y in 1..height {
@@ -363,7 +363,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
             if character == '\u{256d}' || character == '\u{256e}' {
                 let center = canvas.y_center() as usize;
 
-                let extra_offset = if stroke_size % 2 == height % 2 { 0 } else { 1 };
+                let extra_offset = usize::from(stroke_size % 2 != height % 2);
 
                 let buffer = canvas.buffer_mut();
                 if extra_offset != 0 {
@@ -422,7 +422,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
 
             let x = match character {
                 '\u{2590}' => canvas.x_center(),
-                '\u{2595}' => width as f32 - rect_width,
+                '\u{2595}' => width - rect_width,
                 _ => 0.,
             };
 
@@ -592,13 +592,13 @@ impl Canvas {
     /// Draws a horizontal straight line from (`x`, `y`) of `size` with the given `stroke_size`.
     fn draw_h_line(&mut self, x: f32, y: f32, size: f32, stroke_size: usize) {
         let (start_y, end_y) = self.h_line_bounds(y, stroke_size);
-        self.draw_rect(x, start_y as f32, size, (end_y - start_y) as f32, COLOR_FILL);
+        self.draw_rect(x, start_y, size, end_y - start_y, COLOR_FILL);
     }
 
     /// Draws a vertical straight line from (`x`, `y`) of `size` with the given `stroke_size`.
     fn draw_v_line(&mut self, x: f32, y: f32, size: f32, stroke_size: usize) {
         let (start_x, end_x) = self.v_line_bounds(x, stroke_size);
-        self.draw_rect(start_x as f32, y, (end_x - start_x) as f32, size, COLOR_FILL);
+        self.draw_rect(start_x, y, end_x - start_x, size, COLOR_FILL);
     }
 
     /// Draws a rect from the (`x`, `y`) of the given `width` and `height` using `color`.
@@ -750,7 +750,7 @@ impl Canvas {
 
                 let x_next = (x + 1.).clamp(0., v_line_bounds.1 as f32 - 1.);
                 let x = x.clamp(0., v_line_bounds.1 as f32 - 1.);
-                let y = y.clamp(0., radius_y as f32);
+                let y = y.clamp(0., radius_y);
 
                 self.put_pixel(x, y, color_1);
                 self.put_pixel(x_next, y, color_2);

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -234,13 +234,7 @@ impl Default for Percentage {
 
 impl Percentage {
     pub fn new(value: f32) -> Self {
-        Percentage(if value < 0.0 {
-            0.0
-        } else if value > 1.0 {
-            1.0
-        } else {
-            value
-        })
+        Percentage(value.clamp(0., 1.))
     }
 
     pub fn as_f32(self) -> f32 {

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -64,9 +64,9 @@ impl Mul<f32> for Rgb {
 
     fn mul(self, rhs: f32) -> Rgb {
         let result = Rgb {
-            r: (f32::from(self.r) * rhs).max(0.0).min(255.0) as u8,
-            g: (f32::from(self.g) * rhs).max(0.0).min(255.0) as u8,
-            b: (f32::from(self.b) * rhs).max(0.0).min(255.0) as u8,
+            r: (f32::from(self.r) * rhs).clamp(0.0, 255.0) as u8,
+            g: (f32::from(self.g) * rhs).clamp(0.0, 255.0) as u8,
+            b: (f32::from(self.b) * rhs).clamp(0.0, 255.0) as u8,
         };
 
         trace!("Scaling RGB by {} from {:?} to {:?}", rhs, self, result);

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -202,7 +202,7 @@ impl TermDamageState {
     /// Damage point inside of the viewport.
     #[inline]
     fn damage_point(&mut self, point: Point<usize>) {
-        self.damage_line(point.line, point.column.0 as usize, point.column.0 as usize);
+        self.damage_line(point.line, point.column.0, point.column.0);
     }
 
     /// Expand `line`'s damage to span at least `left` to `right` column.
@@ -228,7 +228,7 @@ impl TermDamageState {
         };
 
         let start = cmp::max(selection.start.line.0 + display_offset, 0);
-        let end = cmp::min(cmp::max(selection.end.line.0 + display_offset, 0), last_visible_line);
+        let end = (selection.end.line.0 + display_offset).clamp(0, last_visible_line);
         for line in start as usize..=end as usize {
             self.damage_line(line, 0, num_cols - 1);
         }
@@ -1244,7 +1244,7 @@ impl<T: EventListener> Handler for Term<T> {
 
         if self.grid.cursor.point.column > Column(0) {
             let line = self.grid.cursor.point.line.0 as usize;
-            let column = self.grid.cursor.point.column.0 as usize;
+            let column = self.grid.cursor.point.column.0;
             self.grid.cursor.point.column -= 1;
             self.grid.cursor.input_needs_wrap = false;
             self.damage.damage_line(line, column - 1, column);
@@ -1547,7 +1547,7 @@ impl<T: EventListener> Handler for Term<T> {
         self.event_proxy.send_event(Event::ClipboardLoad(
             clipboard_type,
             Arc::new(move |text| {
-                let base64 = base64::encode(&text);
+                let base64 = base64::encode(text);
                 format!("\x1b]52;{};{}{}", clipboard as char, base64, terminator)
             }),
         ));


### PR DESCRIPTION
This patch applies all clippy lints currently present on the latest clippy master than are compatible with our oldstable clippy (only exception is the `_else(||` stuff).