### PR TITLE
Add `window.use_srgb` config option for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Character `;` inside the `URI` in `OSC 8` sequence breaking the URI
 - Selection on last line not updating correctly on resize
+- Added `use_srgb` option for macOS (default true)
 
 ## 0.12.0
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -113,6 +113,11 @@
   #   - None (default)
   #option_as_alt: None
 
+  # Use sRGB color space (macOS only) (changes require restart)
+  #
+  # Set this to false to enable "vivid" colors.
+  #use_srgb: true
+
 #scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -61,6 +61,10 @@ pub struct WindowConfig {
 
     /// Initial dimensions.
     dimensions: Dimensions,
+
+    /// Use sRGB color space.
+    #[cfg(target_os = "macos")]
+    pub use_srgb: bool,
 }
 
 impl Default for WindowConfig {
@@ -80,6 +84,8 @@ impl Default for WindowConfig {
             resize_increments: Default::default(),
             #[cfg(target_os = "macos")]
             option_as_alt: Default::default(),
+            #[cfg(target_os = "macos")]
+            use_srgb: true,
         }
     }
 }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -179,7 +179,9 @@ impl Window {
         window.set_transparent(config.window_opacity() < 1.);
 
         #[cfg(target_os = "macos")]
-        use_srgb_color_space(&window);
+        if config.window.use_srgb {
+            use_srgb_color_space(&window);
+        }
 
         #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
         if !is_wayland {


### PR DESCRIPTION
Adds a config option to use the default colorspace on macOS.

It may make sense for many users to use the sRGB color space, but some, like myself, prefer the vivid look of the default color space. I don't do any color work & I don't care if the colors are "accurate" are not. Setting this option to false restores colors prior to 0.12.0.

Closes #6815 