### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -378,7 +378,13 @@ echo "source ~/.bash_completion/alacritty" >> ~/.bashrc
 
 #### Fish
 
-To install the completions for fish, run
+Make sure you are in fish shell or run
+
+```
+fish
+```
+
+Once you are in fish shell, to install the completions for fish, run
 
 ```
 mkdir -p $fish_complete_path[1]


### PR DESCRIPTION
Since mostly bash is the default shell in the terminal, so if someone using multiple shells, then first go to fish shell to make sure $fish_complete_path[1] is recognized by shell and then run commands to install the completions for fish.