### PR TITLE
Fix 216-color cube generation

### DIFF
--- a/alacritty/src/display/color.rs
+++ b/alacritty/src/display/color.rs
@@ -97,8 +97,8 @@ impl List {
                     } else {
                         self[index] = Rgb::new(
                             if r == 0 { 0 } else { r * 40 + 55 },
-                            if b == 0 { 0 } else { b * 40 + 55 },
                             if g == 0 { 0 } else { g * 40 + 55 },
+                            if b == 0 { 0 } else { b * 40 + 55 },
                         );
                     }
                     index += 1;


### PR DESCRIPTION
This fixes a regression introduced in cb7ad5b which swapped the green and blue values when constructing the 216-color RGB cube.