### PR TITLE
Update path of changed doc files in Makefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: brew install scdoc
       - name: Install ARM target
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ TARGET = alacritty
 
 ASSETS_DIR = extra
 RELEASE_DIR = target/release
-MANPAGE = $(ASSETS_DIR)/alacritty.man
-MANPAGE-MSG = $(ASSETS_DIR)/alacritty-msg.man
+MANPAGE = $(ASSETS_DIR)/man/alacritty.1.scd
+MANPAGE-MSG = $(ASSETS_DIR)/man/alacritty-msg.1.scd
 CONFIGFILE = alacritty.yml
 TERMINFO = $(ASSETS_DIR)/alacritty.info
 COMPLETIONS_DIR = $(ASSETS_DIR)/completions

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ $(APP_NAME)-%: $(TARGET)-%
 	@mkdir -p $(APP_BINARY_DIR)
 	@mkdir -p $(APP_EXTRAS_DIR)
 	@mkdir -p $(APP_COMPLETIONS_DIR)
-	@gzip -c $(MANPAGE) > $(APP_EXTRAS_DIR)/alacritty.1.gz
-	@gzip -c $(MANPAGE-MSG) > $(APP_EXTRAS_DIR)/alacritty-msg.1.gz
+	@scdoc < $(MANPAGE) | gzip -c > $(APP_EXTRAS_DIR)/alacritty.1.gz
+	@scdoc < $(MANPAGE-MSG) | gzip -c > $(APP_EXTRAS_DIR)/alacritty-msg.1.gz
 	@tic -xe alacritty,alacritty-direct -o $(APP_EXTRAS_DIR) $(TERMINFO)
 	@cp -fRp $(APP_TEMPLATE) $(APP_DIR)
 	@cp -fp $(APP_BINARY) $(APP_BINARY_DIR)


### PR DESCRIPTION
It looks like the paths to the recently changed doc files (https://github.com/alacritty/alacritty/commit/e3746e49a117ebf8d1f43715554c5a1cf8d4a116) were not updated in the Makefile, with this change they now point to the files again.