### PR TITLE
Use `thin` instead of `fat` LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ members = [
 ]
 
 [profile.release]
-lto = true
+lto = "thin"
 debug = 1
 incremental = false


### PR DESCRIPTION
The performance between `thin` and `fat` is in the margin of error, however `thin` LTO is way faster to build.