### PR TITLE
Fix crash during text compose on old GNOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cursor and underlines always being black on very old hardware
 - Crash when using very low negative `font.offset`
 - Startup failure on macOS with default config when system `/bin/sh` is `dash`
+- Crash during text compose on old GNOME under Wayland
 
 ## 0.11.0
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1248,7 +1248,11 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                             let preedit = if text.is_empty() {
                                 None
                             } else {
-                                Some(Preedit::new(text, cursor_offset.map(|offset| offset.0)))
+                                // TODO remove with winit update.
+                                let cursor_offset = cursor_offset.and_then(|offset| {
+                                    text.is_char_boundary(offset.0).then(|| offset.0)
+                                });
+                                Some(Preedit::new(text, cursor_offset))
                             };
 
                             if self.ctx.display.ime.preedit() != preedit.as_ref() {


### PR DESCRIPTION
Fixes #6396.