### PR TITLE
feat: update default macOS new window bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Mode-specific bindings can now be bound in any mode for easier macros
+- Update default macOS bindings for `Cmd`+`N` and `Cmd`+`T` to open windows as expected
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -875,7 +875,8 @@
   #- { key: M,              mods: Command,                    action: Minimize              }
   #- { key: Q,              mods: Command,                    action: Quit                  }
   #- { key: W,              mods: Command,                    action: Quit                  }
-  #- { key: N,              mods: Command,                    action: CreateNewWindow       }
+  #- { key: T,              mods: Command,                    action: CreateNewWindow       }
+  #- { key: N,              mods: Command,                    action: SpawnNewInstance       }
   #- { key: F,              mods: Command|Control,            action: ToggleFullscreen      }
   #- { key: F,              mods: Command, mode: ~Search,     action: SearchForward         }
   #- { key: B,              mods: Command, mode: ~Search,     action: SearchBackward        }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -715,6 +715,8 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         K, ModifiersState::LOGO, ~BindingMode::VI, ~BindingMode::SEARCH;  Action::ClearHistory;
         V, ModifiersState::LOGO, ~BindingMode::VI; Action::Paste;
         N, ModifiersState::LOGO; Action::CreateNewWindow;
+        T, ModifiersState::LOGO; Action::CreateNewWindow;
+        N, ModifiersState::LOGO; Action::SpawnNewInstance;
         F, ModifiersState::CTRL | ModifiersState::LOGO; Action::ToggleFullscreen;
         C, ModifiersState::LOGO; Action::Copy;
         C, ModifiersState::LOGO, +BindingMode::VI, ~BindingMode::SEARCH; Action::ClearSelection;


### PR DESCRIPTION
This PR addresses the unconventional bindings introduced by #6648, adding the following macOS bindings:

- `Cmd + T` for `CreateNewWindow` (mimics opening a new tab if system-enabled)
- `Cmd + N` for `SpawnNewInstance` (opens a separate Alacritty window)