### PR TITLE
Fixed typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ Alacritty's release process aims to provide stable and well tested releases with
 back new features during the testing period.
 
 To achieve these goals, a new branch is created for every new release. Both the release candidates
-and the final version are only comitted and tagged in this branch. The master branch only tracks
+and the final version are only committed and tagged in this branch. The master branch only tracks
 development versions, allowing us to keep the branches completely separate without merging releases
 back into master.
 

--- a/docs/ansicode.txt
+++ b/docs/ansicode.txt
@@ -19,7 +19,7 @@ Standardized Video Terminals" in the April-1984 issue of BYTE magazine.
 ANSI X3.4-1977 defines the 7-bit ASCII character set (C0 and G0).  It was
 written in 1968, revised in 1977, and explains the decisions made in laying out
 the ASCII code.  In particular, it explains why ANSI chose to make ASCII
-incompatible with EBCDIC in order to make it self-consistant.
+incompatible with EBCDIC in order to make it self-consistent.
 
 ANSI X3.41-1974 introduces the idea of an 8-bit ASCII character set (C1 and G1
 in addition to the existing C0 and G0).  It describes how to use the 8-bit
@@ -294,7 +294,7 @@ Pt = Start VT105 graphics on a VT125
 
 ==============================================================================
 
-    Indepenent control functions (from Appendix E of X3.64-1977).
+    Independent control functions (from Appendix E of X3.64-1977).
     These four controls have the same meaning regardless of the current
     definition of the C0 and C1 control sets.  Each control is a two-character
     ESCape sequence, the 2nd character is lowercase.
@@ -449,7 +449,7 @@ Oct Hex  *  	(* marks function used in DEC VT series or LA series terminals)
 	 *	[16h = TTM - Transmit Termination Mode, send scrolling region
 		[17h = SATM - Send Area Transmit Mode, send entire buffer
 		[18h = TSM - Tabulation Stop Mode, lines are independent
-		[19h = EBM - Editing Boundry Mode, all of memory affected
+		[19h = EBM - Editing Boundary Mode, all of memory affected
 	 *	[20h = LNM - Linefeed Newline Mode, LF interpreted as CR LF
 	 *	[?1h = DECCKM - Cursor Keys Mode, send ESC O A for cursor up
 	 *	[?2h = DECANM - ANSI Mode, use ESC < to switch VT52 to ANSI


### PR DESCRIPTION
* Fixed typos in `CONTRIBUTING.MD`.
* Fixed typos in `docs/ansicode.txt`