### PR TITLE
Fix busy rendering when the same warning persists

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1207,7 +1207,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     self.ctx.display.cursor_hidden = false;
                     *self.ctx.dirty = true;
                 },
-                // Add message only in case it's not already queued.
+                // Add message only if it's not already queued.
                 EventType::Message(message) if !self.ctx.message_buffer.is_queued(&message) => {
                     self.ctx.message_buffer.push(message);
                     self.ctx.display.pending_update.dirty = true;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1207,7 +1207,8 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     self.ctx.display.cursor_hidden = false;
                     *self.ctx.dirty = true;
                 },
-                EventType::Message(message) => {
+                // Add message only in case it's not already queued.
+                EventType::Message(message) if !self.ctx.message_buffer.is_queued(&message) => {
                     self.ctx.message_buffer.push(message);
                     self.ctx.display.pending_update.dirty = true;
                 },
@@ -1266,7 +1267,8 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                 },
                 #[cfg(unix)]
                 EventType::IpcConfig(_) => (),
-                EventType::ConfigReload(_) | EventType::CreateWindow(_) => (),
+                EventType::ConfigReload(_) | EventType::CreateWindow(_) | EventType::Message(_) => {
+                },
             },
             WinitEvent::RedrawRequested(_) => *self.ctx.dirty = true,
             WinitEvent::WindowEvent { event, .. } => {

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -181,6 +181,12 @@ impl MessageBuffer {
     pub fn push(&mut self, message: Message) {
         self.messages.push_back(message);
     }
+
+    /// Check whether the message is already queued in the message bar.
+    #[inline]
+    pub fn is_queued(&self, message: &Message) -> bool {
+        self.messages.contains(message)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When the same warning is thrown on the each rendering iteration, it'll force alacritty to always render. This commit changes the message queue to add logs only when they are not 
yet queued, preventing 'sticky' log notices from taking over the message bar buffer.

--

Just a side note, on how this was noticed. When calling a function in winit which is not implemented, winit will throw a warning saying that it's not implemented. When running alacritty with -vvv options that was introducing busy rendering loop and in-ability to look
into the trace log of alacritty, since winit was taking over the message bar queue. Now I just have a constant warning from the message bar due to winit, but I can at least see the
trace log...