### PR TITLE
Bump CHANGELOG development version to 0.13.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.12.0-dev
+## 0.13.0-dev
+
+### Fixed
+
+- Character `;` inside the `URI` in `OSC 8` sequence breaking the URI
+
+## 0.12.0
 
 ### Added
 
@@ -50,7 +56,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - EOT (`\x03`) escaping bracketed paste mode
 - Drag & Drop not working for the search bar
 - Simple-fullscreened window not resized when moving between monitors on macOS
-- Character `;` inside the `URI` in `OSC 8` sequence breaking the URI
 
 ### Removed
 


### PR DESCRIPTION
This is only an update to the development version and does not represent a stable release.

The original bump to 0.13.0-dev was made in 9cf2c89, but did not make any changes to the changelog. This adds a 0.13.0-dev changelog entry to master so new changes are properly added to the correct place.