### PR TITLE
Fix the crash when shrinking scrolled terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Hyperlink preview not being shown when the terminal has exactly 2 lines
 - Crash on Windows when changing display scale factor
 - Freeze with some drivers when using GLX
+- Crash when shrinking the terminal scrolled into the history
 
 ### Removed
 

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -368,6 +368,9 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
         reversed.truncate(self.max_scroll_limit + self.lines);
         self.raw.replace_inner(reversed);
 
+        // Clamp display offset in case some lines went off.
+        self.display_offset = min(self.display_offset, self.history_size());
+
         // Reflow the primary cursor, or clamp it if reflow is disabled.
         if !reflow {
             self.cursor.point.column = min(self.cursor.point.column, Column(columns - 1));


### PR DESCRIPTION
display_offset was adjusted unconditionally, thus it could go beyound the history limits, so clamp it to history like we do in grow_colums.

Fixes #6862.