### PR TITLE
Provide an obvious landmark to config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,3 @@
+# Configuration
+
+While Alacritty is in beta you can refer to the [`alacritty.yml`](/alacritty.yml) config file which is heavily commented.


### PR DESCRIPTION
Ideally we should do something with github actions when mainline branch changes that uploads the `alacritty.yml` to the website repo so it can be injected into a proper documentation section.

For now this can be the minimum that will point people to documentation.

fixes #6525 