### PR TITLE
Fix multi-line bracket selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Mouse cursor staying hidden after window regains focus on macOS Ventura
 - Blurry fonts when changing padding size at runtime
 - Crash while typing on Wayland
+- Multi-line semantic bracket selection
 
 ## 0.11.0
 

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -298,7 +298,7 @@ impl Selection {
         if start == end {
             if let Some(matching) = term.bracket_search(start) {
                 if (matching.line == start.line && matching.column < start.column)
-                    || (matching.line > start.line)
+                    || (matching.line < start.line)
                 {
                     start = matching;
                 } else {


### PR DESCRIPTION
This fixes a bug where semantic selection for bracket characters wasn't working properly over multiple lines since start and end of the selection were swapped.

Closes #6567.