### PR TITLE
Fix selection rotation on the last line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Character `;` inside the `URI` in `OSC 8` sequence breaking the URI
+- Selection on last line not updating correctly on resize
 
 ## 0.12.0
 

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -199,7 +199,7 @@ pub struct RenderableCellExtra {
 }
 
 impl RenderableCell {
-    fn new<'a>(content: &mut RenderableContent<'a>, cell: Indexed<&Cell>) -> Self {
+    fn new(content: &mut RenderableContent<'_>, cell: Indexed<&Cell>) -> Self {
         // Lookup RGB values.
         let mut fg = Self::compute_fg_rgb(content, cell.fg, cell.flags);
         let mut bg = Self::compute_bg_rgb(content, cell.bg);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -796,7 +796,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
             // We remove `\x1b` to ensure it's impossible for the pasted text to write the bracketed
             // paste end escape `\x1b[201~` and `\x03` since some shells incorrectly terminate
             // bracketed paste on its receival.
-            let filtered = text.replace('\x1b', "").replace('\x03', "");
+            let filtered = text.replace(['\x1b', '\x03'], "");
             self.write_to_pty(filtered.into_bytes());
 
             self.write_to_pty(&b"\x1b[201~"[..]);

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -719,9 +719,8 @@ impl Canvas {
         let v_line_bounds = (v_line_bounds.0 as usize, v_line_bounds.1 as usize);
         let max_transparancy = 0.5;
 
-        for (radius_y, radius_x) in (h_line_bounds.0..h_line_bounds.1)
-            .into_iter()
-            .zip((v_line_bounds.0..v_line_bounds.1).into_iter())
+        for (radius_y, radius_x) in
+            (h_line_bounds.0..h_line_bounds.1).zip(v_line_bounds.0..v_line_bounds.1)
         {
             let radius_x = radius_x as f32;
             let radius_y = radius_y as f32;


### PR DESCRIPTION
This fixes an issue with terminal resizes when the selection is on the
last line. Alacritty would fail to rotate lines and keep the selection
in the same line index whenever the terminal line count was grown or
shrunk.

This issue occurred due to the range passed to the selection's rotate
function still being based on the old terminal size, which caused the
initial or target state of the rotation to be outside of the terminal
bounds.

Closes #6698.