### PR TITLE
Copy global IPC options for new windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for dynamically loading conpty.dll on Windows
 - Support for keybindings with dead keys
 - `Back`/`Forward` mouse buttons support in bindings
+- Copy global IPC options (`-w -1`) for new windows
 
 ### Changed
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1403,6 +1403,7 @@ pub struct Processor {
     #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
     wayland_event_queue: Option<EventQueue>,
     windows: HashMap<WindowId, WindowContext, RandomState>,
+    global_ipc_options: Vec<String>,
     cli_options: CliOptions,
     config: Rc<UiConfig>,
 }
@@ -1424,11 +1425,12 @@ impl Processor {
         });
 
         Processor {
-            windows: Default::default(),
             config: Rc::new(config),
             cli_options,
             #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
             wayland_event_queue,
+            global_ipc_options: Default::default(),
+            windows: Default::default(),
         }
     }
 
@@ -1464,7 +1466,7 @@ impl Processor {
         options: WindowOptions,
     ) -> Result<(), Box<dyn Error>> {
         let window = self.windows.iter().next().as_ref().unwrap().1;
-        let window_context = window.additional(
+        let mut window_context = window.additional(
             event_loop,
             proxy,
             self.config.clone(),
@@ -1472,6 +1474,11 @@ impl Processor {
             #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
             self.wayland_event_queue.as_ref(),
         )?;
+
+        // Apply global IPC options.
+        let options = self.global_ipc_options.clone();
+        let ipc_config = IpcConfig { options, window_id: None, reset: false };
+        window_context.update_ipc_config(self.config.clone(), ipc_config);
 
         self.windows.insert(window_context.id(), window_context);
         Ok(())
@@ -1609,6 +1616,15 @@ impl Processor {
                     payload: EventType::IpcConfig(ipc_config),
                     window_id,
                 }) => {
+                    // Persist global options for future windows.
+                    if window_id.is_none() {
+                        if ipc_config.reset {
+                            self.global_ipc_options.clear();
+                        } else {
+                            self.global_ipc_options.extend_from_slice(&ipc_config.options);
+                        }
+                    }
+
                     for (_, window_context) in self
                         .windows
                         .iter_mut()

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1468,6 +1468,8 @@ impl Processor {
         options: WindowOptions,
     ) -> Result<(), Box<dyn Error>> {
         let window = self.windows.iter().next().as_ref().unwrap().1;
+
+        #[allow(unused_mut)]
         let mut window_context = window.additional(
             event_loop,
             proxy,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1403,6 +1403,7 @@ pub struct Processor {
     #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
     wayland_event_queue: Option<EventQueue>,
     windows: HashMap<WindowId, WindowContext, RandomState>,
+    #[cfg(unix)]
     global_ipc_options: Vec<String>,
     cli_options: CliOptions,
     config: Rc<UiConfig>,
@@ -1429,6 +1430,7 @@ impl Processor {
             cli_options,
             #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
             wayland_event_queue,
+            #[cfg(unix)]
             global_ipc_options: Default::default(),
             windows: Default::default(),
         }
@@ -1476,9 +1478,12 @@ impl Processor {
         )?;
 
         // Apply global IPC options.
-        let options = self.global_ipc_options.clone();
-        let ipc_config = IpcConfig { options, window_id: None, reset: false };
-        window_context.update_ipc_config(self.config.clone(), ipc_config);
+        #[cfg(unix)]
+        {
+            let options = self.global_ipc_options.clone();
+            let ipc_config = IpcConfig { options, window_id: None, reset: false };
+            window_context.update_ipc_config(self.config.clone(), ipc_config);
+        }
 
         self.windows.insert(window_context.id(), window_context);
         Ok(())


### PR DESCRIPTION
This patch stores all options set for the Window ID `-1` and automatically applies them to new windows after their creation.

This in theory makes it possible to have a fully dynamic "default config" without having to reapply it for every new window.

Closes #7128.