### PR TITLE
alacritty: prefer alacritty-direct over alacritty terminfo

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -19,9 +19,9 @@
   #
   # This value is used to set the `$TERM` environment variable for
   # each instance of Alacritty. If it is not present, alacritty will
-  # check the local terminfo database and use `alacritty` if it is
-  # available, otherwise `xterm-256color` is used.
-  #TERM: alacritty
+  # check the local terminfo database and use `alacritty-direct` or `alacritty`
+  # in order of presence, otherwise `xterm-256color` is used.
+  #TERM: alacritty-direct
 
 #window:
   # Window dimensions (changes require restart)

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -61,10 +61,16 @@ pub trait EventedPty: EventedReadWrite {
 
 /// Setup environment variables.
 pub fn setup_env(config: &Config) {
-    // Default to 'alacritty' terminfo if it is available, otherwise
+    // Default to 'alacritty-direct' or 'alacritty' terminfo in order of presence, otherwise
     // default to 'xterm-256color'. May be overridden by user's config
     // below.
-    let terminfo = if terminfo_exists("alacritty") { "alacritty" } else { "xterm-256color" };
+    let terminfo = if terminfo_exists("alacritty-direct") {
+        "alacritty-direct"
+    } else if terminfo_exists("alacritty") {
+        "alacritty"
+    } else {
+        "xterm-256color"
+    };
     env::set_var("TERM", terminfo);
 
     // Advertise 24-bit color support.


### PR DESCRIPTION
By default, alacritty sets `TERM` to `alacritty` even if `alacritty-direct` terminfo exists (typically installed by `tic` from `alacritty.info`). So the default behavior forces use of not truecolor term. I suggest to check for `alacritty-direct` terminfo first, then for `alacritty` and fallback to `xterm-256color` as before.