### PR TITLE
Fix crash on ScaleFactorChange on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Hyperlink preview not being shown when the terminal has exactly 2 lines
+- Crash on Windows when changing display scale factor
 
 ## 0.12.1
 


### PR DESCRIPTION
Windows is known to send zero sizes from winit in Risezed and now in ScaleFactorChanged events. They were handled in Resized, but not in ScaleFactorChanged.

Fixes #6949.