### PR TITLE
Improve keybinding flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.13.0-dev
 
+### Changed
+
+- Mode-specific bindings can now be bound in any mode for easier macros
+
 ### Fixed
 
 - Character `;` inside the `URI` in `OSC 8` sequence breaking the URI

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -1114,26 +1114,8 @@ impl<'a> Deserialize<'a> for RawBinding {
 
                 let action = match (action, chars, command) {
                     (Some(action @ Action::ViMotion(_)), None, None)
-                    | (Some(action @ Action::Vi(_)), None, None) => {
-                        if !mode.intersects(BindingMode::VI) || not_mode.intersects(BindingMode::VI)
-                        {
-                            return Err(V::Error::custom(format!(
-                                "action `{}` is only available in vi mode, try adding `mode: Vi`",
-                                action,
-                            )));
-                        }
-                        action
-                    },
-                    (Some(action @ Action::Search(_)), None, None) => {
-                        if !mode.intersects(BindingMode::SEARCH) {
-                            return Err(V::Error::custom(format!(
-                                "action `{}` is only available in search mode, try adding `mode: \
-                                 Search`",
-                                action,
-                            )));
-                        }
-                        action
-                    },
+                    | (Some(action @ Action::Vi(_)), None, None) => action,
+                    (Some(action @ Action::Search(_)), None, None) => action,
                     (Some(action @ Action::Mouse(_)), None, None) => {
                         if mouse.is_none() {
                             return Err(V::Error::custom(format!(

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -496,6 +496,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         // Enable IME so we can input into the search bar with it if we were in Vi mode.
         self.window().set_ime_allowed(true);
 
+        self.terminal.mark_fully_damaged();
         self.display.pending_update.dirty = true;
     }
 
@@ -983,6 +984,7 @@ impl<'a, N: Notify + 'a, T: EventListener> ActionContext<'a, N, T> {
         let vi_mode = self.terminal.mode().contains(TermMode::VI);
         self.window().set_ime_allowed(!vi_mode);
 
+        self.terminal.mark_fully_damaged();
         self.display.pending_update.dirty = true;
         self.search_state.history_index = None;
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -218,6 +218,56 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.notifier.notify(val);
     }
 
+    fn received_char(&mut self, c: char) {
+        // Don't insert chars when we have IME running.
+        if self.display().ime.preedit().is_some() {
+            return;
+        }
+
+        // Handle hint selection over anything else.
+        if self.display().hint_state.active() && !*self.suppress_chars {
+            self.hint_input(c);
+            return;
+        }
+
+        // Pass keys to search and ignore them during `suppress_chars`.
+        let search_active = self.search_active();
+        if *self.suppress_chars || search_active || self.terminal().mode().contains(TermMode::VI) {
+            if search_active && !*self.suppress_chars {
+                self.search_input(c);
+            }
+
+            return;
+        }
+
+        self.on_typing_start();
+
+        if self.terminal().grid().display_offset() != 0 {
+            self.scroll(Scroll::Bottom);
+        }
+        self.clear_selection();
+
+        let utf8_len = c.len_utf8();
+        let mut bytes = vec![0; utf8_len];
+        c.encode_utf8(&mut bytes[..]);
+
+        #[cfg(not(target_os = "macos"))]
+        let alt_send_esc = true;
+
+        // Don't send ESC when `OptionAsAlt` is used. This doesn't handle
+        // `Only{Left,Right}` variants due to inability to distinguish them.
+        #[cfg(target_os = "macos")]
+        let alt_send_esc = self.config().window.option_as_alt != OptionAsAlt::None;
+
+        if alt_send_esc && *self.received_count() == 0 && self.modifiers().alt() && utf8_len == 1 {
+            bytes.insert(0, b'\x1b');
+        }
+
+        self.write_to_pty(bytes);
+
+        *self.received_count() += 1;
+    }
+
     /// Request a redraw.
     #[inline]
     fn mark_dirty(&mut self) {
@@ -1288,7 +1338,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         self.key_input(input);
                     },
                     WindowEvent::ModifiersChanged(modifiers) => self.modifiers_input(modifiers),
-                    WindowEvent::ReceivedCharacter(c) => self.received_char(c),
+                    WindowEvent::ReceivedCharacter(c) => self.ctx.received_char(c),
                     WindowEvent::MouseInput { state, button, .. } => {
                         self.ctx.window().set_mouse_visible(true);
                         self.mouse_input(state, button);
@@ -1336,7 +1386,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                             *self.ctx.dirty = true;
 
                             for ch in text.chars() {
-                                self.received_char(ch);
+                                self.ctx.received_char(ch);
                             }
 
                             self.ctx.update_cursor_blinking();


### PR DESCRIPTION
Previously keybindings for the same key would be evaluated in order using the mode set while evaluating the first binding. This makes it impossible to combine keybindings across mode changes when the action is restricted to a mode entered through a previous binding.

To make it easier to combine keybindings, this patch reevaluates the mode for every keybinding.

To further improve the ability of users to write macros like these, the `chars` action has also been rewired to go through `reiceived_char`, allowing it to automatically work for Alacritty's UI (i.e. search), rather than just writing to the PTY.

Closes #4073.