### PR TITLE
Add `window.resize_increments` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for fractional scaling on Wayland with wp-fractional-scale protocol
 - Support for running on GLES context
 - Touchscreen input for click/scroll/select/zoom
+- `window.resize_increments` config option, disabled by default
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -101,6 +101,11 @@
   # auto pick-up. Set this to `None` to use the default theme variant.
   #decorations_theme_variant: None
 
+  # Resize increments
+  #
+  # Prefer resizing window by discrete steps equal to cell dimensions.
+  #resize_increments: false
+
   # Make `Option` key behave as `Alt` (macOS only):
   #   - OnlyLeft
   #   - OnlyRight

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -53,6 +53,9 @@ pub struct WindowConfig {
     #[cfg(target_os = "macos")]
     pub option_as_alt: OptionAsAlt,
 
+    /// Resize increments.
+    pub resize_increments: bool,
+
     /// Pixel padding.
     padding: Delta<u8>,
 
@@ -74,6 +77,7 @@ impl Default for WindowConfig {
             opacity: Default::default(),
             padding: Default::default(),
             dimensions: Default::default(),
+            resize_increments: Default::default(),
             #[cfg(target_os = "macos")]
             option_as_alt: Default::default(),
         }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -470,7 +470,9 @@ impl Display {
         }
 
         // Set resize increments for the newly created window.
-        window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
+        if config.window.resize_increments {
+            window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
+        }
 
         window.set_visible(true);
 
@@ -646,7 +648,9 @@ impl Display {
         new_size.reserve_lines(message_bar_lines + search_lines);
 
         // Update resize increments.
-        self.window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
+        if config.window.resize_increments {
+            self.window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
+        }
 
         // Resize PTY.
         pty_resize_handle.on_resize(new_size.into());

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -312,10 +312,11 @@ impl WindowContext {
             self.display.pending_update.set_font(font);
         }
 
-        // Update display if padding options were changed.
+        // Update display if either padding options or resize increments were changed.
         let window_config = &old_config.window;
         if window_config.padding(1.) != self.config.window.padding(1.)
             || window_config.dynamic_padding != self.config.window.dynamic_padding
+            || window_config.resize_increments != self.config.window.resize_increments
         {
             self.display.pending_update.dirty = true;
         }


### PR DESCRIPTION
Given how bugged the resize increments are on X11, it's better to disable it by default.