### PR TITLE
Use ahash instead of fnv and regular hash function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "alacritty"
 version = "0.13.0-dev"
 dependencies = [
+ "ahash",
  "alacritty_config",
  "alacritty_config_derive",
  "alacritty_terminal",
@@ -23,7 +36,6 @@ dependencies = [
  "crossfont",
  "dirs",
  "embed-resource",
- "fnv",
  "gl_generator",
  "glutin",
  "home",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -23,11 +23,11 @@ path = "../alacritty_config"
 version = "0.1.2-dev"
 
 [dependencies]
+ahash = { version = "0.8.3", features = ["no-rng"] }
 bitflags = "2.2.1"
 clap = { version = "4.2.7", features = ["derive", "env"] }
 copypasta = { version = "0.8.1", default-features = false }
 crossfont = { version = "0.5.0", features = ["force_system_fontconfig"] }
-fnv = "1"
 glutin = { version = "0.30.4", default-features = false, features = ["egl", "wgl"] }
 home = "0.5.5"
 libc = "0.2"

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -2,6 +2,7 @@ use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::iter;
 
+use ahash::RandomState;
 use winit::keyboard::ModifiersState;
 
 use alacritty_terminal::grid::{BidirectionalIterator, Dimensions};
@@ -307,7 +308,7 @@ pub fn visible_unique_hyperlinks_iter<T>(term: &Term<T>) -> impl Iterator<Item =
     let mut display_iter = term.grid().display_iter().peekable();
 
     // Avoid creating hints for the same hyperlinks, but from a different places.
-    let mut unique_hyperlinks = HashSet::new();
+    let mut unique_hyperlinks = HashSet::<Hyperlink, RandomState>::default();
 
     iter::from_fn(move || {
         // Find the start of the next unique hyperlink.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 use std::{env, f32, mem};
 
+use ahash::RandomState;
 use log::{debug, error, info, warn};
 #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
 use wayland_client::{Display as WaylandDisplay, EventQueue};
@@ -1044,7 +1045,7 @@ pub enum TouchPurpose {
     Scroll(TouchEvent),
     Zoom(TouchZoom),
     Tap(TouchEvent),
-    Invalid(HashSet<u64>),
+    Invalid(HashSet<u64, RandomState>),
 }
 
 impl Default for TouchPurpose {
@@ -1085,8 +1086,8 @@ impl TouchZoom {
     }
 
     /// Get active touch slots.
-    pub fn slots(&self) -> HashSet<u64> {
-        let mut set = HashSet::new();
+    pub fn slots(&self) -> HashSet<u64, RandomState> {
+        let mut set = HashSet::default();
         set.insert(self.slots.0.id);
         set.insert(self.slots.1.id);
         set
@@ -1401,7 +1402,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
 pub struct Processor {
     #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
     wayland_event_queue: Option<EventQueue>,
-    windows: HashMap<WindowId, WindowContext>,
+    windows: HashMap<WindowId, WindowContext, RandomState>,
     cli_options: CliOptions,
     config: Rc<UiConfig>,
 }
@@ -1423,7 +1424,7 @@ impl Processor {
         });
 
         Processor {
-            windows: HashMap::new(),
+            windows: Default::default(),
             config: Rc::new(config),
             cli_options,
             #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -780,7 +780,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             TouchPurpose::Tap(start) => TouchPurpose::Zoom(TouchZoom::new((start, touch))),
             TouchPurpose::Zoom(zoom) => TouchPurpose::Invalid(zoom.slots()),
             TouchPurpose::Scroll(event) | TouchPurpose::Select(event) => {
-                let mut set = HashSet::new();
+                let mut set = HashSet::default();
                 set.insert(event.id);
                 TouchPurpose::Invalid(set)
             },

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -3,6 +3,7 @@ use std::ffi::{CStr, CString};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{fmt, ptr};
 
+use ahash::RandomState;
 use crossfont::Metrics;
 use glutin::context::{ContextApi, GlContext, PossiblyCurrentContext};
 use glutin::display::{GetGlDisplay, GlDisplay};
@@ -290,13 +291,13 @@ impl GlExtensions {
     ///
     /// This function will lazyly load OpenGL extensions.
     fn contains(extension: &str) -> bool {
-        static OPENGL_EXTENSIONS: OnceCell<HashSet<&'static str>> = OnceCell::new();
+        static OPENGL_EXTENSIONS: OnceCell<HashSet<&'static str, RandomState>> = OnceCell::new();
 
         OPENGL_EXTENSIONS.get_or_init(Self::load_extensions).contains(extension)
     }
 
     /// Load available OpenGL extensions.
-    fn load_extensions() -> HashSet<&'static str> {
+    fn load_extensions() -> HashSet<&'static str, RandomState> {
         unsafe {
             let extensions = gl::GetString(gl::EXTENSIONS);
 
@@ -313,7 +314,7 @@ impl GlExtensions {
             } else {
                 match CStr::from_ptr(extensions as *mut _).to_str() {
                     Ok(ext) => ext.split_whitespace().collect(),
-                    Err(_) => HashSet::new(),
+                    Err(_) => Default::default(),
                 }
             }
         }

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::mem;
 
+use ahash::RandomState;
 use crossfont::Metrics;
 
 use alacritty_terminal::grid::Dimensions;
@@ -157,7 +158,7 @@ impl RenderLine {
 /// Lines for underline and strikeout.
 #[derive(Default)]
 pub struct RenderLines {
-    inner: HashMap<Flags, Vec<RenderLine>>,
+    inner: HashMap<Flags, Vec<RenderLine>, RandomState>,
 }
 
 impl RenderLines {

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
-use std::hash::BuildHasherDefault;
 
+use ahash::RandomState;
 use crossfont::{
     Error as RasterizerError, FontDesc, FontKey, GlyphKey, Metrics, Rasterize, RasterizedGlyph,
     Rasterizer, Size, Slant, Style, Weight,
 };
-use fnv::FnvHasher;
 use log::{error, info};
 use unicode_width::UnicodeWidthChar;
 
@@ -46,7 +45,7 @@ pub struct Glyph {
 /// representations of the same code point.
 pub struct GlyphCache {
     /// Cache of buffered glyphs.
-    cache: HashMap<GlyphKey, Glyph, BuildHasherDefault<FnvHasher>>,
+    cache: HashMap<GlyphKey, Glyph, RandomState>,
 
     /// Rasterizer for loading new glyphs.
     rasterizer: Rasterizer,
@@ -91,7 +90,7 @@ impl GlyphCache {
         let metrics = rasterizer.metrics(regular, font.size())?;
 
         Ok(Self {
-            cache: HashMap::default(),
+            cache: Default::default(),
             rasterizer,
             font_size: font.size(),
             font_key: regular,


### PR DESCRIPTION
After evaluation of the ahash with the data alacritty uses it was discovered that it's 1.5-2x times faster when getting the already hashed values, which is the primary cases for alacritty's renderer.

Given that ahash is generally faster, all the HashSet and HashMap's inside the alacritty were changed to use it as a hasher function.

--

You can play with the benchmark here https://git.sr.ht/~kchibisov/hash-bench it uses `cargo bench`.

My results were

```
running 6 tests
test benches::ahash_get    ... bench:      38,873 ns/iter (+/- 1,023)
test benches::ahash_insert ... bench:      84,969 ns/iter (+/- 2,716)
test benches::fnv_get      ... bench:      57,062 ns/iter (+/- 982)
test benches::fnv_insert   ... bench:      90,400 ns/iter (+/- 1,016)
test benches::std_get      ... bench:     164,550 ns/iter (+/- 3,032)
test benches::std_insert   ... bench:     238,054 ns/iter (+/- 7,363)
```

As you can see, the `get` perf of `ahash` is way better than other options.