### PR TITLE
Raise double click threshold to 400ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deprecated config option `mouse_bindings`, use `mouse.bindings`
 - The default colorscheme is now based on base16 classic dark
 - IME popup now tries to not obscure the current cursor line
+- The double click threshold was raised to `400ms`
 
 ### Fixed
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -70,7 +70,7 @@ const TOUCH_SCROLL_FACTOR: f64 = 0.35;
 const MAX_TAP_DISTANCE: f64 = 20.;
 
 /// Threshold used for double_click/triple_click.
-const CLICK_THRESHOLD: Duration = Duration::from_millis(300);
+const CLICK_THRESHOLD: Duration = Duration::from_millis(400);
 
 /// Processes input from winit.
 ///


### PR DESCRIPTION
This should improve the situation with some touchpads. GTK4 is also using the same value.

--

In the issue #7011 the time between the clicks is 370ms if you look into the wayland debug logs, so I guess on some systems it's too tight?
