### PR TITLE
Include changelog in alacritty crate

### DIFF
--- a/alacritty/CHANGELOG.md
+++ b/alacritty/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md


### PR DESCRIPTION
Similar to #6242, this will let us ship the changelog in Debian's
alacritty package.