### PR TITLE
Fix notify doing active polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "glutin",
  "libc",
  "log",
- "notify-debouncer-mini",
+ "notify",
  "objc",
  "once_cell",
  "parking_lot 0.12.1",
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
+checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -1162,16 +1162,7 @@ dependencies = [
  "libc",
  "mio 0.8.4",
  "walkdir",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "notify-debouncer-mini"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23e9fa24f094b143c1eb61f90ac6457de87be6987bc70746e0179f7dbc9007b"
-dependencies = [
- "notify",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2054,6 +2045,21 @@ dependencies = [
  "windows_i686_msvc 0.36.1",
  "windows_x86_64_gnu 0.36.1",
  "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.8"
 serde_json = "1"
 glutin = { version = "0.30.3", default-features = false, features = ["egl", "wgl"] }
 winit = { version = "0.28.0", default-features = false, features = ["serde"] }
-notify-debouncer-mini = { version = "0.2.1", default-features = false }
+notify = "5.1.0"
 parking_lot = "0.12.0"
 crossfont = { version = "0.5.0", features = ["force_system_fontconfig"] }
 copypasta = { version = "0.8.1", default-features = false }


### PR DESCRIPTION
The `notify-debouncer-mini` spawn a thread which checks the events every timeout, which is not desired since we want to avoid active polling.

This commit re-implements debouncer based on the `RecommendedWatcher` without adding an extra thread on top and not doing any busy-waiting.

Fixes #6652.