### PR TITLE
Add TOML migration recommendation to warning

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -228,7 +228,9 @@ pub fn deserialize_config(path: &Path) -> Result<Value> {
     // Convert YAML to TOML as a transitionary fallback mechanism.
     let extension = path.extension().unwrap_or_default();
     if (extension == "yaml" || extension == "yml") && !contents.trim().is_empty() {
-        warn!("YAML config {path:?} is deprecated, please migrate to TOML");
+        warn!(
+            "YAML config {path:?} is deprecated, please migrate to TOML using `alacritty migrate`"
+        );
 
         let value: serde_yaml::Value = serde_yaml::from_str(&contents)?;
         contents = toml::to_string(&value)?;


### PR DESCRIPTION
This adds a little recommendation to use `alacritty migrate` to automatically transition configuration files from YAML to TOML.