### PR TITLE
Apply 'font.glyph_offset.y' for underline/strikeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Uppercase `-T` short form for `--title`
 
+### Changed
+
+- `font.glyph_offset.y` is now applied to underline/strikeout
+
 ### Fixed
 
 - `--help` output for `--class` does not match man pages

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -833,7 +833,7 @@ impl Display {
             );
         }
 
-        let mut rects = lines.rects(&metrics, &size_info);
+        let mut rects = lines.rects(&metrics, &size_info, config.font.glyph_offset);
 
         if let Some(vi_cursor_point) = vi_cursor_point {
             // Indicate vi mode by showing the cursor's position in the top right corner.
@@ -1111,7 +1111,12 @@ impl Display {
 
         // Add underline for preedit text.
         let underline = RenderLine { start, end, color: fg };
-        rects.extend(underline.rects(Flags::UNDERLINE, &metrics, &self.size_info));
+        rects.extend(underline.rects(
+            Flags::UNDERLINE,
+            &metrics,
+            &self.size_info,
+            config.font.glyph_offset,
+        ));
 
         let ime_popup_point = match preedit.cursor_end_offset {
             Some(cursor_end_offset) if cursor_end_offset != 0 => {

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -8,6 +8,7 @@ use alacritty_terminal::index::{Column, Point};
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::color::Rgb;
 
+use crate::config::ui_config::Delta;
 use crate::display::content::RenderableCell;
 use crate::display::SizeInfo;
 use crate::gl;
@@ -51,25 +52,33 @@ pub enum RectKind {
 }
 
 impl RenderLine {
-    pub fn rects(&self, flag: Flags, metrics: &Metrics, size: &SizeInfo) -> Vec<RenderRect> {
+    pub fn rects(
+        &self,
+        flag: Flags,
+        metrics: &Metrics,
+        size: &SizeInfo,
+        offset: Delta<i8>,
+    ) -> Vec<RenderRect> {
         let mut rects = Vec::new();
 
         let mut start = self.start;
         while start.line < self.end.line {
             let end = Point::new(start.line, size.last_column());
-            Self::push_rects(&mut rects, metrics, size, flag, start, end, self.color);
+            Self::push_rects(&mut rects, metrics, size, offset, flag, start, end, self.color);
             start = Point::new(start.line + 1, Column(0));
         }
-        Self::push_rects(&mut rects, metrics, size, flag, start, self.end, self.color);
+        Self::push_rects(&mut rects, metrics, size, offset, flag, start, self.end, self.color);
 
         rects
     }
 
     /// Push all rects required to draw the cell's line.
+    #[allow(clippy::too_many_arguments)]
     fn push_rects(
         rects: &mut Vec<RenderRect>,
         metrics: &Metrics,
         size: &SizeInfo,
+        offset: Delta<i8>,
         flag: Flags,
         start: Point<usize>,
         end: Point<usize>,
@@ -83,6 +92,7 @@ impl RenderLine {
 
                 rects.push(Self::create_rect(
                     size,
+                    offset,
                     metrics.descent,
                     start,
                     end,
@@ -111,15 +121,25 @@ impl RenderLine {
             _ => unimplemented!("Invalid flag for cell line drawing specified"),
         };
 
-        let mut rect =
-            Self::create_rect(size, metrics.descent, start, end, position, thickness, color);
+        let mut rect = Self::create_rect(
+            size,
+            offset,
+            metrics.descent,
+            start,
+            end,
+            position,
+            thickness,
+            color,
+        );
         rect.kind = ty;
         rects.push(rect);
     }
 
     /// Create a line's rect at a position relative to the baseline.
+    #[allow(clippy::too_many_arguments)]
     fn create_rect(
         size: &SizeInfo,
+        offset: Delta<i8>,
         descent: f32,
         start: Point<usize>,
         end: Point<usize>,
@@ -137,7 +157,7 @@ impl RenderLine {
         let line_bottom = (start.line as f32 + 1.) * size.cell_height();
         let baseline = line_bottom + descent;
 
-        let mut y = (baseline - position - thickness / 2.).round();
+        let mut y = (baseline - position - offset.y as f32 - thickness / 2.).round();
         let max_y = line_bottom - thickness;
         if y > max_y {
             y = max_y;
@@ -167,11 +187,11 @@ impl RenderLines {
     }
 
     #[inline]
-    pub fn rects(&self, metrics: &Metrics, size: &SizeInfo) -> Vec<RenderRect> {
+    pub fn rects(&self, metrics: &Metrics, size: &SizeInfo, offset: Delta<i8>) -> Vec<RenderRect> {
         self.inner
             .iter()
             .flat_map(|(flag, lines)| {
-                lines.iter().flat_map(move |line| line.rects(*flag, metrics, size))
+                lines.iter().flat_map(move |line| line.rects(*flag, metrics, size, offset))
             })
             .collect()
     }


### PR DESCRIPTION
Fixes #6561.