### PR TITLE
Load and use conpty.dll if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Warnings for unused configuration file options
 - Config option `persist` in `hints` config section
+- Support for dynamically loading conpty.dll on Windows
 
 ### Changed
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -45,6 +45,7 @@ windows-sys = { version = "0.48", features = [
     "Win32_System_Console",
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_System_WindowsProgramming",
 ]}


### PR DESCRIPTION
I was asked by @kchibisov to put this change in review. I realize that similar PRs were rejected in the past for different reasons. However, the sad fact is that Microsoft has not backported their conpty changes to Windows 10 even though they are many years old. And the same Microsoft is benefiting from the bundled `conpty.dll` in their Windows Terminal. They have no urgency to backport their fixes, but they are leaving Alacritty in the cold if it sticks to the stable API.

Windows 10 is still widespread in the corporate world, it's not my OS of choice by any means, but I'm trying to make my development environment comfortable.

The original change was made by @grueslayer but I touched pretty much every line in that patch. I did my best to get this patch in a good shape for it to be accepted. The missing parts are the documentation and the configuration. I'd like to get some feedback first.

If there are any concerns about the use of unstable API, let's consider how to mitigate them. We can have a configuration option with detailed comments about the implications. The option can be disabled by default. What would be a good name for the option? `use_experimental_conpty`? Should it be boolean or have full path to `conpty.dll`?

If there is an option and it's enabled, it would be good to warn the user if the `conpty.dll` loading fails and fallback is used.