### PR TITLE
Fix damage computation on boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0282c380a3adb52ae095e5847cc575c6bf79d296dcbf333e00be4a3fca07235e"
+checksum = "524d807cd49a0c56a53ef9a6738cd15e7c8c4e9d37a3b7fdb3c250c1cd5bf7a3"
 dependencies = [
  "bitflags",
  "cfg_aliases",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -29,7 +29,7 @@ fnv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1"
-glutin = { version = "0.30.2", default-features = false, features = ["egl", "wgl"] }
+glutin = { version = "0.30.3", default-features = false, features = ["egl", "wgl"] }
 winit = { version = "0.27.4", default-features = false, features = ["serde"] }
 notify-debouncer-mini = { version = "0.2.1", default-features = false }
 parking_lot = "0.12.0"


### PR DESCRIPTION
Given that the Rect started to use signed integers saturating_sub became irrelevant and no clamp to zero were performed. This commit uses max instead to fix it.