### PR TITLE
Ignore errors from swap_buffers

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -554,8 +554,6 @@ impl Display {
             },
             (surface, context) => surface.swap_buffers(context),
         };
-        // We ignore the errors, but log them into `debug` so we can at least
-        // troubleshoot them in case they could be suspicious to real issues.
         if let Err(err) = res {
             debug!("error calling swap_buffers: {}", err);
         }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -545,7 +545,7 @@ impl Display {
 
     fn swap_buffers(&self) {
         #[allow(clippy::single_match)]
-        match (self.surface.deref(), &self.context.get()) {
+        let res = match (self.surface.deref(), &self.context.get()) {
             #[cfg(not(any(target_os = "macos", windows)))]
             (Surface::Egl(surface), PossiblyCurrentContext::Egl(context))
                 if self.is_wayland && !self.debug_damage =>
@@ -553,8 +553,12 @@ impl Display {
                 surface.swap_buffers_with_damage(context, &self.damage_rects)
             },
             (surface, context) => surface.swap_buffers(context),
+        };
+        // We ignore the errors, but log them into `debug` so we can at least
+        // troubleshoot them in case they could be suspicious to real issues.
+        if let Err(err) = res {
+            debug!("error calling swap_buffers: {}", err);
         }
-        .expect("failed to swap buffers.");
     }
 
     /// Update font size and cell dimensions.


### PR DESCRIPTION
Most of them are innocent and require just swap again. It was like that before anyway due to old glutin bug in the error handling implementation where errors won't pulled on swap buffers, but old observed error was used.

Fixes #6538.