### PR TITLE
Revert "Apply 'font.glyph_offset.y' for underline/strikeout"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- `font.glyph_offset.y` is now applied to underline/strikeout
 - Always use sRGB color space on macOS
 - Erase in line after the last column will no longer clear the last column
 - Open new windows by default with macOS `Cmd`+`N` binding

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -841,7 +841,7 @@ impl Display {
             );
         }
 
-        let mut rects = lines.rects(&metrics, &size_info, config.font.glyph_offset);
+        let mut rects = lines.rects(&metrics, &size_info);
 
         if let Some(vi_cursor_point) = vi_cursor_point {
             // Indicate vi mode by showing the cursor's position in the top right corner.
@@ -1126,12 +1126,7 @@ impl Display {
 
         // Add underline for preedit text.
         let underline = RenderLine { start, end, color: fg };
-        rects.extend(underline.rects(
-            Flags::UNDERLINE,
-            &metrics,
-            &self.size_info,
-            config.font.glyph_offset,
-        ));
+        rects.extend(underline.rects(Flags::UNDERLINE, &metrics, &self.size_info));
 
         let ime_popup_point = match preedit.cursor_end_offset {
             Some(cursor_end_offset) if cursor_end_offset != 0 => {

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -8,7 +8,6 @@ use alacritty_terminal::index::{Column, Point};
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::color::Rgb;
 
-use crate::config::ui_config::Delta;
 use crate::display::content::RenderableCell;
 use crate::display::SizeInfo;
 use crate::gl;
@@ -52,33 +51,25 @@ pub enum RectKind {
 }
 
 impl RenderLine {
-    pub fn rects(
-        &self,
-        flag: Flags,
-        metrics: &Metrics,
-        size: &SizeInfo,
-        offset: Delta<i8>,
-    ) -> Vec<RenderRect> {
+    pub fn rects(&self, flag: Flags, metrics: &Metrics, size: &SizeInfo) -> Vec<RenderRect> {
         let mut rects = Vec::new();
 
         let mut start = self.start;
         while start.line < self.end.line {
             let end = Point::new(start.line, size.last_column());
-            Self::push_rects(&mut rects, metrics, size, offset, flag, start, end, self.color);
+            Self::push_rects(&mut rects, metrics, size, flag, start, end, self.color);
             start = Point::new(start.line + 1, Column(0));
         }
-        Self::push_rects(&mut rects, metrics, size, offset, flag, start, self.end, self.color);
+        Self::push_rects(&mut rects, metrics, size, flag, start, self.end, self.color);
 
         rects
     }
 
     /// Push all rects required to draw the cell's line.
-    #[allow(clippy::too_many_arguments)]
     fn push_rects(
         rects: &mut Vec<RenderRect>,
         metrics: &Metrics,
         size: &SizeInfo,
-        offset: Delta<i8>,
         flag: Flags,
         start: Point<usize>,
         end: Point<usize>,
@@ -92,7 +83,6 @@ impl RenderLine {
 
                 rects.push(Self::create_rect(
                     size,
-                    offset,
                     metrics.descent,
                     start,
                     end,
@@ -121,25 +111,15 @@ impl RenderLine {
             _ => unimplemented!("Invalid flag for cell line drawing specified"),
         };
 
-        let mut rect = Self::create_rect(
-            size,
-            offset,
-            metrics.descent,
-            start,
-            end,
-            position,
-            thickness,
-            color,
-        );
+        let mut rect =
+            Self::create_rect(size, metrics.descent, start, end, position, thickness, color);
         rect.kind = ty;
         rects.push(rect);
     }
 
     /// Create a line's rect at a position relative to the baseline.
-    #[allow(clippy::too_many_arguments)]
     fn create_rect(
         size: &SizeInfo,
-        offset: Delta<i8>,
         descent: f32,
         start: Point<usize>,
         end: Point<usize>,
@@ -157,7 +137,7 @@ impl RenderLine {
         let line_bottom = (start.line as f32 + 1.) * size.cell_height();
         let baseline = line_bottom + descent;
 
-        let mut y = (baseline - position - offset.y as f32 - thickness / 2.).round();
+        let mut y = (baseline - position - thickness / 2.).round();
         let max_y = line_bottom - thickness;
         if y > max_y {
             y = max_y;
@@ -187,11 +167,11 @@ impl RenderLines {
     }
 
     #[inline]
-    pub fn rects(&self, metrics: &Metrics, size: &SizeInfo, offset: Delta<i8>) -> Vec<RenderRect> {
+    pub fn rects(&self, metrics: &Metrics, size: &SizeInfo) -> Vec<RenderRect> {
         self.inner
             .iter()
             .flat_map(|(flag, lines)| {
-                lines.iter().flat_map(move |line| line.rects(*flag, metrics, size, offset))
+                lines.iter().flat_map(move |line| line.rects(*flag, metrics, size))
             })
             .collect()
     }


### PR DESCRIPTION
This reverts commit d5e9d1d88317afc1f4374f2c2a7679cece14cb7b.