### PR TITLE
🦥 Disable icon jumping when a bell is received

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1246,12 +1246,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     },
                     TerminalEvent::Wakeup => *self.ctx.dirty = true,
                     TerminalEvent::Bell => {
-                        // Set window urgency hint when window is not focused.
-                        let focused = self.ctx.terminal.is_focused;
-                        if !focused && self.ctx.terminal.mode().contains(TermMode::URGENCY_HINTS) {
-                            self.ctx.window().set_urgent(true);
-                        }
-
                         // Ring visual bell.
                         self.ctx.display.visual_bell.ring();
 


### PR DESCRIPTION
This PR is essentially a manual fix for #2492 and #2950. It changes the terminal bell event handler so that it no longer sets the `"urgent"` flag on the window. macOS uses the urgent flag to detect if the dock icon should be jumping.

As discussed in #2950, alacritty will expect the inner process to set a terminal mode flag instead. However, in my experience, it is almost impossible to find what is sending the bell. For me, the optimal fix was just reacting to bells normally *without* causing the dock icon to jump.

I assume the PR isn't really a candidate for release - but it may help someone get rid of an annoying icon jump issue.

I track alacritty in my forked repository and add this commit on top, so that there's a version of alacritty without the dock icon jumping functionality.

