### PR TITLE
Use sRGB color space for NSWindow on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - `font.glyph_offset.y` is now applied to underline/strikeout
+- Always use sRGB color space on macOS
 
 ### Fixed
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -26,18 +26,18 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 #[cfg(target_os = "macos")]
-use cocoa::base::{nil, id, NO, YES};
-#[cfg(target_os = "macos")]
-use cocoa::appkit::NSColorSpace;
-#[cfg(target_os = "macos")]
-use objc::{msg_send, sel, sel_impl};
+use {
+    cocoa::appkit::NSColorSpace,
+    cocoa::base::{id, nil, NO, YES},
+    objc::{msg_send, sel, sel_impl},
+    winit::platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS},
+};
+
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event_loop::EventLoopWindowTarget;
 use winit::monitor::MonitorHandle;
-#[cfg(target_os = "macos")]
-use winit::platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS};
 #[cfg(windows)]
 use winit::platform::windows::IconExtWindows;
 use winit::window::{

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -167,7 +167,7 @@ impl Window {
         window.set_ime_allowed(true);
 
         #[cfg(target_os = "macos")]
-        macos_use_srgb_color_space(&window);
+        use_srgb_color_space(&window);
 
         #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
         if !is_wayland {
@@ -466,7 +466,7 @@ fn x_embed_window(window: &WinitWindow, parent_id: std::os::raw::c_ulong) {
 }
 
 #[cfg(target_os = "macos")]
-fn macos_use_srgb_color_space(window: &WinitWindow) {
+fn use_srgb_color_space(window: &WinitWindow) {
     let raw_window = match window.raw_window_handle() {
         RawWindowHandle::AppKit(handle) => handle.ns_window as id,
         _ => return,


### PR DESCRIPTION
This is the same change as https://github.com/kovidgoyal/kitty/commit/368bc91eed446daf9c32dfbce8aec718ebb1201d (also relevant: https://github.com/kovidgoyal/kitty/issues/4686)
I confirmed that now the rendered color is exactly the same as Kitty.

I think it makes sense to make the default color space sRGB since other popular terminals are using sRGB by default including Kitty and iTerm.
Also showing the same color as web browser, which is using sRGB, is beneficial for several apps such as [nvim-colorizer.lua](https://github.com/norcalli/nvim-colorizer.lua) while doing web development.


Closes https://github.com/alacritty/alacritty/issues/4939

## Verification on MacBook
I tested on MacBook Pro 14 inch, 2021 with [pastel](https://github.com/sharkdp/pastel)

- master (2bd26fbeb0c51cd8a98ae31d58ea105d1274387a)
  -  We see that digital color meter (sRGB) is "out of range"
  - <img width="862" alt="master" src="https://user-images.githubusercontent.com/2931577/210383032-df061b89-bde6-40a6-8f6b-2996560a4df9.png">

- this PR
  -  We see the color is different from master and digital color meter (sRGB) is showing the "correct" value, which was the same value as the one shown on Kitty / iTerm (tested with the same pastel command) and Apple Safari (tested with `<div style="background-color: #398810;">X</div>`)
  - <img width="862" alt="fixed" src="https://user-images.githubusercontent.com/2931577/210383082-e3aa7954-31fb-4e74-be7c-be17e637939c.png">


## Concerns
~Although I am personally happy with this patch since I am familiar with sRGB more than other color space (had no idea about P3 initially), this will be "breaking change" and some of macOS users will be unhappy due to changed colors for their colorscheme although changed one should be more consistent with other terminals. Actually it looks like Kitty made this configurable via `macos_colorspace` option so that people can still choose other color space such as P3 via configuration option.~

~Before merging this patch, we might need more discussions / considerations. (cf. https://github.com/kovidgoyal/kitty/issues/4686)~

UPDATE: Now I think this change is "correct" and we actually should not have configuration option to switch color space like kitty does (Kitty's `macos_colorspace` option). Terminal apps do not need to be such "rich" in color config. Simply we should just follow common accepted color space both in terminal world and web platform world, which is sRGB. See https://github.com/alacritty/alacritty/pull/6602#issuecomment-1374421852