### PR TITLE
Resize the window by cell dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `window.decorations_theme_variant` could now control theme on macOS and Windows
 - The IME purpose is now set to `Terminal` which could help with OSK
 - `window.decorations_theme_variant` is now using `Dark`, `Light`, and `None` values
+- Resize increments are now set on macOS and X11 to resize by cell sizes
 
 ### Fixed
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -469,6 +469,9 @@ impl Display {
             renderer.finish();
         }
 
+        // Set resize increments for the newly created window.
+        window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
+
         window.set_visible(true);
 
         #[allow(clippy::single_match)]
@@ -641,6 +644,9 @@ impl Display {
         let message_bar_lines = message_buffer.message().map_or(0, |m| m.text(&new_size).len());
         let search_lines = usize::from(search_active);
         new_size.reserve_lines(message_bar_lines + search_lines);
+
+        // Update resize increments.
+        self.window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
 
         // Resize PTY.
         pty_resize_handle.on_resize(new_size.into());

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -353,6 +353,10 @@ impl Window {
         self.window.set_minimized(minimized);
     }
 
+    pub fn set_resize_increments(&self, increments: PhysicalSize<f32>) {
+        self.window.set_resize_increments(Some(increments));
+    }
+
     /// Toggle the window's fullscreen state.
     pub fn toggle_fullscreen(&self) {
         self.set_fullscreen(self.window.fullscreen().is_none());


### PR DESCRIPTION
This should resize window by cell dimensions granularity instead of using pixels.

Fixes #388.

--

Probably will need a config option for that, idk, given that it might not be desirable behavior for everyone.

It works fine on both macOS/GNOME.