### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/alacritty_config/Cargo.toml
+++ b/alacritty_config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alacritty_config"
 version = "0.1.2-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Alacritty configuration abstractions"
 homepage = "https://github.com/alacritty/alacritty"
 edition = "2021"

--- a/alacritty_config_derive/Cargo.toml
+++ b/alacritty_config_derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alacritty_config_derive"
 version = "0.2.2-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Failure resistant deserialization derive"
 homepage = "https://github.com/alacritty/alacritty"
 edition = "2021"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields