### PR TITLE
Fix `--help` output for `--class` to match man pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CPU usage spikes due to mouse movements for unfocused windows on X11/Windows
 - First window on macOS not tabbed with system prefer tabs setting
 - Window being treaten as focused by default on Wayland
+- `--help` output for `--class` does not match man pages
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.12.0-dev
 
+### Fixed
+
+- `--help` output for `--class` does not match man pages
+
 ## 0.11.0
 
 ### Packaging
@@ -74,7 +78,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CPU usage spikes due to mouse movements for unfocused windows on X11/Windows
 - First window on macOS not tabbed with system prefer tabs setting
 - Window being treaten as focused by default on Wayland
-- `--help` output for `--class` does not match man pages
 
 ### Removed
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -242,7 +242,7 @@ pub struct WindowIdentity {
     pub title: Option<String>,
 
     /// Defines window class/app_id on X11/Wayland [default: Alacritty].
-    #[clap(long, value_name = "instance> | <instance>,<general", parse(try_from_str = parse_class))]
+    #[clap(long, value_name = "general> | <general>,<instance", parse(try_from_str = parse_class))]
     pub class: Option<Class>,
 }
 

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -25,7 +25,7 @@ _alacritty() {
 '*--command=[Command and args to execute (must be last argument)]:COMMAND: ' \
 '-t+[Defines the window title \[default: Alacritty\]]:TITLE: ' \
 '--title=[Defines the window title \[default: Alacritty\]]:TITLE: ' \
-'--class=[Defines window class/app_id on X11/Wayland \[default: Alacritty\]]:instance> | <instance>,<general: ' \
+'--class=[Defines window class/app_id on X11/Wayland \[default: Alacritty\]]:general> | <general>,<instance: ' \
 '-h[Print help information]' \
 '--help[Print help information]' \
 '-V[Print version information]' \
@@ -67,7 +67,7 @@ _arguments "${_arguments_options[@]}" \
 '*--command=[Command and args to execute (must be last argument)]:COMMAND: ' \
 '-t+[Defines the window title \[default: Alacritty\]]:TITLE: ' \
 '--title=[Defines the window title \[default: Alacritty\]]:TITLE: ' \
-'--class=[Defines window class/app_id on X11/Wayland \[default: Alacritty\]]:instance> | <instance>,<general: ' \
+'--class=[Defines window class/app_id on X11/Wayland \[default: Alacritty\]]:general> | <general>,<instance: ' \
 '--hold[Remain open after child process exit]' \
 '-h[Print help information]' \
 '--help[Print help information]' \


### PR DESCRIPTION
Fixes https://github.com/alacritty/alacritty/issues/6413.

The output of `--help` did not match the man pages with regards to the ordering of arguments for the `--class` flag. This has now been fixed.