### PR TITLE
CI: bump `actions/checkout` to v3, fix Node 12 deprecation warning in action runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Stable
         run: cargo test
       - name: Oldstable
@@ -28,7 +28,7 @@ jobs:
   check-macos-arm:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install target
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-11
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install ARM target
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Test
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Test
         run: cargo test --release
       - name: Build
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt-get install cmake pkg-config libfreetype6-dev libfontconfig1-dev \


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version from `v2` (**Deprecated**: Node 12) to `v3` (Node 16).