### PR TITLE
Optional fallback font support natively in Alacritty (ie. support NerdFont symbols with any font)

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -155,7 +155,14 @@
     #family: monospace
 
     # The `style` can be specified to pick a specific face.
-    #style: Bold Italic
+# 
+  # Fallback font used for glphs that cannot be found in normal font
+  #fallback:
+    # Font family
+    #
+    # If the fallback family is not specified, it will fall back to the
+    # value specified for the normal font.
+    #family: Hasklug Nerd Font
 
   # Point size
   #size: 11.0

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -155,7 +155,8 @@
     #family: monospace
 
     # The `style` can be specified to pick a specific face.
-# 
+    #style: Bold Italic
+ 
   # Fallback font used for glphs that cannot be found in normal font
   #fallback:
     # Font family

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -37,6 +37,9 @@ pub struct Font {
     /// Bold italic font face.
     bold_italic: SecondaryFontDescription,
 
+    /// Fallback symbol font face.
+    fallback: SecondaryFontDescription,
+
     /// Font size in points.
     size: Size,
 
@@ -74,6 +77,11 @@ impl Font {
     pub fn bold_italic(&self) -> FontDescription {
         self.bold_italic.desc(&self.normal)
     }
+
+    /// Get fallback font description.
+    pub fn fallback(&self) -> FontDescription {
+        self.fallback.desc(&self.normal)
+    }
 }
 
 impl Default for Font {
@@ -87,6 +95,7 @@ impl Default for Font {
             offset: Default::default(),
             normal: Default::default(),
             bold: Default::default(),
+            fallback: Default::default(),
             size: Default::default(),
         }
     }


### PR DESCRIPTION
Patching fonts with extra symbols can be a pain (unless a pre-patched NerdFont is already available).  Even then, the patched font is not exactly the same as the original.  OS level fallback font configuration may be possible with Linux, but is not viable with MacOS and difficult to figure out with Windows.  Adding support for an optional fallback font directly in Alacritty makes life easier for those of us who use shiny n/vim/tmux configurations.  All that is needed is a single installed NerdFont specified as the fallback, and all of the NF symbols become available across all system fonts.

A couple notes on these changes:
1. No effort has been made to match the top/bottom offsets of the symbols used for power line symbols.  This is not needed since native support for those will be included in Alacritty going forward.
2. I tried to keep the changes minimal and straightforward.  This is my first time with Rust, so I'm guessing there may be a more elegant way to handle the main logic.  Feedback is very much appreciated.