### PR TITLE
Skip whitespaces for wide chars in preedit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `Maximized` startup mode not filling the screen properly on GNOME Wayland
 - `OptionAsAlt` with `OnlyLeft`/`OnlyRight` settings not working properly on macOS
 - Default Vi key bindings for `Last`/`First` actions not working on X11/Wayland
+- Cut off wide characters in preedit string
 
 ### Removed
 


### PR DESCRIPTION
While we skip the spacers for the wide characters in the grid due to them having a proper flags, the draw_string method was generating the cells with incorrect flags leading to wide chars being cut off.

--

I'm not sure I like this fix.
