### PR TITLE
Unset `XDG_ACTIVATION_TOKEN` in alacritty_terminal

### DIFF
--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -72,6 +72,7 @@ pub fn setup_env(config: &Config) {
 
     // Prevent child processes from inheriting startup notification env.
     env::remove_var("DESKTOP_STARTUP_ID");
+    env::remove_var("XDG_ACTIVATION_TOKEN");
 
     // Set env vars from config.
     for (key, value) in config.env.iter() {


### PR DESCRIPTION
This variable is what being used for Wayland's activation stuff.

--

Don't think that this needs a changelog.