### PR TITLE
Add errors for deserializing with unknown fields

### DIFF
--- a/alacritty/src/config/color.rs
+++ b/alacritty/src/config/color.rs
@@ -75,6 +75,7 @@ impl Default for HintEndColors {
 }
 
 #[derive(Deserialize, Copy, Clone, Default, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct IndexedColor {
     pub color: Rgb,
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -455,6 +455,7 @@ impl<'de> Deserialize<'de> for HintContent {
 
 /// Binding for triggering a keyboard hint.
 #[derive(Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct HintBinding {
     pub key: Key,
     #[serde(default)]

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -127,7 +127,7 @@ impl Cursor {
 }
 
 #[derive(SerdeReplace, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ConfigCursorStyle {
     Shape(CursorShapeShim),
     WithBlinking {
@@ -191,7 +191,7 @@ impl From<CursorBlinking> for bool {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum Program {
     Just(String),
     WithArgs {


### PR DESCRIPTION
Currently there are still some places where `Deserialize` is used rather than `ConfigDeserialize`, which means that the built-in warning for unused fields is not emitted automatically.

To ensure users don't have invalid configurations, the `#[serde(deny_unknown_fields)]` annotation has been added to these structs, making it a hard error when an unknown field is present.