### PR TITLE
Fix: Set IME purpose before enable

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -172,8 +172,8 @@ impl Window {
         window.set_cursor_icon(current_mouse_cursor);
 
         // Enable IME.
-        window.set_ime_allowed(true);
         window.set_ime_purpose(ImePurpose::Terminal);
+        window.set_ime_allowed(true);
 
         // Set initial transparency hint.
         window.set_transparent(config.window_opacity() < 1.);


### PR DESCRIPTION
@kchibisov, thanks for releasing winit and updating alacritty.

As I understood, setting the IME purpose after enabling may have no effect, so simply do it before enabling.