### PR TITLE
Terminal content align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Option for padding align (`window.valign`, `window.halign`)
+- Options for padding align (`window.valign`, `window.halign`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.12.0-dev
 
+### Added
+
+- Option for padding align (`window.valign`, `window.halign`)
+
 ### Fixed
 
 - `--help` output for `--class` does not match man pages

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -50,8 +50,10 @@
   #  x: 0
   #  y: 0
 
-  # Spread additional padding evenly around the terminal content.
-  #dynamic_padding: false
+  # Vertical align for terminal content.
+  #valign: middle
+  # Horizontal align for terminal content.
+  #halign: center
 
   # Window decorations
   #

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -138,10 +138,10 @@ impl WindowConfig {
     #[inline]
     pub fn align(&self) -> (VerticalAlign, HorizontalAlign) {
         if self.valign == Default::default() && self.halign == Default::default() && self.dynamic_padding {
-            return (VerticalAlign::Middle, HorizontalAlign::Center)
+            return (VerticalAlign::Middle, HorizontalAlign::Center);
         }
 
-        return (self.valign, self.halign)
+        (self.valign, self.halign)
     }
 
     #[inline]

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -40,7 +40,13 @@ pub struct WindowConfig {
     decorations_theme_variant: Option<String>,
 
     /// Spread out additional padding evenly.
+    #[config(deprecated = "use window.valign and window.halign instead")]
     pub dynamic_padding: bool,
+
+    /// Vertical align for terminal content.
+    pub valign: VerticalAlign,
+    /// Horizontal align for terminal content.
+    pub halign: HorizontalAlign,
 
     /// Use dynamic title.
     pub dynamic_title: bool,
@@ -70,6 +76,8 @@ impl Default for WindowConfig {
             decorations_theme_variant: Default::default(),
             gtk_theme_variant: Default::default(),
             dynamic_padding: Default::default(),
+            valign: Default::default(),
+            halign: Default::default(),
             identity: Identity::default(),
             opacity: Default::default(),
             padding: Default::default(),
@@ -125,6 +133,15 @@ impl WindowConfig {
         let padding_x = (f32::from(self.padding.x) * scale_factor as f32).floor();
         let padding_y = (f32::from(self.padding.y) * scale_factor as f32).floor();
         (padding_x, padding_y)
+    }
+
+    #[inline]
+    pub fn align(&self) -> (VerticalAlign, HorizontalAlign) {
+        if self.valign == Default::default() && self.halign == Default::default() && self.dynamic_padding {
+            return (VerticalAlign::Middle, HorizontalAlign::Center)
+        }
+
+        return (self.valign, self.halign)
     }
 
     #[inline]
@@ -185,6 +202,32 @@ pub enum Decorations {
 impl Default for Decorations {
     fn default() -> Decorations {
         Decorations::Full
+    }
+}
+
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum VerticalAlign {
+    Top,
+    Middle,
+    Bottom,
+}
+
+impl Default for VerticalAlign {
+    fn default() -> VerticalAlign {
+        VerticalAlign::Top
+    }
+}
+
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HorizontalAlign {
+    Left,
+    Center,
+    Right,
+}
+
+impl Default for HorizontalAlign {
+    fn default() -> HorizontalAlign {
+        HorizontalAlign::Left
     }
 }
 

--- a/alacritty/src/display/cursor.rs
+++ b/alacritty/src/display/cursor.rs
@@ -16,8 +16,8 @@ pub trait IntoRects {
 impl IntoRects for RenderableCursor {
     fn rects(self, size_info: &SizeInfo, thickness: f32) -> CursorRects {
         let point = self.point();
-        let x = point.column.0 as f32 * size_info.cell_width() + size_info.padding_x();
-        let y = point.line as f32 * size_info.cell_height() + size_info.padding_y();
+        let x = point.column.0 as f32 * size_info.cell_width() + size_info.padding_left();
+        let y = point.line as f32 * size_info.cell_height() + size_info.padding_top();
 
         let mut width = size_info.cell_width();
         let height = size_info.cell_height();

--- a/alacritty/src/display/damage.rs
+++ b/alacritty/src/display/damage.rs
@@ -21,8 +21,8 @@ impl<'a> RenderDamageIterator<'a> {
     #[inline]
     fn rect_for_line(&self, line_damage: LineDamageBounds) -> Rect {
         let size_info = &self.size_info;
-        let y_top = size_info.height() - size_info.padding_y();
-        let x = size_info.padding_x() + line_damage.left as u32 * size_info.cell_width();
+        let y_top = size_info.height() - size_info.padding_top();
+        let x = size_info.padding_left() + line_damage.left as u32 * size_info.cell_width();
         let y = y_top - (line_damage.line + 1) as u32 * size_info.cell_height();
         let width = (line_damage.right - line_damage.left + 1) as u32 * size_info.cell_width();
         Rect { x, y, height: size_info.cell_height(), width }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -210,12 +210,22 @@ impl<T: Clone + Copy> SizeInfo<T> {
     }
 
     #[inline]
-    pub fn padding_x(&self) -> T {
+    pub fn padding_left(&self) -> T {
         self.padding_x
     }
 
     #[inline]
-    pub fn padding_y(&self) -> T {
+    pub fn padding_right(&self) -> T {
+        self.padding_x
+    }
+
+    #[inline]
+    pub fn padding_top(&self) -> T {
+        self.padding_y
+    }
+
+    #[inline]
+    pub fn padding_bottom(&self) -> T {
         self.padding_y
     }
 }
@@ -553,7 +563,13 @@ impl Display {
         );
 
         info!("Cell size: {} x {}", cell_width, cell_height);
-        info!("Padding: {} x {}", size_info.padding_x(), size_info.padding_y());
+        info!(
+            "Padding: {} {} {} {}",
+            size_info.padding_top(),
+            size_info.padding_right(),
+            size_info.padding_bottom(),
+            size_info.padding_left()
+        );
         info!("Width: {}, Height: {}", size_info.width(), size_info.height());
 
         // Update OpenGL projection.
@@ -754,7 +770,13 @@ impl Display {
             }
         }
 
-        info!("Padding: {} x {}", self.size_info.padding_x(), self.size_info.padding_y());
+        info!(
+            "Padding: {} {} {} {}",
+            self.size_info.padding_top(),
+            self.size_info.padding_right(),
+            self.size_info.padding_bottom(),
+            self.size_info.padding_left()
+        );
         info!("Width: {}, Height: {}", self.size_info.width(), self.size_info.height());
 
         // Damage the entire screen after processing update.
@@ -987,7 +1009,7 @@ impl Display {
 
             // Create a new rectangle for the background.
             let start_line = size_info.screen_lines() + search_offset;
-            let y = size_info.cell_height().mul_add(start_line as f32, size_info.padding_y());
+            let y = size_info.cell_height().mul_add(start_line as f32, size_info.padding_top());
 
             let bg = match message.ty() {
                 MessageType::Error => config.colors.normal.red,
@@ -1393,8 +1415,8 @@ impl Display {
     /// This method also enqueues damage for the next frame automatically.
     fn damage_from_point(&self, point: Point<usize>, len: u32) -> DamageRect {
         let size_info: SizeInfo<u32> = self.size_info.into();
-        let x = size_info.padding_x() + point.column.0 as u32 * size_info.cell_width();
-        let y_top = size_info.height() - size_info.padding_y();
+        let x = size_info.padding_left() + point.column.0 as u32 * size_info.cell_width();
+        let y_top = size_info.height() - size_info.padding_top();
         let y = y_top - (point.line as u32 + 1) * size_info.cell_height();
         let width = len * size_info.cell_width();
         DamageRect { x, y, width, height: size_info.cell_height() }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -456,8 +456,8 @@ impl Window {
 
     /// Adjust the IME editor position according to the new location of the cursor.
     pub fn update_ime_position(&self, point: Point<usize>, size: &SizeInfo) {
-        let nspot_x = f64::from(size.padding_x() + point.column.0 as f32 * size.cell_width());
-        let nspot_y = f64::from(size.padding_y() + (point.line + 1) as f32 * size.cell_height());
+        let nspot_x = f64::from(size.padding_left() + point.column.0 as f32 * size.cell_width());
+        let nspot_y = f64::from(size.padding_top() + (point.line + 1) as f32 * size.cell_height());
 
         self.window().set_ime_position(PhysicalPosition::new(nspot_x, nspot_y));
     }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1069,10 +1069,10 @@ impl Mouse {
     /// coordinates will be clamped to the closest grid coordinates.
     #[inline]
     pub fn point(&self, size: &SizeInfo, display_offset: usize) -> Point {
-        let col = self.x.saturating_sub(size.padding_x() as usize) / (size.cell_width() as usize);
+        let col = self.x.saturating_sub(size.padding_left() as usize) / (size.cell_width() as usize);
         let col = min(Column(col), size.last_column());
 
-        let line = self.y.saturating_sub(size.padding_y() as usize) / (size.cell_height() as usize);
+        let line = self.y.saturating_sub(size.padding_top() as usize) / (size.cell_height() as usize);
         let line = min(line, size.bottommost_line().0 as usize);
 
         term::viewport_to_point(display_offset, Point::new(line, col))

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -424,12 +424,12 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let size_info = self.ctx.size_info();
 
         let cell_x =
-            x.saturating_sub(size_info.padding_x() as usize) % size_info.cell_width() as usize;
+            x.saturating_sub(size_info.padding_left() as usize) % size_info.cell_width() as usize;
         let half_cell_width = (size_info.cell_width() / 2.0) as usize;
 
         let additional_padding =
-            (size_info.width() - size_info.padding_x() * 2.) % size_info.cell_width();
-        let end_of_grid = size_info.width() - size_info.padding_x() - additional_padding;
+            (size_info.width() - size_info.padding_left() - size_info.padding_right()) % size_info.cell_width();
+        let end_of_grid = size_info.width() - size_info.padding_left() - additional_padding;
 
         if cell_x > half_cell_width
             // Edge case when mouse leaves the window.
@@ -912,7 +912,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         // Calculate Y position of the end of the last terminal line.
         let size = self.ctx.size_info();
-        let terminal_end = size.padding_y() as usize
+        let terminal_end = size.padding_top() as usize
             + size.cell_height() as usize * (size.screen_lines() + search_height);
 
         let mouse = self.ctx.mouse();
@@ -962,8 +962,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let step = (SELECTION_SCROLLING_STEP * scale_factor) as i32;
 
         // Compute the height of the scrolling areas.
-        let end_top = max(min_height, size.padding_y() as i32);
-        let text_area_bottom = size.padding_y() + size.screen_lines() as f32 * size.cell_height();
+        let end_top = max(min_height, size.padding_top() as i32);
+        let text_area_bottom = size.padding_top() + size.screen_lines() as f32 * size.cell_height();
         let start_bottom = min(size.height() as i32 - min_height, text_area_bottom as i32);
 
         // Get distance from closest window boundary.

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1129,9 +1129,6 @@ mod tests {
                     51.0,
                     3.0,
                     3.0,
-                    0.,
-                    0.,
-                    false,
                 );
 
                 let mut terminal = Term::new(&cfg.terminal_config, &size, MockEventProxy);

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -194,7 +194,7 @@ mod tests {
         let input = "a";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(7., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(7., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -206,7 +206,7 @@ mod tests {
         let input = "fo\nbar";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(6., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(6., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -218,7 +218,7 @@ mod tests {
         let input = "a\nb";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(6., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(6., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -230,7 +230,7 @@ mod tests {
         let input = "foobar1";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(6., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(6., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -242,7 +242,7 @@ mod tests {
         let input = "foobar";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(6., 0., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(6., 0., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -254,7 +254,7 @@ mod tests {
         let input = "hahahahahahahahahahaha truncate this because it's too long for the term";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(22., (MIN_FREE_LINES + 2) as f32, 1., 1., 0., 0., false);
+        let size = SizeInfo::new(22., (MIN_FREE_LINES + 2) as f32, 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -269,7 +269,7 @@ mod tests {
         let input = "ha";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(2., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(2., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -281,7 +281,7 @@ mod tests {
         let input = "hahahahahahahahaha";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(2., (MIN_FREE_LINES + 2) as f32, 1., 1., 0., 0., false);
+        let size = SizeInfo::new(2., (MIN_FREE_LINES + 2) as f32, 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -293,7 +293,7 @@ mod tests {
         let input = "test";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(5., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(5., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -343,7 +343,7 @@ mod tests {
         let input = "a\nbc defg";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(5., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(5., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -359,7 +359,7 @@ mod tests {
         let input = "ab\nc 👩d fgh";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(7., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(7., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 
@@ -375,7 +375,7 @@ mod tests {
         let input = "\n0 1 2 3";
         let mut message_buffer = MessageBuffer::default();
         message_buffer.push(Message::new(input.into(), MessageType::Error));
-        let size = SizeInfo::new(3., 10., 1., 1., 0., 0., false);
+        let size = SizeInfo::new(3., 10., 1., 1.);
 
         let lines = message_buffer.message().unwrap().text(&size);
 

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -39,7 +39,7 @@ impl Message {
     pub fn text(&self, size_info: &SizeInfo) -> Vec<String> {
         let num_cols = size_info.columns();
         let total_lines =
-            (size_info.height() - 2. * size_info.padding_y()) / size_info.cell_height();
+            (size_info.height() - size_info.padding_top() - size_info.padding_bottom()) / size_info.cell_height();
         let max_lines = (total_lines as usize).saturating_sub(MIN_FREE_LINES);
         let button_len = CLOSE_BUTTON_TEXT.chars().count();
 

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -203,10 +203,10 @@ impl Renderer {
     pub fn set_viewport(&self, size: &SizeInfo) {
         unsafe {
             gl::Viewport(
-                size.padding_x() as i32,
-                size.padding_y() as i32,
-                size.width() as i32 - 2 * size.padding_x() as i32,
-                size.height() as i32 - 2 * size.padding_y() as i32,
+                size.padding_left() as i32,
+                size.padding_bottom() as i32,
+                size.width() as i32 - (size.padding_left() + size.padding_right()) as i32,
+                size.height() as i32 - (size.padding_top() + size.padding_bottom()) as i32,
             );
         }
     }

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -144,8 +144,8 @@ impl RenderLine {
         }
 
         RenderRect::new(
-            start_x + size.padding_x(),
-            y + size.padding_y(),
+            start_x + size.padding_left(),
+            y + size.padding_top(),
             width,
             thickness,
             color,
@@ -455,7 +455,7 @@ impl RectShaderProgram {
         let position = (0.5 * metrics.descent).abs();
         let underline_position = metrics.descent.abs() - metrics.underline_position.abs();
 
-        let viewport_height = size_info.height() - size_info.padding_y();
+        let viewport_height = size_info.height() - size_info.padding_top();
         let padding_y = viewport_height
             - (viewport_height / size_info.cell_height()).floor() * size_info.cell_height();
 
@@ -470,7 +470,7 @@ impl RectShaderProgram {
                 gl::Uniform1f(u_padding_y, padding_y);
             }
             if let Some(u_padding_x) = self.u_padding_x {
-                gl::Uniform1f(u_padding_x, size_info.padding_x());
+                gl::Uniform1f(u_padding_x, size_info.padding_left());
             }
             if let Some(u_underline_position) = self.u_underline_position {
                 gl::Uniform1f(u_underline_position, underline_position);

--- a/alacritty/src/renderer/text/mod.rs
+++ b/alacritty/src/renderer/text/mod.rs
@@ -198,19 +198,19 @@ impl<'a> LoadGlyph for LoaderApi<'a> {
 fn update_projection(u_projection: GLint, size: &SizeInfo) {
     let width = size.width();
     let height = size.height();
-    let padding_x = size.padding_x();
-    let padding_y = size.padding_y();
+    let padding_x = size.padding_left() + size.padding_right();
+    let padding_y = size.padding_top() + size.padding_bottom();
 
     // Bounds check.
-    if (width as u32) < (2 * padding_x as u32) || (height as u32) < (2 * padding_y as u32) {
+    if (width as u32) < (padding_x as u32) || (height as u32) < (padding_y as u32) {
         return;
     }
 
     // Compute scale and offset factors, from pixel to ndc space. Y is inverted.
-    //   [0, width - 2 * padding_x] to [-1, 1]
-    //   [height - 2 * padding_y, 0] to [-1, 1]
-    let scale_x = 2. / (width - 2. * padding_x);
-    let scale_y = -2. / (height - 2. * padding_y);
+    //   [0, width - padding_x] to [-1, 1]
+    //   [height - padding_y, 0] to [-1, 1]
+    let scale_x = 2. / (width - padding_x);
+    let scale_y = -2. / (height - padding_y);
     let offset_x = -1.;
     let offset_y = 1.;
 

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -231,6 +231,8 @@ impl WindowContext {
         let window_config = &old_config.window;
         if window_config.padding(1.) != self.config.window.padding(1.)
             || window_config.dynamic_padding != self.config.window.dynamic_padding
+            || window_config.valign != self.config.window.valign
+            || window_config.halign != self.config.window.halign
         {
             self.display.pending_update.dirty = true;
         }


### PR DESCRIPTION
Now is possible to align content based on padding. This is a very important functionality for displays with rounded corners.

For example, new MacBooks have rounded top corners, which makes it impractical to use `window.startup_mode: SimpleFullscreen`. The current solution was to specify `padding.y` losing space at the bottom, now you can do this:

```yaml
window:
  valign: bottom
  padding:
    y: 10
```

Another problem is the inability to specify where to leave space for indentation requirements. ( #6440 ).

This PR adds 2 new properties:
 - `window.valign`: `top`/`middle`/`bottom`, where `middle` same as `dynamic_padding` for vertical align.
 - `window.halign`: `left`/`center`/`right`, where `center ` same as `dynamic_padding` for horizontal align.

`dynamic_padding` now is deprecated.

Examples:

```yaml
  valign: bottom
  halign: center
  padding:
    y: 10
    x: 20
```

<img width="1728" alt="Screenshot 2022-10-24 at 13 29 58" src="https://user-images.githubusercontent.com/1789565/197506401-701f81c7-7625-4896-b610-46998ad5947e.png">
