### PR TITLE
Fix bracketed paste with EOT payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Redraw hanging until a keypress on X11 in rare cases
 - Window clipping when maximizing a window without decorations on Windows
 - Quadrants not aligned with half blocks with built-in font
+- EOT (`\x03`) escaping bracketed paste mode
 
 ### Removed
 


### PR DESCRIPTION
This works around an issue in many (all?) shells where the bracketed paste logic would only strip out `\r` but interpret EOT (`\x03`) as a termination of the bracketed paste.