### PR TITLE
add action DuplicateInstance

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -180,6 +180,9 @@ pub enum Action {
     /// Spawn a new instance of Alacritty.
     SpawnNewInstance,
 
+    /// Duplicate instance of Alacritty.
+    DuplicateInstance,
+
     /// Create a new Alacritty window.
     CreateNewWindow,
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -400,6 +400,28 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.spawn_daemon(&alacritty, &args);
     }
 
+    fn duplicate_instance(&mut self) {
+        let mut env_args = env::args();
+        let alacritty = env_args.next().unwrap();
+
+        let mut args: Vec<String> = Vec::new();
+
+        // Reuse the arguments passed to Alacritty for the new instance.
+        #[allow(clippy::while_let_on_iterator)]
+        while let Some(arg) = env_args.next() {
+            // On unix, the working directory of the foreground shell is used by `start_daemon`.
+            #[cfg(not(windows))]
+            if arg == "--working-directory" {
+                let _ = env_args.next();
+                continue;
+            }
+
+            args.push(arg);
+        }
+
+        self.spawn_daemon(&alacritty, &args);
+    }
+
     #[cfg(not(windows))]
     fn create_new_window(&mut self) {
         let mut options = WindowOptions::default();

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -81,6 +81,7 @@ pub trait ActionContext<T: EventListener> {
     fn terminal(&self) -> &Term<T>;
     fn terminal_mut(&mut self) -> &mut Term<T>;
     fn spawn_new_instance(&mut self) {}
+    fn duplicate_instance(&mut self) {}
     fn create_new_window(&mut self) {}
     fn change_font_size(&mut self, _delta: f32) {}
     fn reset_font_size(&mut self) {}
@@ -343,6 +344,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
             Action::ClearLogNotice => ctx.pop_message(),
             Action::SpawnNewInstance => ctx.spawn_new_instance(),
+            Action::DuplicateInstance => ctx.duplicate_instance(),
             Action::CreateNewWindow => ctx.create_new_window(),
             Action::ReceiveChar | Action::None => (),
         }


### PR DESCRIPTION
Added Action 'DuplicateInstance' wich spawns a new instance but inherits all args except --working-directory.
Useful when working with --command arguments.
Reaction to #6060 