### PR TITLE
Bump crossfont and sctk-adwaita

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cursor and underlines always being black on very old hardware
 - Crash when using very low negative `font.offset`
 - Startup failure on macOS with default config when system `/bin/sh` is `dash`
+- Artifacts in corners for maximized window with CSD on Wayland
+- Dotted underline not shown on macOS
+- Underline on macOS always being at the bottom of the cell
+- Crash with `OT-SVG` fonts on Linux/BSD
 
 ## 0.11.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "crossfont"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66b1c1979c4362323f03ab6bf7fb522902bfc418e0c37319ab347f9561d980f"
+checksum = "21fd3add36ea31aba1520aa5288714dd63be506106753226d0eb387a93bc9c45"
 dependencies = [
  "cocoa",
  "core-foundation",
@@ -1448,9 +1448,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b7c47a572f73de28bee5b5060d085b42b6ce1e4ee2b49c956ea7b25e94b6f0"
+checksum = "61270629cc6b4d77ec1907db1033d5c2e1a404c412743621981a871dc9c12339"
 dependencies = [
  "crossfont",
  "log",


### PR DESCRIPTION
Fixes #6432.
Fixes #6414.
Fixes #6400.
Fixes #6338.