### PR TITLE
Improve renderer debuggability

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -15,9 +15,12 @@ fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(Path::new(&dest).join("gl_bindings.rs")).unwrap();
 
-    Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, ["GL_ARB_blend_func_extended"])
-        .write_bindings(GlobalGenerator, &mut file)
-        .unwrap();
+    Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, [
+        "GL_ARB_blend_func_extended",
+        "GL_KHR_debug",
+    ])
+    .write_bindings(GlobalGenerator, &mut file)
+    .unwrap();
 
     #[cfg(windows)]
     embed_resource::compile("./windows/alacritty.rc");

--- a/alacritty/src/renderer/platform.rs
+++ b/alacritty/src/renderer/platform.rs
@@ -10,6 +10,7 @@ use glutin::display::{Display, DisplayApiPreference, GetGlDisplay};
 use glutin::error::Result as GlutinResult;
 use glutin::prelude::*;
 use glutin::surface::{Surface, SurfaceAttributesBuilder, WindowSurface};
+use log::{debug, LevelFilter};
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use winit::dpi::PhysicalSize;
@@ -69,6 +70,24 @@ pub fn pick_gl_config(
         };
 
         if let Some(gl_config) = gl_config {
+            debug!(
+                r#"Picked GL Config:
+  buffer_type: {:?}
+  alpha_size: {}
+  num_samples: {}
+  hardware_accelerated: {:?}
+  supports_transparency: {:?}
+  config_api: {:?}
+  srgb_capable: {}"#,
+                gl_config.color_buffer_type(),
+                gl_config.alpha_size(),
+                gl_config.num_samples(),
+                gl_config.hardware_accelerated(),
+                gl_config.supports_transparency(),
+                gl_config.api(),
+                gl_config.srgb_capable(),
+            );
+
             return Ok(gl_config);
         }
     }
@@ -81,15 +100,19 @@ pub fn create_gl_context(
     gl_config: &Config,
     raw_window_handle: Option<RawWindowHandle>,
 ) -> GlutinResult<NotCurrentContext> {
+    let debug = log::max_level() >= LevelFilter::Debug;
     let mut profiles = [
         ContextAttributesBuilder::new()
+            .with_debug(debug)
             .with_context_api(ContextApi::OpenGl(Some(Version::new(3, 3))))
             .build(raw_window_handle),
         // Try gles before OpenGL 2.1 as it tends to be more stable.
         ContextAttributesBuilder::new()
+            .with_debug(debug)
             .with_context_api(ContextApi::Gles(Some(Version::new(2, 0))))
             .build(raw_window_handle),
         ContextAttributesBuilder::new()
+            .with_debug(debug)
             .with_profile(GlProfile::Compatibility)
             .with_context_api(ContextApi::OpenGl(Some(Version::new(2, 1))))
             .build(raw_window_handle),


### PR DESCRIPTION
Make the renderer more debuggable by adding extra logging and using `GL_KHR_debug` when running with the debug log level.