### PR TITLE
Use bracketed paste only for multi-char IME input

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1342,7 +1342,8 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     WindowEvent::Ime(ime) => match ime {
                         Ime::Commit(text) => {
                             *self.ctx.dirty = true;
-                            self.ctx.paste(&text, true);
+                            // Don't use bracketed paste for single char input.
+                            self.ctx.paste(&text, text.chars().count() > 1);
                             self.ctx.update_cursor_blinking();
                         },
                         Ime::Preedit(text, cursor_offset) => {


### PR DESCRIPTION
Some IME setups do only `commit` single char input, like fcitx5 when doing ru input.