### PR TITLE
Fix startup failure on macOS with dash as /bin/sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `--help` output for `--class` does not match man pages
 - Cursor and underlines always being black on very old hardware
 - Crash when using very low negative `font.offset`
+- Startup failure on macOS with default config when system `/bin/sh` is `dash`
 
 ## 0.11.0
 

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -143,7 +143,9 @@ fn default_shell_command(pw: &Passwd<'_>) -> Command {
     // -f: Bypasses authentication for the already-logged-in user.
     // -l: Skips changing directory to $HOME and prepending '-' to argv[0].
     // -p: Preserves the environment.
-    login_command.args(["-flp", pw.name, "/bin/sh", "-c", &exec]);
+    //
+    // XXX: we use zsh here over sh due to `exec -a`.
+    login_command.args(["-flp", pw.name, "/bin/zsh", "-c", &exec]);
     login_command
 }
 


### PR DESCRIPTION
The dash's exec doesn't have `-a` argument we rely on when running login shell, so use bash instead.

Fixes #6426.