### PR TITLE
Add ability to zoom to alternate font size directly

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -134,6 +134,9 @@ pub enum Action {
     /// Reset font size to the config value.
     ResetFontSize,
 
+    /// Set font size to specific value
+    ZoomFont,
+
     /// Scroll exactly one page up.
     ScrollPageUp,
 
@@ -675,6 +678,7 @@ fn common_keybindings() -> Vec<KeyBinding> {
             +BindingMode::VI, ~BindingMode::SEARCH; Action::ClearSelection;
         Insert,   ModifiersState::SHIFT, ~BindingMode::VI; Action::PasteSelection;
         Key0,     ModifiersState::CTRL;  Action::ResetFontSize;
+        Key9,     ModifiersState::CTRL;  Action::ZoomFont;
         Equals,   ModifiersState::CTRL;  Action::IncreaseFontSize;
         Plus,     ModifiersState::CTRL;  Action::IncreaseFontSize;
         NumpadAdd,      ModifiersState::CTRL;  Action::IncreaseFontSize;

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -40,6 +40,9 @@ pub struct Font {
     /// Font size in points.
     size: Size,
 
+    /// Font size in points, when zoomed int.
+    zoom_size: Size,
+
     /// Whether to use the built-in font for box drawing characters.
     pub builtin_box_drawing: bool,
 }
@@ -53,6 +56,11 @@ impl Font {
     #[inline]
     pub fn size(&self) -> FontSize {
         self.size.0
+    }
+
+    #[inline]
+    pub fn zoom_size(&self) -> FontSize {
+        self.zoom_size.0
     }
 
     /// Get normal font description.
@@ -88,6 +96,7 @@ impl Default for Font {
             normal: Default::default(),
             bold: Default::default(),
             size: Default::default(),
+            zoom_size: Size(FontSize::from(Size::default().0 * 2.)),
         }
     }
 }

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -96,7 +96,7 @@ impl Default for Font {
             normal: Default::default(),
             bold: Default::default(),
             size: Default::default(),
-            zoom_size: Size(FontSize::from(Size::default().0 * 2.)),
+            zoom_size: Size(Size::default().0 * 2.),
         }
     }
 }

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -40,7 +40,7 @@ pub struct Font {
     /// Font size in points.
     size: Size,
 
-    /// Font size in points, when zoomed int.
+    /// Font size in points, when zoomed in.
     zoom_size: Size,
 
     /// Whether to use the built-in font for box drawing characters.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -454,6 +454,12 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.display.pending_update.set_font(self.config.font.clone());
     }
 
+    fn zoom_font(&mut self) {
+        *self.font_size = self.config.font.zoom_size();
+        let font = self.config.font.clone().with_size(*self.font_size);
+        self.display.pending_update.set_font(font);
+    }
+
     #[inline]
     fn pop_message(&mut self) {
         if !self.message_buffer.is_empty() {

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -97,6 +97,7 @@ pub trait ActionContext<T: EventListener> {
     fn create_new_window(&mut self) {}
     fn change_font_size(&mut self, _delta: f32) {}
     fn reset_font_size(&mut self) {}
+    fn zoom_font(&mut self) {}
     fn pop_message(&mut self) {}
     fn message(&self) -> Option<&Message>;
     fn config(&self) -> &UiConfig;
@@ -301,6 +302,7 @@ impl<T: EventListener> Execute<T> for Action {
             Action::Quit => ctx.terminal_mut().exit(),
             Action::IncreaseFontSize => ctx.change_font_size(FONT_SIZE_STEP),
             Action::DecreaseFontSize => ctx.change_font_size(FONT_SIZE_STEP * -1.),
+            Action::ZoomFont => ctx.zoom_font(),
             Action::ResetFontSize => ctx.reset_font_size(),
             Action::ScrollPageUp => {
                 // Move vi mode cursor.


### PR DESCRIPTION
I share my screen during video calls a fair bit during work.  On these calls, it's common to need to increase the font size so the other person can read my terminal.  I can't be bothered to type Ctrl+Plus mutliple times, so it'd be nice to bind a key to put my terminal into "Big Font Mode", then I can ResetFontSize when I'm done.  I chose Key9 for this default binding since the ResetFontSize binding defaults to Key0.