### PR TITLE
Add daemon subcommand

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -263,6 +263,7 @@ impl WindowIdentity {
 #[derive(Subcommand, Debug)]
 pub enum Subcommands {
     Msg(MessageOptions),
+    Daemon,
 }
 
 /// Send a message to the Alacritty socket.

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -185,9 +185,13 @@ fn alacritty(options: Options) -> Result<(), Box<dyn Error>> {
     let window_options = options.window_options.clone();
     let daemon = if cfg!(unix) {
         #[cfg(unix)]
-        matches!(&options.subcommands, Some(Subcommands::Daemon))
+        {
+            matches!(&options.subcommands, Some(Subcommands::Daemon))
+        }
         #[cfg(not(unix))]
-        false
+        {
+            false
+        }
     } else {
         false
     };

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     #[cfg(unix)]
     match options.subcommands {
         Some(Subcommands::Msg(options)) => msg(options),
-        None => alacritty(options),
+        Some(Subcommands::Daemon) | None => alacritty(options),
     }
 
     #[cfg(not(unix))]
@@ -183,10 +183,11 @@ fn alacritty(options: Options) -> Result<(), Box<dyn Error>> {
 
     // Event processor.
     let window_options = options.window_options.clone();
+    let daemon = matches!(&options.subcommands, Some(Subcommands::Daemon));
     let mut processor = Processor::new(config, options, &window_event_loop);
 
     // Start event loop and block until shutdown.
-    let result = processor.run(window_event_loop, window_options);
+    let result = processor.run(window_event_loop, daemon, window_options);
 
     // This explicit drop is needed for Windows, ConPTY backend. Otherwise a deadlock can occur.
     // The cause:

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -183,7 +183,12 @@ fn alacritty(options: Options) -> Result<(), Box<dyn Error>> {
 
     // Event processor.
     let window_options = options.window_options.clone();
-    let daemon = matches!(&options.subcommands, Some(Subcommands::Daemon));
+    let daemon = if cfg!(unix) {
+        #[cfg(unix)]
+        matches!(&options.subcommands, Some(Subcommands::Daemon))
+    } else {
+        false
+    };
     let mut processor = Processor::new(config, options, &window_event_loop);
 
     // Start event loop and block until shutdown.

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -186,6 +186,8 @@ fn alacritty(options: Options) -> Result<(), Box<dyn Error>> {
     let daemon = if cfg!(unix) {
         #[cfg(unix)]
         matches!(&options.subcommands, Some(Subcommands::Daemon))
+        #[cfg(not(unix))]
+        false
     } else {
         false
     };


### PR DESCRIPTION
This allows alacritty to run in the background with no windows open, and then create them upon being messaged on the IPC socket.

In daemon mode, alacritty does not exit when the last window is closed, and alacritty does not create an initial window when executed, it only opens the IPC socket and listens for messages.

My use case is that I can start alacritty in daemon mode using a user service, and then bind a key to message the socket to make a new window. I find that alacritty launches ~~much~~ slightly faster this way!