### PR TITLE
Add resolver to workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "alacritty_config",
     "alacritty_config_derive",
 ]
+resolver = "2"
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
This explicitly specifies resolver "2" in the root manifest, to fix a warning introduced in a recent nightly release.