### PR TITLE
Update the VirtualKeyCode documentation

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -566,7 +566,7 @@
 #    - Key0-Key9
 #
 #    A full list with available key codes can be found here:
-#    https://docs.rs/glutin/*/glutin/event/enum.VirtualKeyCode.html#variants
+#    https://docs.rs/winit/*/winit/event/enum.VirtualKeyCode.html#variants
 #
 #    Instead of using the name of the keys, the `key` field also supports using
 #    the scancode of the desired key. Scancodes have to be specified as a


### PR DESCRIPTION
The `winit` crate was split off of the `glutin` crate. The new link to see all the keycodes is now https://docs.rs/winit/*/winit/event/enum.VirtualKeyCode.html.