### PR TITLE
features.md: Fix configuration link typo

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -14,8 +14,8 @@ opening URLs with the keyboard. By default you can launch it using
 ### Motion
 
 The cursor motions are setup by default to mimic vi, however they are fully
-configurable. If you don't like vi's bindings, take a look at the [onfiguration
-file to change the various movements.
+configurable. If you don't like vi's bindings, take a look at the [configuration
+file](../extra/man/alacritty.5.scd) to change the various movements.
 
 ### Selection
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,8 +14,8 @@ opening URLs with the keyboard. By default you can launch it using
 ### Motion
 
 The cursor motions are setup by default to mimic vi, however they are fully
-configurable. If you don't like vi's bindings, take a look at the [configuration
-file](../extra/man/alacritty.5.scd) to change the various movements.
+configurable. If you don't like vi's bindings, take a look at the configuration
+file to change the various movements.
 
 ### Selection
 


### PR DESCRIPTION
Saw a square bracket standing in for the letter 'c'; attempted to fix with a markdown relative link instead of just removing it.