### PR TITLE
Add EmptySelection key binding mode

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -757,6 +757,7 @@
 #    - Search
 #    - Alt
 #    - Vi
+#    - EmptySelection
 #
 #    A `~` operator can be used before a mode to apply the binding whenever
 #    the mode is *not* active, e.g. `~Alt`.

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -770,17 +770,19 @@ bitflags! {
         const ALT_SCREEN          = 0b0000_0100;
         const VI                  = 0b0000_1000;
         const SEARCH              = 0b0001_0000;
+        const EMPTY_SELECTION     = 0b0010_0000;
     }
 }
 
 impl BindingMode {
-    pub fn new(mode: &TermMode, search: bool) -> BindingMode {
+    pub fn new(mode: &TermMode, search: bool, empty_selection: bool) -> BindingMode {
         let mut binding_mode = BindingMode::empty();
         binding_mode.set(BindingMode::APP_CURSOR, mode.contains(TermMode::APP_CURSOR));
         binding_mode.set(BindingMode::APP_KEYPAD, mode.contains(TermMode::APP_KEYPAD));
         binding_mode.set(BindingMode::ALT_SCREEN, mode.contains(TermMode::ALT_SCREEN));
         binding_mode.set(BindingMode::VI, mode.contains(TermMode::VI));
         binding_mode.set(BindingMode::SEARCH, search);
+        binding_mode.set(BindingMode::EMPTY_SELECTION, empty_selection);
         binding_mode
     }
 }
@@ -826,6 +828,8 @@ impl<'a> Deserialize<'a> for ModeWrapper {
                         "~vi" => res.not_mode |= BindingMode::VI,
                         "search" => res.mode |= BindingMode::SEARCH,
                         "~search" => res.not_mode |= BindingMode::SEARCH,
+                        "emptyselection" => res.mode |= BindingMode::EMPTY_SELECTION,
+                        "~emptyselection" => res.not_mode |= BindingMode::EMPTY_SELECTION,
                         _ => return Err(E::invalid_value(Unexpected::Str(modifier), &self)),
                     }
                 }

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1026,7 +1026,11 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     /// The provided mode, mods, and key must match what is allowed by a binding
     /// for its action to be executed.
     fn process_key_bindings(&mut self, input: KeyboardInput) {
-        let mode = BindingMode::new(self.ctx.terminal().mode(), self.ctx.search_active());
+        let mode = BindingMode::new(
+            self.ctx.terminal().mode(),
+            self.ctx.search_active(),
+            self.ctx.selection_is_empty(),
+        );
         let mods = *self.ctx.modifiers();
         let mut suppress_chars = None;
 
@@ -1057,7 +1061,11 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     /// The provided mode, mods, and key must match what is allowed by a binding
     /// for its action to be executed.
     fn process_mouse_bindings(&mut self, button: MouseButton) {
-        let mode = BindingMode::new(self.ctx.terminal().mode(), self.ctx.search_active());
+        let mode = BindingMode::new(
+            self.ctx.terminal().mode(),
+            self.ctx.search_active(),
+            self.ctx.selection_is_empty(),
+        );
         let mouse_mode = self.ctx.mouse_mode();
         let mods = *self.ctx.modifiers();
 


### PR DESCRIPTION
With this, a bind can be configured to trigger based on the presence or absence of a selection.

For example, this config emulates windows terminal style copy paste:
- { mouse: Right,  mode: ~EmptySelection, mods: Shift, action: Copy }
- { mouse: Right,  mode: ~EmptySelection, mods: Shift, action: ClearSelection }
- { mouse: Right,  mode: EmptySelection,  mods: Shift, action: PasteSelection }

In the above example, when no text is selected shift-rightclick will paste. If text is selected, then shift-rightclick will copy and clear the selection.