### PR TITLE
Update ndk-sys to workaround cargo checksum issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,9 +1094,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.4.0"
+version = "0.4.1+23.1.7779620"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d83ec9c63ec5bf950200a8e508bdad6659972187b625469f58ef8c08e29046"
+checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
 dependencies = [
  "jni-sys",
 ]


### PR DESCRIPTION
This causes sporadic errors when fetching dependencies, especially in clean sandboxed build like Nix.
See https://github.com/rust-lang/cargo/issues/11412

> The package [ndk-sys](https://crates.io/crates/ndk-sys) has a latest version 0.4.0 and a more recent yanked version 0.4.0+25.0.8775105. Cargo is downloading the 0.4.0 crate, but comparing the hash with the checksum of the yanked version, and therefore failing with a "failed to verify checksum of ndk-sys v0.4.0" error.

