### PR TITLE
Mention `Forward`/`Back` mouse buttons in man page

### DIFF
--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -553,7 +553,7 @@ This section documents the *[mouse]* table of the configuration file.
 	captures the mouse, the `Shift` modifier is automatically added as a
 	requirement.
 
-	*mouse* "Middle" | "Left" | "Right" | <number>
+	*mouse* "Middle" | "Left" | "Right" | "Back" | "Forward" | <number>
 
 		Mouse button which needs to be pressed to trigger this binding.
 


### PR DESCRIPTION
They were mentioned only in the changelog, but forgotten in the man page.