### PR TITLE
Fix `alacritty msg config` toml replacement

### DIFF
--- a/alacritty_config/src/lib.rs
+++ b/alacritty_config/src/lib.rs
@@ -6,15 +6,15 @@ use serde::Deserialize;
 use toml::Value;
 
 pub trait SerdeReplace {
-    fn replace(&mut self, key: &str, value: Value) -> Result<(), Box<dyn Error>>;
+    fn replace(&mut self, value: Value) -> Result<(), Box<dyn Error>>;
 }
 
 macro_rules! impl_replace {
     ($($ty:ty),*$(,)*) => {
         $(
             impl SerdeReplace for $ty {
-                fn replace(&mut self, key: &str, value: Value) -> Result<(), Box<dyn Error>> {
-                    replace_simple(self, key, value)
+                fn replace(&mut self, value: Value) -> Result<(), Box<dyn Error>> {
+                    replace_simple(self, value)
                 }
             }
         )*
@@ -35,33 +35,29 @@ impl_replace!(
 #[cfg(target_os = "macos")]
 impl_replace!(winit::platform::macos::OptionAsAlt,);
 
-fn replace_simple<'de, D>(data: &mut D, key: &str, value: Value) -> Result<(), Box<dyn Error>>
+fn replace_simple<'de, D>(data: &mut D, value: Value) -> Result<(), Box<dyn Error>>
 where
     D: Deserialize<'de>,
 {
-    if !key.is_empty() {
-        let error = format!("Fields \"{key}\" do not exist");
-        return Err(error.into());
-    }
     *data = D::deserialize(value)?;
 
     Ok(())
 }
 
 impl<'de, T: Deserialize<'de>> SerdeReplace for Vec<T> {
-    fn replace(&mut self, key: &str, value: Value) -> Result<(), Box<dyn Error>> {
-        replace_simple(self, key, value)
+    fn replace(&mut self, value: Value) -> Result<(), Box<dyn Error>> {
+        replace_simple(self, value)
     }
 }
 
 impl<'de, T: Deserialize<'de>> SerdeReplace for Option<T> {
-    fn replace(&mut self, key: &str, value: Value) -> Result<(), Box<dyn Error>> {
-        replace_simple(self, key, value)
+    fn replace(&mut self, value: Value) -> Result<(), Box<dyn Error>> {
+        replace_simple(self, value)
     }
 }
 
 impl<'de, T: Deserialize<'de>> SerdeReplace for HashMap<String, T> {
-    fn replace(&mut self, key: &str, value: Value) -> Result<(), Box<dyn Error>> {
-        replace_simple(self, key, value)
+    fn replace(&mut self, value: Value) -> Result<(), Box<dyn Error>> {
+        replace_simple(self, value)
     }
 }

--- a/alacritty_config_derive/src/serde_replace.rs
+++ b/alacritty_config_derive/src/serde_replace.rs
@@ -28,11 +28,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 pub fn derive_direct(ident: Ident, generics: Generics) -> TokenStream2 {
     quote! {
         impl <#generics> alacritty_config::SerdeReplace for #ident <#generics> {
-            fn replace(&mut self, key: &str, value: toml::Value) -> Result<(), Box<dyn std::error::Error>> {
-                if !key.is_empty() {
-                    let error = format!("Fields \"{}\" do not exist", key);
-                    return Err(error.into());
-                }
+            fn replace(&mut self, value: toml::Value) -> Result<(), Box<dyn std::error::Error>> {
                 *self = serde::Deserialize::deserialize(value)?;
 
                 Ok(())
@@ -53,19 +49,23 @@ pub fn derive_recursive<T>(
     quote! {
         #[allow(clippy::extra_unused_lifetimes)]
         impl <'de, #constrained> alacritty_config::SerdeReplace for #ident <#unconstrained> {
-            fn replace(&mut self, key: &str, value: toml::Value) -> Result<(), Box<dyn std::error::Error>> {
-                if key.is_empty() {
-                    *self = serde::Deserialize::deserialize(value)?;
-                    return Ok(());
-                }
+            fn replace(&mut self, value: toml::Value) -> Result<(), Box<dyn std::error::Error>> {
+                match value.as_table() {
+                    Some(table) => {
+                        for (field, next_value) in table {
+                            let next_value = next_value.clone();
+                            let value = value.clone();
 
-                let (field, next_key) = key.split_once('.').unwrap_or((key, ""));
-                match field {
-                    #replace_arms
-                    _ => {
-                        let error = format!("Field \"{}\" does not exist", field);
-                        return Err(error.into());
+                            match field.as_str() {
+                                #replace_arms
+                                _ => {
+                                    let error = format!("Field \"{}\" does not exist", field);
+                                    return Err(error.into());
+                                },
+                            }
+                        }
                     },
+                    None => *self = serde::Deserialize::deserialize(value)?,
                 }
 
                 Ok(())
@@ -95,11 +95,11 @@ fn match_arms<T>(fields: &Punctuated<Field, T>) -> TokenStream2 {
             return Error::new(ident.span(), MULTIPLE_FLATTEN_ERROR).to_compile_error();
         } else if flatten {
             flattened_arm = Some(quote! {
-                _ => alacritty_config::SerdeReplace::replace(&mut self.#ident, key, value)?,
+                _ => alacritty_config::SerdeReplace::replace(&mut self.#ident, value)?,
             });
         } else {
             stream.extend(quote! {
-                #literal => alacritty_config::SerdeReplace::replace(&mut self.#ident, next_key, value)?,
+                #literal => alacritty_config::SerdeReplace::replace(&mut self.#ident, next_value)?,
             });
         }
     }

--- a/alacritty_config_derive/tests/config.rs
+++ b/alacritty_config_derive/tests/config.rs
@@ -173,8 +173,8 @@ impl Log for Logger {
 fn field_replacement() {
     let mut test = Test::default();
 
-    let value = toml::Value::Integer(13);
-    test.replace("nesting.field2", value).unwrap();
+    let value = toml::from_str("nesting.field2=13").unwrap();
+    test.replace(value).unwrap();
 
     assert_eq!(test.nesting.field2, Some(13));
 }
@@ -183,8 +183,8 @@ fn field_replacement() {
 fn replace_derive() {
     let mut test = Test::default();
 
-    let value = toml::Value::Integer(9);
-    test.replace("nesting.newtype", value).unwrap();
+    let value = toml::from_str("nesting.newtype=9").unwrap();
+    test.replace(value).unwrap();
 
     assert_eq!(test.nesting.newtype, NewType(9));
 }
@@ -193,8 +193,8 @@ fn replace_derive() {
 fn replace_flatten() {
     let mut test = Test::default();
 
-    let value = toml::Value::Integer(7);
-    test.replace("flatty", value).unwrap();
+    let value = toml::from_str("flatty=7").unwrap();
+    test.replace(value).unwrap();
 
     assert_eq!(test.flatten.flatty, 7);
 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -52,12 +52,9 @@ impl<'de> serde::Deserialize<'de> for CursorShapeShim {
 }
 
 impl alacritty_config::SerdeReplace for CursorShapeShim {
-    fn replace(&mut self, key: &str, value: toml::Value) -> Result<(), Box<dyn std::error::Error>> {
-        if !key.is_empty() {
-            return Err(format!("Fields \"{0}\" do not exist", key).into());
-        }
-
+    fn replace(&mut self, value: toml::Value) -> Result<(), Box<dyn std::error::Error>> {
         *self = serde::Deserialize::deserialize(value)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
This fixes a regression introduced in bd49067 which broke the override of configuration file variables using `alacritty msg config`.

To fix this the `replace` functionality was rewritten to behave more like the `serde_utils::merge` where entire values are inserted into the existing structure rather than separating the keys from the values.

---

I originally suggested on IRC to just use serialize to convert the config back to `toml::Value` and then use `serde_utils::merge`, however based on my estimations this wouldn't work since some of our values are `#[serde(skip)]` (most notably key bindings).

It's possible that it would work as long as we stick to just `toml::Value`, but I didn't want to go through the trouble of rewriting everything just to find out it doesn't work anyway. 