### PR TITLE
Change default bright colors to bright versions of the normal colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.12.0-dev
 
+### Changed
+
+- Default bright colors are now derived from `Tomorrow Night` rather than using `Tomorrow Night Bright`
+
 ### Fixed
 
 - `--help` output for `--class` does not match man pages

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -293,14 +293,14 @@
 
   # Bright colors
   #bright:
-  #  black:   '#666666'
-  #  red:     '#d54e53'
-  #  green:   '#b9ca4a'
-  #  yellow:  '#e7c547'
-  #  blue:    '#7aa6da'
-  #  magenta: '#c397d8'
-  #  cyan:    '#70c0b1'
-  #  white:   '#eaeaea'
+  #  black:   '#5a6066'
+  #  red:     '#ff8080'
+  #  green:   '#f2fd8b'
+  #  yellow:  '#ffdd99'
+  #  blue:    '#add8ff'
+  #  magenta: '#eec6fa'
+  #  cyan:    '#b9fff5'
+  #  white:   '#fbfffc'
 
   # Dim colors
   #

--- a/alacritty/src/config/color.rs
+++ b/alacritty/src/config/color.rs
@@ -227,14 +227,14 @@ pub struct BrightColors {
 impl Default for BrightColors {
     fn default() -> Self {
         BrightColors {
-            black: Rgb { r: 0x66, g: 0x66, b: 0x66 },
-            red: Rgb { r: 0xd5, g: 0x4e, b: 0x53 },
-            green: Rgb { r: 0xb9, g: 0xca, b: 0x4a },
-            yellow: Rgb { r: 0xe7, g: 0xc5, b: 0x47 },
-            blue: Rgb { r: 0x7a, g: 0xa6, b: 0xda },
-            magenta: Rgb { r: 0xc3, g: 0x97, b: 0xd8 },
-            cyan: Rgb { r: 0x70, g: 0xc0, b: 0xb1 },
-            white: Rgb { r: 0xea, g: 0xea, b: 0xea },
+            black: Rgb { r: 0x5a, g: 0x60, b: 0x66 },
+            red: Rgb { r: 0xff, g: 0x80, b: 0x80 },
+            green: Rgb { r: 0xf2, g: 0xfd, b: 0x8b },
+            yellow: Rgb { r: 0xff, g: 0xdd, b: 0x99 },
+            blue: Rgb { r: 0xad, g: 0xd8, b: 0xff },
+            magenta: Rgb { r: 0xee, g: 0xc6, b: 0xfa },
+            cyan: Rgb { r: 0xb9, g: 0xff, b: 0xf5 },
+            white: Rgb { r: 0xfb, g: 0xff, b: 0xfc },
         }
     }
 }


### PR DESCRIPTION
Set the bright colors to the normal colors ("Tomorrow Night") multiplied by a brightness factor of 1.34 (capped at 100%).

This follows the proposed approach given in the [original issue](https://github.com/alacritty/alacritty/issues/3404) from Mar 2020 to rework the default bright colors.

More precisely, take each normal color, convert RGB to HSV, then multiply the V by 1.34, and finally convert back to RGB.

There are just two minor deviations:
1. The normal yellow already has a brightness of 94.1%, so changing the brightness to 100% doesn't result in a big enough difference; so for bright yellow the saturation was also changed, from 51.7 to 40, which gives it a noticeable difference.
2. For bright black the brightness was just changed from 12.9% to 40%; 40% is exactly the same brightness level we are currently using; the formula just doesn't work to go from black to bright black because multiplying black brightness by 1.34 doesn't really change it much.

The new color scheme has all of the following advantages:
* Bright colors are now easily distinguishable from their normal counterparts.
* Bright red is now brighter than normal red instead of darker.
* Bright cyan is now brighter than normal cyan instead of being almost identical and actually slightly darker.
* Overall contrast is greatly improved across the board (see bar chart below).

Luminance calculations (using formula `0.2126*R + 0.7152*G + 0.0722*B`) for Red and Cyan:
* **Red BEFORE:**
  * Normal = 0.23299420863212106
  * Bright = 0.20219445780928133
* **Red AFTER:**
  * Normal = 0.23299420863212106
  * Bright = 0.3825685577896843
* **Cyan BEFORE:**
  * Normal = 0.4564908235539082
  * Bright = 0.4431834311169868
* **Cyan AFTER:**
  * Normal = 0.4564908235539082
  * Bright = 0.8842685999154053

Here is a visual comparison of the current (old) colorscheme versus the new one with this PR.  The screenshots show all color combinations:

**OLD**

<img width="1455" alt="old" src="https://user-images.githubusercontent.com/1693761/197359669-d76aead8-33f9-48aa-b6dd-cb4ef97bfc3b.png">

**NEW**

<img width="1454" alt="new" src="https://user-images.githubusercontent.com/1693761/197359671-63415e9b-e53c-40a9-8483-7d9d7da9c605.png">

Finally, here is a bar chart showing the contrast delta (X axis has a point for each color combination; Y axis shows the new contrast minus the old contrast):

![contrast_delta](https://user-images.githubusercontent.com/1693761/197359736-b0bbfdb6-e117-44ec-9678-3cec09898ab6.png)

See https://github.com/alacritty/alacritty/issues/6213 for more details.

Some history:

The original issue was "solved" by incorporating the 8 colors from "Tomorrow Night Bright" as the bright colors, but there was no logical reason for doing that as that color scheme is just another nice 8-color scheme and has no correlation to "Tomorrow Night" other than having a similar name.  Any other random color scheme could have been chose for the bright colors and would have resulted in the same problem.

As a result, the original issue was only partially solved as many bright colors remained hard to distinguish from their normal counterpart, since both the hue and brightness remained very close (and yes it makes sense for normal and bright to have the same hue, but not the same brightness).