### PR TITLE
Add `terminal` config section to control OSCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The default colorscheme is now based on base16 classic dark
 - IME popup now tries to not obscure the current cursor line
 - The double click threshold was raised to `400ms`
+- OSC 52 paste ability is now **disabled by default**; use `terminal.osc52` to adjust it
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.19.2-dev"
+version = "0.20.0-dev"
 dependencies = [
  "alacritty_config",
  "alacritty_config_derive",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.65.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.19.2-dev"
+version = "0.20.0-dev"
 default-features = false
 
 [dependencies.alacritty_config_derive]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.19.2-dev"
+version = "0.20.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -31,8 +31,33 @@ pub struct Config {
     /// Cursor configuration.
     pub cursor: Cursor,
 
+    /// Terminal specific settings.
+    pub terminal: Terminal,
+
     #[config(flatten)]
     pub pty_config: PtyConfig,
+}
+
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct Terminal {
+    // OSC 52 handling (clipboard handling).
+    pub osc52: Osc52,
+}
+
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq, Default)]
+pub enum Osc52 {
+    /// The handling of the escape sequence is disabled.
+    Disabled,
+    /// Only copy sequence is accepted.
+    ///
+    /// This option is the default as a compromiss between entirely
+    /// disabling it (the most secure) and allowing `paste` (the less secure).
+    #[default]
+    OnlyCopy,
+    /// Only paste sequence is accepted.
+    OnlyPaste,
+    /// Both are accepted.
+    CopyPaste,
 }
 
 #[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq, Default)]

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -534,6 +534,20 @@ This section documents the *[cursor]* table of the configuration file.
 
 	Default: _0.15_
 
+# Terminal
+
+This section documents the *[terminal]* table of the configuration file.
+
+*osc52* "Disabled" | "OnlyCopy" | "OnlyPaste" | "CopyPaste"
+
+	Controls the ability to write to the system clipboard with the _OSC 52_
+	escape sequence. While this escape sequence is useful to copy contents
+	from the remote server, the ability to paste is not that necessary
+	given that normal `Paste` action could be used instead and such
+	sequence could be abused.
+
+	Default: _"OnlyCopy"_
+
 # Mouse
 
 This section documents the *[mouse]* table of the configuration file.

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -542,9 +542,9 @@ This section documents the *[terminal]* table of the configuration file.
 
 	Controls the ability to write to the system clipboard with the _OSC 52_
 	escape sequence. While this escape sequence is useful to copy contents
-	from the remote server, the ability to paste is not that necessary
-	given that normal `Paste` action could be used instead and such
-	sequence could be abused.
+	from the remote server, allowing any application to read from the clipboard
+	can be easily abused while not providing significant benefits over
+	explicitly pasting text.
 
 	Default: _"OnlyCopy"_
 


### PR DESCRIPTION
Some environments demand certain OSC sequences to be disabled or some escape sequence could require handling which is out of scope of alacritty, but could be done by external script (OSC 777).

Added section for now just handles the `OSC 52` sequence and changes its default to be `OnlyCopy`, which is handy for remote copy, but `Paste` is redundant because normal `Paste` hotkey could be used as well.

Fixes #3386.