### PR TITLE
Add .d convention for a configuration directory in bash completions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -376,6 +376,14 @@ cp extra/completions/alacritty.bash ~/.bash_completion/alacritty
 echo "source ~/.bash_completion/alacritty" >> ~/.bashrc
 ```
 
+Most Linux distributions consider that `~/.bash_completion` is a configuration file, not a configuration directory. To avoid name clashing, there is a convention for creating a configuration directory, and it is to add the suffix `.d` at the end of the directory `~/.bash_completion.d`. If you have any issue, you can run:
+
+```sh
+mkdir -p ~/.bash_completion.d
+cp extra/completions/alacritty.bash ~/.bash_completion.d/alacritty
+echo "source ~/.bash_completion.d/alacritty" >> ~/.bashrc
+```
+
 #### Fish
 
 To install the completions for fish, run


### PR DESCRIPTION
Hi,

## Intro
I was installing alacritty in Ubuntu 20.04 LTS and when I add the bash completions, every time that I opened the terminal, the next message was shown.

 **bash: .: /home/<my_user>/.bash_completion: is a directory**
 
## Solution
So, the way that I solved this, was by adding the suffix `.d` to the configuration directory `.bash_completion`. Like this `.bash_completion.d` 

```sh
mkdir -p ~/.bash_completion.d
cp extra/completions/alacritty.bash ~/.bash_completion.d/alacritty
echo "source ~/.bash_completion.d/alacritty" >> ~/.bashrc
```

The reason to do that was because most of Linux distributions consider `.bash_completion` as a configuration file not a configuration directory.

## Conclusion
I think this may be helpful for people when installing alacritty and the bash completions.

Thanks for your time