### PR TITLE
Use lowercase latters in bindings for h/m/l

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -465,9 +465,9 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         "0",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::First;
         "4",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Last;
         "6",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::FirstOccupied;
-        "H",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::High;
-        "M",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Middle;
-        "L",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Low;
+        "h",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::High;
+        "m",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Middle;
+        "l",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Low;
         "b",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::SemanticLeft;
         "w",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::SemanticRight;
         "e",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::SemanticRightEnd;


### PR DESCRIPTION
They were using uppercase latters, however our config expects everything as lowercase, because we're using `key_without_modifiers` + `ModifiersState`.