### PR TITLE
Fix keys like `+` not working on neo layouts

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -463,8 +463,8 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         ArrowLeft,                          +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Left;
         ArrowRight,                         +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Right;
         "0",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::First;
-        "4",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Last;
-        "6",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::FirstOccupied;
+        "$",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Last;
+        "^",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::FirstOccupied;
         "h",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::High;
         "m",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Middle;
         "l",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Low;
@@ -474,7 +474,7 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         "b",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::WordLeft;
         "w",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::WordRight;
         "e",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::WordRightEnd;
-        "5",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Bracket;
+        "%",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Bracket;
         Enter,                              +BindingMode::VI, +BindingMode::SEARCH; SearchAction::SearchConfirm;
         // Plain search.
         Escape,                             +BindingMode::SEARCH; SearchAction::SearchCancel;

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1050,10 +1050,11 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         for i in 0..self.ctx.config().key_bindings().len() {
             let binding = &self.ctx.config().key_bindings()[i];
 
-            // When the logical key is some named key, use it, otherwise fallback to
-            // key without modifiers to account for bindings.
-            let logical_key = if matches!(key.logical_key, Key::Character(_)) {
-                key.key_without_modifiers()
+            // We don't want the key without modifier, because it means something else most of
+            // the time. However what we want is to manually lowercase the character to account
+            // for both small and capital latters on regular characters at the same time.
+            let logical_key = if let Key::Character(ch) = key.logical_key.as_ref() {
+                Key::Character(ch.to_lowercase().into())
             } else {
                 key.logical_key.clone()
             };

--- a/extra/man/alacritty-bindings.5.scd
+++ b/extra/man/alacritty-bindings.5.scd
@@ -197,11 +197,11 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :[
 :  _"Vi|~Search"_
 :  _"First"_
-|  _"4"_
+|  _"$"_
 :  _"Shift"_
 :  _"Vi|~Search"_
 :  _"Last"_
-|  _"6"_
+|  _"^"_
 :  _"Shift"_
 :  _"Vi|~Search"_
 :  _"FirstOccupied"_
@@ -241,7 +241,7 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :  _"Shift"_
 :  _"Vi|~Search"_
 :  _"WordRightEnd"_
-|  _"5"_
+|  _"%"_
 :  _"Shift"_
 :  _"Vi|~Search"_
 :  _"Bracket"_


### PR DESCRIPTION
The key_without_modifier removes all the modifiers including the multiple shift levels, which is not desired. In alacritty we just wanted to treat uppercase and lowercase latters the same, which we can with the help of builtin functions.