### PR TITLE
Use -T as the short form for --title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.12.0-dev
 
+### Added
+
+- Uppercase `-T` short form for `--title`
+
 ### Fixed
 
 - `--help` output for `--class` does not match man pages

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -238,7 +238,7 @@ impl From<TerminalOptions> for PtyConfig {
 #[derive(Serialize, Deserialize, Args, Default, Debug, Clone, PartialEq, Eq)]
 pub struct WindowIdentity {
     /// Defines the window title [default: Alacritty].
-    #[clap(short, long)]
+    #[clap(short = 'T', short_alias('t'), long)]
     pub title: Option<String>,
 
     /// Defines window class/app_id on X11/Wayland [default: Alacritty].

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -62,7 +62,7 @@ Override configuration file options [example: cursor.style=Beam]
 \fB\-\-socket\fR <socket>
 Path for IPC socket creation
 .TP
-\fB\-t\fR, \fB\-\-title\fR <title>
+\fB\-T\fR, \fB\-\-title\fR <title>
 Defines the window title [default: Alacritty]
 .TP
 \fB\-\-working\-directory\fR <working\-directory>

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -23,7 +23,7 @@ _alacritty() {
 '--working-directory=[Start the shell in the specified working directory]:WORKING_DIRECTORY:_files' \
 '*-e+[Command and args to execute (must be last argument)]:COMMAND: ' \
 '*--command=[Command and args to execute (must be last argument)]:COMMAND: ' \
-'-t+[Defines the window title \[default: Alacritty\]]:TITLE: ' \
+'-T+[Defines the window title \[default: Alacritty\]]:TITLE: ' \
 '--title=[Defines the window title \[default: Alacritty\]]:TITLE: ' \
 '--class=[Defines window class/app_id on X11/Wayland \[default: Alacritty\]]:general> | <general>,<instance: ' \
 '-h[Print help information]' \
@@ -65,7 +65,7 @@ _arguments "${_arguments_options[@]}" \
 '--working-directory=[Start the shell in the specified working directory]:WORKING_DIRECTORY:_files' \
 '*-e+[Command and args to execute (must be last argument)]:COMMAND: ' \
 '*--command=[Command and args to execute (must be last argument)]:COMMAND: ' \
-'-t+[Defines the window title \[default: Alacritty\]]:TITLE: ' \
+'-T+[Defines the window title \[default: Alacritty\]]:TITLE: ' \
 '--title=[Defines the window title \[default: Alacritty\]]:TITLE: ' \
 '--class=[Defines window class/app_id on X11/Wayland \[default: Alacritty\]]:general> | <general>,<instance: ' \
 '--hold[Remain open after child process exit]' \

--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -31,7 +31,7 @@ _alacritty() {
 
     case "${cmd}" in
         alacritty)
-            opts="-h -V -q -v -o -e -t --help --version --print-events --ref-test --embed --config-file --socket --option --working-directory --hold --command --title --class msg help"
+            opts="-h -V -q -v -o -e -T --help --version --print-events --ref-test --embed --config-file --socket --option --working-directory --hold --command --title --class msg help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -73,7 +73,7 @@ _alacritty() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                -t)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -147,7 +147,7 @@ _alacritty() {
             return 0
             ;;
         alacritty__msg__create__window)
-            opts="-e -t -h --working-directory --hold --command --title --class --help"
+            opts="-e -T -h --working-directory --hold --command --title --class --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -169,7 +169,7 @@ _alacritty() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                -t)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -4,7 +4,7 @@ complete -c alacritty -n "__fish_use_subcommand" -l socket -d 'Path for IPC sock
 complete -c alacritty -n "__fish_use_subcommand" -s o -l option -d 'Override configuration file options [example: cursor.style=Beam]' -r
 complete -c alacritty -n "__fish_use_subcommand" -l working-directory -d 'Start the shell in the specified working directory' -r -F
 complete -c alacritty -n "__fish_use_subcommand" -s e -l command -d 'Command and args to execute (must be last argument)' -r
-complete -c alacritty -n "__fish_use_subcommand" -s t -l title -d 'Defines the window title [default: Alacritty]' -r
+complete -c alacritty -n "__fish_use_subcommand" -s T -l title -d 'Defines the window title [default: Alacritty]' -r
 complete -c alacritty -n "__fish_use_subcommand" -l class -d 'Defines window class/app_id on X11/Wayland [default: Alacritty]' -r
 complete -c alacritty -n "__fish_use_subcommand" -s h -l help -d 'Print help information'
 complete -c alacritty -n "__fish_use_subcommand" -s V -l version -d 'Print version information'
@@ -22,7 +22,7 @@ complete -c alacritty -n "__fish_seen_subcommand_from msg; and not __fish_seen_s
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and not __fish_seen_subcommand_from create-window; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -l working-directory -d 'Start the shell in the specified working directory' -r -F
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s e -l command -d 'Command and args to execute (must be last argument)' -r
-complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s t -l title -d 'Defines the window title [default: Alacritty]' -r
+complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s T -l title -d 'Defines the window title [default: Alacritty]' -r
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -l class -d 'Defines window class/app_id on X11/Wayland [default: Alacritty]' -r
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -l hold -d 'Remain open after child process exit'
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s h -l help -d 'Print help information'


### PR DESCRIPTION
Debian-based distributions provide a standard interface to launch a terminal via the x-terminal-emulator name.  In order for a terminal emualtor to satisfy that interface, it must

* Be VT100 compatiable
* Support the "-e <command> <args>" CLI option
* Support the "-T <title>" CLI option

Adjust the short form of --title accordingly, providing -t as an alias to avoid breaking any existing usage.