### PR TITLE
Don't report alternate scroll while search/vi active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The double click threshold was raised to `400ms`
 - OSC 52 paste ability is now **disabled by default**; use `terminal.osc52` to adjust it
 - Apply `colors.transparent_background_colors` for selections, hints, and search matches
+- Alternate scroll is no longer reported while Vi mode or Search is active
 
 ### Fixed
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -713,6 +713,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             .mode()
             .contains(TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL)
             && !self.ctx.modifiers().state().shift_key()
+            && !self.ctx.terminal().mode().contains(TermMode::VI)
+            && !self.ctx.search_active()
         {
             self.ctx.mouse_mut().accumulated_scroll.x += new_scroll_x_px * multiplier;
             self.ctx.mouse_mut().accumulated_scroll.y += new_scroll_y_px * multiplier;


### PR DESCRIPTION
Reporting them is a bit confusing, since it could result in unpredictable input, when the user will try to scroll with the mouse wheel.

The mouse mode reporting was left untouched, since it was intended to be like that, but it could be alterated later, if it'll be undesirable either