### PR TITLE
Add touch input support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for horizontal scrolling in mouse mode and alternative scrolling modes
 - Support for fractional scaling on Wayland with wp-fractional-scale protocol
 - Support for running on GLES context
+- Touchscreen input for click/scroll/select/zoom
 
 ### Changed
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 use std::cmp::{max, min};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt::Debug;
@@ -19,7 +19,8 @@ use log::{debug, error, info, warn};
 use wayland_client::{Display as WaylandDisplay, EventQueue};
 use winit::dpi::PhysicalSize;
 use winit::event::{
-    ElementState, Event as WinitEvent, Ime, ModifiersState, MouseButton, StartCause, WindowEvent,
+    ElementState, Event as WinitEvent, Ime, ModifiersState, MouseButton, StartCause,
+    Touch as TouchEvent, WindowEvent,
 };
 use winit::event_loop::{
     ControlFlow, DeviceEventFilter, EventLoop, EventLoopProxy, EventLoopWindowTarget,
@@ -65,6 +66,9 @@ const MAX_SEARCH_WHILE_TYPING: Option<usize> = Some(1000);
 
 /// Maximum number of search terms stored in the history.
 const MAX_SEARCH_HISTORY_SIZE: usize = 255;
+
+/// Touch zoom speed.
+const TOUCH_ZOOM_FACTOR: f32 = 0.01;
 
 /// Alacritty events.
 #[derive(Debug, Clone)]
@@ -186,6 +190,7 @@ pub struct ActionContext<'a, N, T> {
     pub terminal: &'a mut Term<T>,
     pub clipboard: &'a mut Clipboard,
     pub mouse: &'a mut Mouse,
+    pub touch: &'a mut Touch,
     pub received_count: &'a mut usize,
     pub suppress_chars: &'a mut bool,
     pub modifiers: &'a mut ModifiersState,
@@ -336,6 +341,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[inline]
     fn mouse(&self) -> &Mouse {
         self.mouse
+    }
+
+    #[inline]
+    fn touch(&mut self) -> &mut Touch {
+        self.touch
     }
 
     #[inline]
@@ -1016,12 +1026,63 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum ClickState {
+/// Identified purpose of the touch input.
+#[derive(Default, Debug)]
+pub enum Touch {
+    #[default]
     None,
-    Click,
-    DoubleClick,
-    TripleClick,
+    Select(TouchEvent),
+    Scroll(TouchEvent),
+    Zoom(TouchZoom),
+    Tap(TouchEvent),
+    Invalid(HashSet<u64>),
+}
+
+/// Touch zooming state.
+#[derive(Debug)]
+pub struct TouchZoom {
+    slots: (TouchEvent, TouchEvent),
+    fractions: f32,
+}
+
+impl TouchZoom {
+    pub fn new(slots: (TouchEvent, TouchEvent)) -> Self {
+        Self { slots, fractions: Default::default() }
+    }
+
+    /// Get slot distance change since last update.
+    pub fn font_delta(&mut self, slot: TouchEvent) -> f32 {
+        let old_distance = self.distance();
+
+        // Update touch slots.
+        if slot.id == self.slots.0.id {
+            self.slots.0 = slot;
+        } else {
+            self.slots.1 = slot;
+        }
+
+        // Calculate font change in `FONT_SIZE_STEP` increments.
+        let delta = (self.distance() - old_distance) * TOUCH_ZOOM_FACTOR + self.fractions;
+        let font_delta = (delta.abs() / FONT_SIZE_STEP).floor() * FONT_SIZE_STEP * delta.signum();
+        self.fractions = delta - font_delta;
+
+        font_delta
+    }
+
+    /// Get active touch slots.
+    pub fn slots(&self) -> HashSet<u64> {
+        let mut set = HashSet::new();
+        set.insert(self.slots.0.id);
+        set.insert(self.slots.1.id);
+        set
+    }
+
+    /// Calculate distance between slots.
+    fn distance(&self) -> f32 {
+        let delta_x = self.slots.0.location.x - self.slots.1.location.x;
+        let delta_y = self.slots.0.location.y - self.slots.1.location.y;
+        delta_x.hypot(delta_y) as f32
+    }
 }
 
 /// State of the mouse.
@@ -1079,6 +1140,14 @@ impl Mouse {
 
         term::viewport_to_point(display_offset, Point::new(line, col))
     }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum ClickState {
+    None,
+    Click,
+    DoubleClick,
+    TripleClick,
 }
 
 /// The amount of scroll accumulated from the pointer events.
@@ -1217,6 +1286,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         self.ctx.window().set_mouse_visible(true);
                         self.mouse_wheel_input(delta, phase);
                     },
+                    WindowEvent::Touch(touch) => self.touch(touch),
                     WindowEvent::Focused(is_focused) => {
                         self.ctx.terminal.is_focused = is_focused;
 
@@ -1290,7 +1360,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     | WindowEvent::Destroyed
                     | WindowEvent::ThemeChanged(_)
                     | WindowEvent::HoveredFile(_)
-                    | WindowEvent::Touch(_)
                     | WindowEvent::Moved(_) => (),
                 }
             },
@@ -1592,7 +1661,6 @@ impl Processor {
                     | WindowEvent::HoveredFileCancelled
                     | WindowEvent::Destroyed
                     | WindowEvent::HoveredFile(_)
-                    | WindowEvent::Touch(_)
                     | WindowEvent::Moved(_)
             ),
             WinitEvent::Suspended { .. }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -190,7 +190,7 @@ pub struct ActionContext<'a, N, T> {
     pub terminal: &'a mut Term<T>,
     pub clipboard: &'a mut Clipboard,
     pub mouse: &'a mut Mouse,
