### PR TITLE
Send D&D input through paste action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Window clipping when maximizing a window without decorations on Windows
 - Quadrants not aligned with half blocks with built-in font
 - EOT (`\x03`) escaping bracketed paste mode
+- Drag & Drop not working for the search bar
 
 ### Removed
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1320,7 +1320,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     },
                     WindowEvent::DroppedFile(path) => {
                         let path: String = path.to_string_lossy().into();
-                        self.ctx.write_to_pty((path + " ").into_bytes());
+                        self.ctx.paste(&(path + " "));
                     },
                     WindowEvent::CursorLeft { .. } => {
                         self.ctx.mouse.inside_text_area = false;


### PR DESCRIPTION
Treating D&D like paste allows using D&D to input text into areas other than the PTY, like the search bar.