### PR TITLE
Fix very long startup time on some Wayland systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Character `;` inside the `URI` in `OSC 8` sequence breaking the URI
 - Selection on last line not updating correctly on resize
 - Keyboard input not working on macOS with some IMEs like Fig.io
+- Very long startup times on Wayland systems with broken xdg-portal setup.
 
 ## 0.12.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,9 +1491,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc56402866c717f54e48b122eb93c69f709bc5a6359c403598992fd92f017931"
+checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
 dependencies = [
  "crossfont",
  "log",


### PR DESCRIPTION
This is not a real fix for the issue given that dbus method sctk-adwaita is using will being called anyway. The proper fix will be available with the winit's 0.29.0 release.

Right now the delay reduced from around 20 seconds to 100ms on a systems with broken xdg-desktop-portal setup.

--

It's not a real fix, but it's better than nothing.