### PR TITLE
Disable depth and stencil buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Blurry fonts when changing padding size at runtime
 - Crash while typing on Wayland
 - Multi-line semantic bracket selection
+- Reduced GPU memory usage
 
 ## 0.11.0
 

--- a/alacritty/src/renderer/platform.rs
+++ b/alacritty/src/renderer/platform.rs
@@ -42,7 +42,10 @@ pub fn pick_gl_config(
     gl_display: &Display,
     raw_window_handle: Option<RawWindowHandle>,
 ) -> Result<Config, String> {
-    let mut default_config = ConfigTemplateBuilder::new().with_transparency(true);
+    let mut default_config = ConfigTemplateBuilder::new()
+        .with_depth_size(0)
+        .with_stencil_size(0)
+        .with_transparency(true);
 
     if let Some(raw_window_handle) = raw_window_handle {
         default_config = default_config.compatible_with_native_window(raw_window_handle);


### PR DESCRIPTION
This patch reduces the active GPU memory consumption by disabling the depth and stencil buffers. During original testing it reduced GPU memory usage on Linux by almost a third.

This is a reintroduction of previously reverted patch 3475e44.

Closes #2881.