### PR TITLE
Fix hyperlink preview for 2 lines terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Mode-specific bindings can now be bound in any mode for easier macros
 - `--help` output is more compact now and uses more neutral palette
 
+### Fixed
+
+- Hyperlink preview not being shown when the terminal has exactly 2 lines
+
 ## 0.12.1
 
 ### Fixed

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -1201,10 +1201,9 @@ impl Display {
         // The maximum amount of protected lines including the ones we'll show preview on.
         let max_protected_lines = uris.len() * 2;
 
-        // Lines we shouldn't shouldn't show preview on, because it'll obscure the highlighted
-        // hint.
+        // Lines we shouldn't show preview on, because it'll obscure the highlighted hint.
         let mut protected_lines = Vec::with_capacity(max_protected_lines);
-        if self.size_info.screen_lines() >= max_protected_lines {
+        if self.size_info.screen_lines() > max_protected_lines {
             // Prefer to show preview even when it'll likely obscure the highlighted hint, when
             // there's no place left for it.
             protected_lines.push(self.hint_mouse_point.map(|point| point.line));


### PR DESCRIPTION
The intention was to show it, however it was hidden due to wrong comparisson check.