-    pub touch: &'a mut Touch,
+    pub touch: &'a mut TouchPurpose,
     pub received_count: &'a mut usize,
     pub suppress_chars: &'a mut bool,
     pub modifiers: &'a mut ModifiersState,
@@ -344,7 +344,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     }
 
     #[inline]
-    fn touch(&mut self) -> &mut Touch {
+    fn touch_purpose(&mut self) -> &mut TouchPurpose {
         self.touch
     }
 
@@ -1028,7 +1028,7 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
 
 /// Identified purpose of the touch input.
 #[derive(Default, Debug)]
-pub enum Touch {
+pub enum TouchPurpose {
     #[default]
     None,
     Select(TouchEvent),

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1027,15 +1027,20 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
 }
 
 /// Identified purpose of the touch input.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub enum TouchPurpose {
-    #[default]
     None,
     Select(TouchEvent),
     Scroll(TouchEvent),
     Zoom(TouchZoom),
     Tap(TouchEvent),
     Invalid(HashSet<u64>),
+}
+
+impl Default for TouchPurpose {
+    fn default() -> Self {
+        Self::None
+    }
 }
 
 /// Touch zooming state.

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -38,7 +38,9 @@ use crate::config::{Action, BindingMode, Key, MouseAction, SearchAction, UiConfi
 use crate::display::hint::HintMatch;
 use crate::display::window::Window;
 use crate::display::{Display, SizeInfo};
-use crate::event::{ClickState, Event, EventType, Mouse, TouchPurpose, TouchZoom, TYPING_SEARCH_DELAY};
+use crate::event::{
+    ClickState, Event, EventType, Mouse, TouchPurpose, TouchZoom, TYPING_SEARCH_DELAY,
+};
 use crate::message_bar::{self, Message};
 use crate::scheduler::{Scheduler, TimerId, Topic};
 

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -42,7 +42,7 @@ use crate::clipboard::Clipboard;
 use crate::config::UiConfig;
 use crate::display::window::Window;
 use crate::display::Display;
-use crate::event::{ActionContext, Event, EventProxy, EventType, Mouse, SearchState};
+use crate::event::{ActionContext, Event, EventProxy, EventType, Mouse, SearchState, Touch};
 use crate::logging::LOG_TARGET_IPC_CONFIG;
 use crate::message_bar::MessageBuffer;
 use crate::scheduler::Scheduler;
@@ -62,6 +62,7 @@ pub struct WindowContext {
     notifier: Notifier,
     font_size: Size,
     mouse: Mouse,
+    touch: Touch,
     dirty: bool,
     occluded: bool,
     preserve_title: bool,
@@ -255,6 +256,7 @@ impl WindowContext {
             ipc_config: Default::default(),
             modifiers: Default::default(),
             mouse: Default::default(),
+            touch: Default::default(),
             dirty: Default::default(),
             occluded: Default::default(),
         })
@@ -441,6 +443,7 @@ impl WindowContext {
             notifier: &mut self.notifier,
             display: &mut self.display,
             mouse: &mut self.mouse,
+            touch: &mut self.touch,
             dirty: &mut self.dirty,
             occluded: &mut self.occluded,
             terminal: &mut terminal,

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -42,7 +42,7 @@ use crate::clipboard::Clipboard;
 use crate::config::UiConfig;
 use crate::display::window::Window;
 use crate::display::Display;
-use crate::event::{ActionContext, Event, EventProxy, EventType, Mouse, SearchState, Touch};
+use crate::event::{ActionContext, Event, EventProxy, EventType, Mouse, SearchState, TouchPurpose};
 use crate::logging::LOG_TARGET_IPC_CONFIG;
 use crate::message_bar::MessageBuffer;
 use crate::scheduler::Scheduler;
@@ -62,7 +62,7 @@ pub struct WindowContext {
     notifier: Notifier,
     font_size: Size,
     mouse: Mouse,
-    touch: Touch,
+    touch: TouchPurpose,
     dirty: bool,
     occluded: bool,
     preserve_title: bool,


### PR DESCRIPTION
This patch builds upon the prior work by @4z3 and @bytbox to add touchscreen support to Alacritty. While some inspiration was taken from @4z3's patch, it was rewritten from scratch.

This patch supports 4 basic touch interactions:
 - Tap
 - Scroll
 - Select
 - Zoom

Tap allows emulating the mouse to enter a single LMB click. While it would be possible to add more complicated mouse emulation including support for RMB and others, it's likely more confusing than anything else and could conflict with other more useful touch actions.

Scroll and Select are started by horizontal or vertical dragging. While selection isn't particularly accurate with a fat finger, it works reasonably well and the separation from selection through horizontal and vertical start feels pretty natural.

Since horizontal drag is reserved for selection we do not support horizontal scrolling inside the terminal. While it would be possible to somewhat support it by starting a selection with vertical movement and then scrolling horizontally afterwards, it would likely just confuse people so it was left out.

Zoom is pretty simple in just changing the font size when a two-finger pinch gesture is used. Performance of this is pretty terrible especially on low-end hardware since this obviously isn't a cheap operation, but it seems like a worthwhile addition since small touchscreen devices are most likely to need frequent font size adjustment to make output readable.

Closes #3671.