### PR TITLE
Hack in tpp-bypass compatibility

### DIFF
--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -1,18 +1,17 @@
-use std::io::Error;
-use std::os::windows::io::IntoRawHandle;
+use std::io::{Error, Read, Write};
+use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 use std::{mem, ptr};
 
 use mio_anonymous_pipes::{EventedAnonRead, EventedAnonWrite};
 
 use windows_sys::core::PWSTR;
-use windows_sys::Win32::Foundation::{HANDLE, S_OK};
-use windows_sys::Win32::System::Console::{
-    ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole, COORD, HPCON,
+use windows_sys::Win32::Foundation::{
+    DuplicateHandle, SetHandleInformation, DUPLICATE_SAME_ACCESS, HANDLE, HANDLE_FLAG_INHERIT,
 };
 use windows_sys::Win32::System::Threading::{
-    CreateProcessW, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
-    EXTENDED_STARTUPINFO_PRESENT, PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
-    STARTF_USESTDHANDLES, STARTUPINFOEXW, STARTUPINFOW,
+    CreateProcessW, GetCurrentProcess, InitializeProcThreadAttributeList,
+    UpdateProcThreadAttribute, EXTENDED_STARTUPINFO_PRESENT, PROCESS_INFORMATION,
+    PROC_THREAD_ATTRIBUTE_HANDLE_LIST, STARTF_USESTDHANDLES, STARTUPINFOEXW, STARTUPINFOW,
 };
 
 use crate::config::PtyConfig;
@@ -22,44 +21,39 @@ use crate::tty::windows::{cmdline, win32_string, Pty};
 
 /// RAII Pseudoconsole.
 pub struct Conpty {
-    pub handle: HPCON,
+    conin: miow::pipe::AnonWrite,
 }
 
 impl Drop for Conpty {
-    fn drop(&mut self) {
-        // XXX: This will block until the conout pipe is drained. Will cause a deadlock if the
-        // conout pipe has already been dropped by this point.
-        //
-        // See PR #3084 and https://docs.microsoft.com/en-us/windows/console/closepseudoconsole.
-        unsafe { ClosePseudoConsole(self.handle) }
-    }
+    fn drop(&mut self) {}
 }
 
 // The ConPTY handle can be sent between threads.
 unsafe impl Send for Conpty {}
 
 pub fn new(config: &PtyConfig, window_size: WindowSize) -> Option<Pty> {
-    let mut pty_handle: HPCON = 0;
-
     // Passing 0 as the size parameter allows the "system default" buffer
     // size to be used. There may be small performance and memory advantages
     // to be gained by tuning this in the future, but it's likely a reasonable
     // start point.
     let (conout, conout_pty_handle) = miow::pipe::anonymous(0).unwrap();
-    let (conin_pty_handle, conin) = miow::pipe::anonymous(0).unwrap();
+    let (conin_pty_handle, mut conin) = miow::pipe::anonymous(0).unwrap();
 
-    // Create the Pseudo Console, using the pipes.
-    let result = unsafe {
-        CreatePseudoConsole(
-            window_size.into(),
-            conin_pty_handle.into_raw_handle() as HANDLE,
-            conout_pty_handle.into_raw_handle() as HANDLE,
-            0,
-            &mut pty_handle as *mut _,
-        )
+    let failure = unsafe {
+        SetHandleInformation(conout_pty_handle.as_raw_handle() as _, HANDLE_FLAG_INHERIT, 1)
     };
 
-    assert_eq!(result, S_OK);
+    if failure == 0 {
+        panic_shell_spawn();
+    }
+
+    let failure = unsafe {
+        SetHandleInformation(conin_pty_handle.as_raw_handle() as _, HANDLE_FLAG_INHERIT, 1)
+    };
+
+    if failure == 0 {
+        panic_shell_spawn();
+    }
 
     let mut success;
 
@@ -73,8 +67,10 @@ pub fn new(config: &PtyConfig, window_size: WindowSize) -> Option<Pty> {
 
     startup_info_ex.StartupInfo.cb = mem::size_of::<STARTUPINFOEXW>() as u32;
 
-    // Setting this flag but leaving all the handles as default (null) ensures the
-    // PTY process does not inherit any handles from this Alacritty process.
+    startup_info_ex.StartupInfo.hStdError = conout_pty_handle.into_raw_handle() as _;
+    startup_info_ex.StartupInfo.hStdOutput = startup_info_ex.StartupInfo.hStdError;
+    startup_info_ex.StartupInfo.hStdInput = conin_pty_handle.into_raw_handle() as _;
+
     startup_info_ex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
 
     // Create the appropriately sized thread attribute list.
@@ -114,14 +110,17 @@ pub fn new(config: &PtyConfig, window_size: WindowSize) -> Option<Pty> {
         }
     }
 
-    // Set thread attribute list's Pseudo Console to the specified ConPTY.
+    let mut inherit_handles =
+        vec![startup_info_ex.StartupInfo.hStdOutput, startup_info_ex.StartupInfo.hStdInput];
+
+    // Set thread attribute list's handle list to the new stdin and stdout.
     unsafe {
         success = UpdateProcThreadAttribute(
             startup_info_ex.lpAttributeList,
             0,
-            PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE as usize,
-            pty_handle as *mut std::ffi::c_void,
-            mem::size_of::<HPCON>(),
+            PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
+            inherit_handles.as_mut_ptr() as *mut std::ffi::c_void,
+            mem::size_of::<HANDLE>() * inherit_handles.len(),
             ptr::null_mut(),
             ptr::null_mut(),
         ) > 0;
@@ -141,7 +140,7 @@ pub fn new(config: &PtyConfig, window_size: WindowSize) -> Option<Pty> {
             cmdline.as_ptr() as PWSTR,
             ptr::null_mut(),
             ptr::null_mut(),
-            false as i32,
+            true as i32,
             EXTENDED_STARTUPINFO_PRESENT,
             ptr::null_mut(),
             cwd.as_ref().map_or_else(ptr::null, |s| s.as_ptr()),
@@ -154,13 +153,50 @@ pub fn new(config: &PtyConfig, window_size: WindowSize) -> Option<Pty> {
         }
     }
 
-    let conin = EventedAnonWrite::new(conin);
+    let mut conpty = Conpty { conin: dup_pipe(&conin) };
+    conpty.on_resize(window_size);
+
+    let (mut alacout, conin_internal) = miow::pipe::anonymous(0).unwrap();
+    std::thread::spawn(move || {
+        let mut buffer = [0; 512];
+        while let Ok(read) = alacout.read(&mut buffer) {
+            let mut start = 0;
+            while let Some(next_tick) = buffer[start..read].iter().position(|&x| x == b'`') {
+                conin.write_all(&buffer[start..next_tick + 1]).unwrap();
+                conin.write_all(b"`").unwrap();
+                start += next_tick + 1;
+            }
+            conin.write_all(&buffer[start..read]).unwrap();
+        }
+    });
+
+    let conin = EventedAnonWrite::new(conin_internal);
     let conout = EventedAnonRead::new(conout);
 
     let child_watcher = ChildExitWatcher::new(proc_info.hProcess).unwrap();
-    let conpty = Conpty { handle: pty_handle as HPCON };
 
     Some(Pty::new(conpty, conout, conin, child_watcher))
+}
+
+fn dup_pipe(pipe: &miow::pipe::AnonWrite) -> miow::pipe::AnonWrite {
+    unsafe {
+        let mut new_handle: HANDLE = mem::zeroed();
+        let success = DuplicateHandle(
+            GetCurrentProcess(),
+            pipe.as_raw_handle() as HANDLE,
+            GetCurrentProcess(),
+            &mut new_handle as *mut HANDLE,
+            0,
+            false as i32,
+            DUPLICATE_SAME_ACCESS,
+        ) != 0;
+
+        if !success {
+            panic_shell_spawn();
+        }
+
+        miow::pipe::AnonWrite::from_raw_handle(new_handle as _)
+    }
 }
 
 // Panic with the last os error as message.
@@ -170,15 +206,7 @@ fn panic_shell_spawn() {
 
 impl OnResize for Conpty {
     fn on_resize(&mut self, window_size: WindowSize) {
-        let result = unsafe { ResizePseudoConsole(self.handle, window_size.into()) };
-        assert_eq!(result, S_OK);
-    }
-}
-
-impl From<WindowSize> for COORD {
-    fn from(window_size: WindowSize) -> Self {
-        let lines = window_size.num_lines;
-        let columns = window_size.num_cols;
-        COORD { X: columns as i16, Y: lines as i16 }
+        let pkt = format!("`r{}:{};", window_size.num_cols, window_size.num_lines);
+        self.conin.write_all(pkt.as_bytes()).unwrap();
     }
 }


### PR DESCRIPTION
The purpose of this PR is to explore the possibility of circumventing ConPTY for wsl on windows. This is my first real rust code, and it's been years since I touched the windows api. It's a best effort and any comments ar appreciated.

With that out of the way. I've been having some issues with the vim scrolling in wsl and being unable to use color 0 (black). It turns out that both issues are caused by ConPTY parsing the VTE codes from linux, breaking them in the process. It turns out that alacritty isn't the first project to have that issue. Mintty for example solved that in their [wsltty](https://github.com/mintty/wsltty) project by using a project called [wslbridge2](https://github.com/Biswa96/wslbridge2) that, using some undocumented COM objects and a process on either side of the wsl vm, redirects the terminal through some AF_VSOCK sockets, circumventing ConPTY. It works a treat, but it seems a little complicated and brittle to me. Unfortunately wslbridge is tied to cygwin, so it's not easily usable from rust and therefore not directly applicable to alacritty.

Another interesting project that has a solution to the ConPTY problem is [terminalpp](https://github.com/terminalpp/terminalpp). I've never heard of the terminal, but they have a subproject called [tpp-bypass](https://github.com/terminalpp/terminalpp/tree/master/tpp-bypass) which smuggles the raw terminal connection inside the stdin and stdout stream of wsl, no ConPTY involved at all. This project also avoids any external channel for resizes by encoding that control information inside the input stream of the linux pty. This design means it only needs a single executable on the linux side to establish and forward the pty.

I've tried to implement a backend for alacritty that can talk to tpp-bypass. That's the code you see in this PR. The pty output stream is passed directly to alacritty whereas the input stream is redirected through a thread that escapes the characters that need escaping. There may be some race condition between that thread and resize, but that could be solved with a mutex.

To test this out you'll need to compile tpp-bypass for your wsl distro. Be aware that the directions in the tpp-bypass repo do not work. You have to run cmake in the root directory, and then copy the stamp.h file into the tpp-bypass subdirectory.

With tpp-bypass installed into your `/home/<username>/.local/bin` folder you can run this backend with the commandline `alacritty.exe -e "wsl -e /home/<username>/.local/bin/tpp-bypass TERM=alacritty"` to connect directly to your wsl terminal without ConPTY.

To reiterate. This isn't ready for merging, but I'm looking for comments on style and direction. I think this could resolve a lot of VTE related issues on windows, but I will admit it's a bit of a hack.