### PR TITLE
Fix padding update not updating renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Crash with `OT-SVG` fonts on Linux/BSD
 - Crash during text compose on old GNOME under Wayland
 - Mouse cursor staying hidden after window regains focus on macOS Ventura
+- Blurry fonts when changing padding size at runtime
 
 ## 0.11.0
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -620,14 +620,11 @@ impl Display {
         if let Some(dimensions) = pending_update.dimensions() {
             width = dimensions.width as f32;
             height = dimensions.height as f32;
-
-            let renderer_update = self.pending_renderer_update.get_or_insert(Default::default());
-            renderer_update.resize = true
         }
 
         let padding = config.window.padding(self.window.scale_factor as f32);
 
-        self.size_info = SizeInfo::new(
+        let new_size = SizeInfo::new(
             width,
             height,
             cell_width,
@@ -636,6 +633,14 @@ impl Display {
             padding.1,
             config.window.dynamic_padding,
         );
+
+        // Queue renderer update if terminal dimensions/padding changed.
+        if new_size != self.size_info {
+            let renderer_update = self.pending_renderer_update.get_or_insert(Default::default());
+            renderer_update.resize = true;
+        }
+
+        self.size_info = new_size;
 
         // Update number of column/lines in the viewport.
         let message_bar_lines =


### PR DESCRIPTION
This fixes an issue where it was possible to update the padding of the terminal without actually queueing an update for the renderer projection, leading to a blurry projection.

Closes #6502.