### PR TITLE
Implement basic smoothing of the cursor movement

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -425,6 +425,12 @@
   # Specifying '0' will disable timeout for blinking.
   #blink_timeout: 5
 
+  # Cursor movement smoothing factor
+  # Cursor position each frame is determined via `old_pos + (new_pos - old_pos) / factor`
+  # The more the factor - the slower the cursor movement. 0.0 turns smoothing off
+  # 'Block' cursor shape gets replaced with 'Undeline' if this is on
+  #smooth_factor: 0.0
+
   # If this is `true`, the cursor will be rendered as a hollow box when the
   # window is not focused.
   #unfocused_hollow: true

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -159,7 +159,7 @@ impl<'a> Iterator for RenderableContent<'a> {
             if self.cursor_point == cell.point {
                 // Store the cursor which should be rendered.
                 self.cursor = self.renderable_cursor(&cell);
-                if self.cursor.shape == CursorShape::Block {
+                if self.cursor.shape == CursorShape::Block && self.config.terminal_config.cursor.smooth_factor() == 0.0 {
                     cell.fg = self.cursor.text_color;
                     cell.bg = self.cursor.cursor_color;
 

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -159,7 +159,9 @@ impl<'a> Iterator for RenderableContent<'a> {
             if self.cursor_point == cell.point {
                 // Store the cursor which should be rendered.
                 self.cursor = self.renderable_cursor(&cell);
-                if self.cursor.shape == CursorShape::Block && self.config.terminal_config.cursor.smooth_factor() == 0.0 {
+                if self.cursor.shape == CursorShape::Block
+                    && self.config.terminal_config.cursor.smooth_factor() == 0.0
+                {
                     cell.fg = self.cursor.text_color;
                     cell.bg = self.cursor.cursor_color;
 

--- a/alacritty/src/display/cursor.rs
+++ b/alacritty/src/display/cursor.rs
@@ -37,8 +37,8 @@ impl IntoRects for RenderableCursor {
             *cx += (x - *cx) / smooth;
             *cy += (y - *cy) / smooth;
 
-            x = cx.clone();
-            y = cy.clone();
+            x = *cx;
+            y = *cy;
         }
 
         let mut width = size_info.cell_width();

--- a/alacritty/src/display/cursor.rs
+++ b/alacritty/src/display/cursor.rs
@@ -10,11 +10,25 @@ use crate::renderer::rects::RenderRect;
 /// Trait for conversion into the iterator.
 pub trait IntoRects {
     /// Consume the cursor for an iterator of rects.
-    fn rects(self, size_info: &SizeInfo, thickness: f32, smooth: f32, cx: &mut f32, cy: &mut f32) -> CursorRects;
+    fn rects(
+        self,
+        size_info: &SizeInfo,
+        thickness: f32,
+        smooth: f32,
+        cx: &mut f32,
+        cy: &mut f32,
+    ) -> CursorRects;
 }
 
 impl IntoRects for RenderableCursor {
-    fn rects(self, size_info: &SizeInfo, thickness: f32, smooth: f32, cx: &mut f32, cy: &mut f32) -> CursorRects {
+    fn rects(
+        self,
+        size_info: &SizeInfo,
+        thickness: f32,
+        smooth: f32,
+        cx: &mut f32,
+        cy: &mut f32,
+    ) -> CursorRects {
         let point = self.point();
         let mut x = point.column.0 as f32 * size_info.cell_width() + size_info.padding_x();
         let mut y = point.line as f32 * size_info.cell_height() + size_info.padding_y();
@@ -40,11 +54,13 @@ impl IntoRects for RenderableCursor {
             CursorShape::Beam => beam(x, y, height, thickness, self.color()),
             CursorShape::Underline => underline(x, y, width, height, thickness, self.color()),
             CursorShape::HollowBlock => hollow(x, y, width, height, thickness, self.color()),
-            _ => if smooth > 0.0 {
+            _ => {
+                if smooth > 0.0 {
                     underline(x, y, width, height, thickness, self.color())
                 } else {
                     CursorRects::default()
                 }
+            },
         }
     }
 }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -385,6 +385,9 @@ pub struct Display {
     next_frame_damage_rects: Vec<DamageRect>,
     glyph_cache: GlyphCache,
     meter: Meter,
+
+    cur_x: f32,
+    cur_y: f32
 }
 
 impl Display {
@@ -522,6 +525,8 @@ impl Display {
             damage_rects,
             next_frame_damage_rects,
             hint_mouse_point: None,
+            cur_x: 0.0,
+            cur_y: 0.0
         })
     }
 
@@ -856,7 +861,7 @@ impl Display {
         };
 
         // Draw cursor.
-        rects.extend(cursor.rects(&size_info, config.terminal_config.cursor.thickness()));
+        rects.extend(cursor.rects(&size_info, config.terminal_config.cursor.thickness(), config.terminal_config.cursor.smooth_factor(), &mut self.cur_x, &mut self.cur_y));
 
         // Push visual bell after url/underline/strikeout rects.
         let visual_bell_intensity = self.visual_bell.intensity();
@@ -895,7 +900,7 @@ impl Display {
                     let shape = CursorShape::Underline;
                     let cursor = RenderableCursor::new(Point::new(line, column), shape, fg, false);
                     rects.extend(
-                        cursor.rects(&size_info, config.terminal_config.cursor.thickness()),
+                        cursor.rects(&size_info, config.terminal_config.cursor.thickness(), config.terminal_config.cursor.smooth_factor(), &mut self.cur_x, &mut self.cur_y),
                     );
                 }
 
@@ -1143,7 +1148,7 @@ impl Display {
                 let cursor =
                     RenderableCursor::new(cursor_point, CursorShape::HollowBlock, fg, is_wide);
                 rects.extend(
-                    cursor.rects(&self.size_info, config.terminal_config.cursor.thickness()),
+                    cursor.rects(&self.size_info, config.terminal_config.cursor.thickness(), config.terminal_config.cursor.smooth_factor(), &mut self.cur_x, &mut self.cur_y),
                 );
                 cursor_point
             },

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -387,7 +387,7 @@ pub struct Display {
     meter: Meter,
 
     cur_x: f32,
-    cur_y: f32
+    cur_y: f32,
 }
 
 impl Display {
@@ -526,7 +526,7 @@ impl Display {
             next_frame_damage_rects,
             hint_mouse_point: None,
             cur_x: 0.0,
-            cur_y: 0.0
+            cur_y: 0.0,
         })
     }
 
@@ -861,7 +861,13 @@ impl Display {
         };
 
         // Draw cursor.
-        rects.extend(cursor.rects(&size_info, config.terminal_config.cursor.thickness(), config.terminal_config.cursor.smooth_factor(), &mut self.cur_x, &mut self.cur_y));
+        rects.extend(cursor.rects(
+            &size_info,
+            config.terminal_config.cursor.thickness(),
+            config.terminal_config.cursor.smooth_factor(),
+            &mut self.cur_x,
+            &mut self.cur_y,
+        ));
 
         // Push visual bell after url/underline/strikeout rects.
         let visual_bell_intensity = self.visual_bell.intensity();
@@ -899,9 +905,13 @@ impl Display {
                     let fg = config.colors.footer_bar_foreground();
                     let shape = CursorShape::Underline;
                     let cursor = RenderableCursor::new(Point::new(line, column), shape, fg, false);
-                    rects.extend(
-                        cursor.rects(&size_info, config.terminal_config.cursor.thickness(), config.terminal_config.cursor.smooth_factor(), &mut self.cur_x, &mut self.cur_y),
-                    );
+                    rects.extend(cursor.rects(
+                        &size_info,
+                        config.terminal_config.cursor.thickness(),
+                        config.terminal_config.cursor.smooth_factor(),
+                        &mut self.cur_x,
+                        &mut self.cur_y,
+                    ));
                 }
 
                 Some(Point::new(line, column))
@@ -1147,9 +1157,13 @@ impl Display {
                 let cursor_point = Point::new(point.line, cursor_column);
                 let cursor =
                     RenderableCursor::new(cursor_point, CursorShape::HollowBlock, fg, is_wide);
-                rects.extend(
-                    cursor.rects(&self.size_info, config.terminal_config.cursor.thickness(), config.terminal_config.cursor.smooth_factor(), &mut self.cur_x, &mut self.cur_y),
-                );
+                rects.extend(cursor.rects(
+                    &self.size_info,
+                    config.terminal_config.cursor.thickness(),
+                    config.terminal_config.cursor.smooth_factor(),
+                    &mut self.cur_x,
+                    &mut self.cur_y,
+                ));
                 cursor_point
             },
             _ => end,

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -493,6 +493,10 @@ impl WindowContext {
             return;
         }
 
+        if self.config.terminal_config.cursor.smooth_factor() > 0.0 {
+            self.dirty = true;
+        }
+
         if self.dirty && !self.occluded {
             // Force the display to process any pending display update.
             self.display.process_renderer_update();

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -78,6 +78,7 @@ pub struct Cursor {
     thickness: Percentage,
     blink_interval: u64,
     blink_timeout: u8,
+    smooth_factor: f32
 }
 
 impl Default for Cursor {
@@ -87,6 +88,7 @@ impl Default for Cursor {
             unfocused_hollow: true,
             blink_interval: 750,
             blink_timeout: 5,
+            smooth_factor: 0.0,
             style: Default::default(),
             vi_mode_style: Default::default(),
         }
@@ -123,6 +125,11 @@ impl Cursor {
                 cmp::max(self.blink_interval * 5 / MILLIS_IN_SECOND, blink_timeout as u64)
             },
         }
+    }
+
+    #[inline]
+    pub fn smooth_factor(self) -> f32 {
+        if self.smooth_factor > 0.0 { self.smooth_factor } else { 0.0 }
     }
 }
 

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -78,7 +78,7 @@ pub struct Cursor {
     thickness: Percentage,
     blink_interval: u64,
     blink_timeout: u8,
-    smooth_factor: f32
+    smooth_factor: f32,
 }
 
 impl Default for Cursor {
@@ -129,7 +129,11 @@ impl Cursor {
 
     #[inline]
     pub fn smooth_factor(self) -> f32 {
-        if self.smooth_factor > 0.0 { self.smooth_factor } else { 0.0 }
+        if self.smooth_factor > 0.0 {
+            self.smooth_factor
+        } else {
+            0.0
+        }
     }
 }
 


### PR DESCRIPTION
This is made by simply caching the previous cursor position and interpolating between it and the current position from frame to frame. This means rendering all of the frames, and an increased GPU load (which is comparable to watching a YouTube video), but that's just an optional feature that's off by default. Maybe the possible performance hit should be specified in the config template comments.
Also, turning the feature on switches block cursor to underline, because block cursor is rendered via replacing cell's fore-/background colors and you couldn't really interpolate there, unless there's a bigger change to the code.