### PR TITLE
Fix scaling for offset and glyph offset

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -400,7 +400,7 @@ impl Display {
         let rasterizer = Rasterizer::new(scale_factor)?;
 
         debug!("Loading \"{}\" font", &config.font.normal().family);
-        let mut glyph_cache = GlyphCache::new(rasterizer, &config.font)?;
+        let mut glyph_cache = GlyphCache::new(rasterizer, &config.font, window.scale_factor)?;
 
         let metrics = glyph_cache.font_metrics();
         let (cell_width, cell_height) = compute_cell_size(config, &metrics, window.scale_factor);

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -1610,7 +1610,11 @@ impl FrameTimer {
 ///
 /// This will return a tuple of the cell width and height.
 #[inline]
-fn compute_cell_size(config: &UiConfig, metrics: &crossfont::Metrics, scale_factor: f64) -> (f32, f32) {
+fn compute_cell_size(
+    config: &UiConfig,
+    metrics: &crossfont::Metrics,
+    scale_factor: f64,
+) -> (f32, f32) {
     let offset_x = f64::from(config.font.offset.x);
     let offset_y = f64::from(config.font.offset.y);
     (

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -403,7 +403,7 @@ impl Display {
         let mut glyph_cache = GlyphCache::new(rasterizer, &config.font)?;
 
         let metrics = glyph_cache.font_metrics();
-        let (cell_width, cell_height) = compute_cell_size(config, &metrics);
+        let (cell_width, cell_height) = compute_cell_size(config, &metrics, window.scale_factor);
 
         // Resize the window to account for the user configured size.
         if let Some(dimensions) = config.window.dimensions() {
@@ -575,7 +575,7 @@ impl Display {
         let _ = glyph_cache.update_font_size(font, scale_factor);
 
         // Compute new cell sizes.
-        compute_cell_size(config, &glyph_cache.font_metrics())
+        compute_cell_size(config, &glyph_cache.font_metrics(), scale_factor)
     }
 
     /// Reset glyph cache.
@@ -1610,12 +1610,12 @@ impl FrameTimer {
 ///
 /// This will return a tuple of the cell width and height.
 #[inline]
-fn compute_cell_size(config: &UiConfig, metrics: &crossfont::Metrics) -> (f32, f32) {
+fn compute_cell_size(config: &UiConfig, metrics: &crossfont::Metrics, scale_factor: f64) -> (f32, f32) {
     let offset_x = f64::from(config.font.offset.x);
     let offset_y = f64::from(config.font.offset.y);
     (
-        (metrics.average_advance + offset_x).floor().max(1.) as f32,
-        (metrics.line_height + offset_y).floor().max(1.) as f32,
+        (metrics.average_advance + offset_x * scale_factor).floor().max(1.) as f32,
+        (metrics.line_height + offset_y * scale_factor).floor().max(1.) as f32,
     )
 }
 

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -833,13 +833,11 @@ mod tests {
 
         // Test coverage of box drawing characters.
         for character in '\u{2500}'..='\u{259f}' {
-            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, 1.0)
-                .is_some());
+            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, 1.0).is_some());
         }
 
         for character in ('\u{2450}'..'\u{2500}').chain('\u{25a0}'..'\u{2600}') {
-            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, 1.0)
-                .is_none());
+            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, 1.0).is_none());
         }
     }
 }

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -833,12 +833,12 @@ mod tests {
 
         // Test coverage of box drawing characters.
         for character in '\u{2500}'..='\u{259f}' {
-            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, f64::from(1.0))
+            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, 1.0)
                 .is_some());
         }
 
         for character in ('\u{2450}'..'\u{2500}').chain('\u{25a0}'..'\u{2600}') {
-            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, f64::from(1.0))
+            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, 1.0)
                 .is_none());
         }
     }

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -21,25 +21,33 @@ pub fn builtin_glyph(
     metrics: &Metrics,
     offset: &Delta<i8>,
     glyph_offset: &Delta<i8>,
+    scale_factor: f64,
 ) -> Option<RasterizedGlyph> {
     let mut glyph = match character {
         // Box drawing characters and block elements.
-        '\u{2500}'..='\u{259f}' => box_drawing(character, metrics, offset),
+        '\u{2500}'..='\u{259f}' => box_drawing(character, metrics, offset, scale_factor),
         _ => return None,
     };
 
     // Since we want to ignore `glyph_offset` for the built-in font, subtract it to compensate its
     // addition when loading glyphs in the renderer.
-    glyph.left -= glyph_offset.x as i32;
-    glyph.top -= glyph_offset.y as i32;
+    glyph.left -= ((glyph_offset.x as f64) * scale_factor) as i32;
+    glyph.top -= ((glyph_offset.y as f64) * scale_factor) as i32;
 
     Some(glyph)
 }
 
-fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> RasterizedGlyph {
+fn box_drawing(
+    character: char,
+    metrics: &Metrics,
+    offset: &Delta<i8>,
+    scale_factor: f64,
+) -> RasterizedGlyph {
     // Ensure that width and height is at least one.
-    let height = (metrics.line_height as i32 + offset.y as i32).max(1) as usize;
-    let width = (metrics.average_advance as i32 + offset.x as i32).max(1) as usize;
+    let offset_y = ((offset.y as f64) * scale_factor) as i32;
+    let offset_x = ((offset.x as f64) * scale_factor) as i32;
+    let height = (metrics.line_height as i32 + offset_y).max(1) as usize;
+    let width = (metrics.average_advance as i32 + offset_x).max(1) as usize;
     // Use one eight of the cell width, since this is used as a step size for block elemenets.
     let stroke_size = cmp::max((width as f32 / 8.).round() as usize, 1);
     let heavy_stroke_size = stroke_size * 2;
@@ -482,7 +490,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
         _ => unreachable!(),
     }
 
-    let top = height as i32 + metrics.descent as i32;
+    let top = height as i32 + ((metrics.descent as f64) * scale_factor) as i32;
     let buffer = BitmapBuffer::Rgb(canvas.into_raw());
     RasterizedGlyph {
         character,
@@ -825,11 +833,13 @@ mod tests {
 
         // Test coverage of box drawing characters.
         for character in '\u{2500}'..='\u{259f}' {
-            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset).is_some());
+            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, f64::from(1.0))
+                .is_some());
         }
 
         for character in ('\u{2450}'..'\u{2500}').chain('\u{25a0}'..'\u{2600}') {
-            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset).is_none());
+            assert!(builtin_glyph(character, &metrics, &offset, &glyph_offset, f64::from(1.0))
+                .is_none());
         }
     }
 }

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -82,7 +82,11 @@ pub struct GlyphCache {
 }
 
 impl GlyphCache {
-    pub fn new(mut rasterizer: Rasterizer, font: &Font, scale_factor: f64) -> Result<GlyphCache, crossfont::Error> {
+    pub fn new(
+        mut rasterizer: Rasterizer,
+        font: &Font,
+        scale_factor: f64,
+    ) -> Result<GlyphCache, crossfont::Error> {
         let (regular, bold, italic, bold_italic) = Self::compute_font_keys(font, &mut rasterizer)?;
 
         // Need to load at least one glyph for the face before calling metrics.

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -219,6 +219,7 @@ impl GlyphCache {
                     &self.metrics,
                     &self.font_offset,
                     &self.glyph_offset,
+                    self.scale_factor,
                 )
             })
             .flatten()

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -76,10 +76,13 @@ pub struct GlyphCache {
 
     /// Whether to use the built-in font for box drawing characters.
     builtin_box_drawing: bool,
+
+    /// Display scale factor
+    scale_factor: f64,
 }
 
 impl GlyphCache {
-    pub fn new(mut rasterizer: Rasterizer, font: &Font) -> Result<GlyphCache, crossfont::Error> {
+    pub fn new(mut rasterizer: Rasterizer, font: &Font, scale_factor: f64) -> Result<GlyphCache, crossfont::Error> {
         let (regular, bold, italic, bold_italic) = Self::compute_font_keys(font, &mut rasterizer)?;
 
         // Need to load at least one glyph for the face before calling metrics.
@@ -101,6 +104,7 @@ impl GlyphCache {
             glyph_offset: font.glyph_offset,
             metrics,
             builtin_box_drawing: font.builtin_box_drawing,
+            scale_factor,
         })
     }
 
@@ -246,8 +250,8 @@ impl GlyphCache {
     where
         L: LoadGlyph,
     {
-        glyph.left += i32::from(self.glyph_offset.x);
-        glyph.top += i32::from(self.glyph_offset.y);
+        glyph.left += ((self.glyph_offset.x as f64) * self.scale_factor) as i32;
+        glyph.top += ((self.glyph_offset.y as f64) * self.scale_factor) as i32;
         glyph.top -= self.metrics.descent as i32;
 
         // The metrics of zero-width characters are based on rendering
@@ -284,6 +288,7 @@ impl GlyphCache {
         self.rasterizer.update_dpr(scale_factor as f32);
         self.font_offset = font.offset;
         self.glyph_offset = font.glyph_offset;
+        self.scale_factor = scale_factor;
 
         // Recompute font keys.
         let (regular, bold, italic, bold_italic) =


### PR DESCRIPTION
# Issue

Currently, offsets and glyph offsets are not scaled with the display scale factor and applied as-is. When using a single display this is not an issue because the offset values can be manually set to achieve the desired results. When using both low-DPI and high-DPI displays however, the missing scaling leads to inconsistent cell size proportions (see attached screenshot).

![Screenshot showing cell size inconsistency](https://github.com/alacritty/alacritty/assets/12427009/48b04ffd-a3f8-43a2-b2a1-cccbd30afc37)

# Changes

This PR adds scaling for both offsets (applied in cell size calculation) and glyph offsets (applied in glyph cache). The changes require the glyph cache to be aware of the scale factor.