### PR TITLE
Remove winit dependency from alacritty_config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,6 @@ dependencies = [
  "log",
  "serde",
  "toml 0.7.4",
- "winit",
 ]
 
 [[package]]

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use winit::window::{Fullscreen, Theme};
 
 #[cfg(target_os = "macos")]
-use winit::platform::macos::OptionAsAlt;
+use alacritty_terminal::config::OptionAsAlt;
 
 use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
 use alacritty_terminal::config::{Percentage, LOG_TARGET_CONFIG};
@@ -51,7 +51,7 @@ pub struct WindowConfig {
 
     /// Controls which `Option` key should be treated as `Alt`.
     #[cfg(target_os = "macos")]
-    pub option_as_alt: OptionAsAlt,
+    option_as_alt: OptionAsAlt,
 
     /// Resize increments.
     pub resize_increments: bool,
@@ -136,6 +136,16 @@ impl WindowConfig {
     #[inline]
     pub fn maximized(&self) -> bool {
         self.startup_mode == StartupMode::Maximized
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn option_as_alt(&self) -> winit::platform::macos::OptionAsAlt {
+        match self.option_as_alt {
+            OptionAsAlt::OnlyLeft => winit::platform::macos::OptionAsAlt::OnlyLeft,
+            OptionAsAlt::OnlyRight => winit::platform::macos::OptionAsAlt::OnlyRight,
+            OptionAsAlt::Both => winit::platform::macos::OptionAsAlt::Both,
+            OptionAsAlt::None => winit::platform::macos::OptionAsAlt::None,
+        }
     }
 }
 

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -8,6 +8,8 @@ use winit::window::{Fullscreen, Theme};
 
 #[cfg(target_os = "macos")]
 use alacritty_terminal::config::OptionAsAlt;
+#[cfg(target_os = "macos")]
+use winit::platform::macos::OptionAsAlt as WinitOptionAsAlt;
 
 use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
 use alacritty_terminal::config::{Percentage, LOG_TARGET_CONFIG};
@@ -139,12 +141,12 @@ impl WindowConfig {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn option_as_alt(&self) -> winit::platform::macos::OptionAsAlt {
+    pub fn option_as_alt(&self) -> WinitOptionAsAlt {
         match self.option_as_alt {
-            OptionAsAlt::OnlyLeft => winit::platform::macos::OptionAsAlt::OnlyLeft,
-            OptionAsAlt::OnlyRight => winit::platform::macos::OptionAsAlt::OnlyRight,
-            OptionAsAlt::Both => winit::platform::macos::OptionAsAlt::Both,
-            OptionAsAlt::None => winit::platform::macos::OptionAsAlt::None,
+            OptionAsAlt::OnlyLeft => WinitOptionAsAlt::OnlyLeft,
+            OptionAsAlt::OnlyRight => WinitOptionAsAlt::OnlyRight,
+            OptionAsAlt::Both => WinitOptionAsAlt::Both,
+            OptionAsAlt::None => WinitOptionAsAlt::None,
         }
     }
 }

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -7,8 +7,6 @@ use serde::{Deserialize, Deserializer, Serialize};
 use winit::window::{Fullscreen, Theme};
 
 #[cfg(target_os = "macos")]
-use alacritty_terminal::config::OptionAsAlt;
-#[cfg(target_os = "macos")]
 use winit::platform::macos::OptionAsAlt as WinitOptionAsAlt;
 
 use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
@@ -274,4 +272,21 @@ impl<'de> Deserialize<'de> for Class {
 
         deserializer.deserialize_any(ClassVisitor)
     }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(ConfigDeserialize, Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionAsAlt {
+    /// The left `Option` key is treated as `Alt`.
+    OnlyLeft,
+
+    /// The right `Option` key is treated as `Alt`.
+    OnlyRight,
+
+    /// Both `Option` keys are treated as `Alt`.
+    Both,
+
+    /// No special handling is applied for `Option` key.
+    #[default]
+    None,
 }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -314,7 +314,7 @@ impl Window {
 
     #[cfg(target_os = "macos")]
     pub fn get_platform_window(_: &Identity, window_config: &WindowConfig) -> WindowBuilder {
-        let window = WindowBuilder::new().with_option_as_alt(window_config.option_as_alt);
+        let window = WindowBuilder::new().with_option_as_alt(window_config.option_as_alt());
 
         match window_config.decorations {
             Decorations::Full => window,

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1027,7 +1027,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
     #[cfg(target_os = "macos")]
     fn alt_send_esc(&mut self) -> bool {
-        let option_as_alt = self.ctx.config().window.option_as_alt;
+        let option_as_alt = self.ctx.config().window.option_as_alt();
         self.ctx.modifiers().state().alt_key()
             && (option_as_alt == OptionAsAlt::Both
                 || (option_as_alt == OptionAsAlt::OnlyLeft

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -337,7 +337,7 @@ impl WindowContext {
         self.display.window.set_has_shadow(opaque);
 
         #[cfg(target_os = "macos")]
-        self.display.window.set_option_as_alt(self.config.window.option_as_alt);
+        self.display.window.set_option_as_alt(self.config.window.option_as_alt());
 
         // Change opacity state.
         self.display.window.set_transparent(!opaque);

--- a/alacritty_config/Cargo.toml
+++ b/alacritty_config/Cargo.toml
@@ -12,6 +12,3 @@ rust-version = "1.65.0"
 log = { version = "0.4.17", features = ["serde"] }
 serde = "1.0.163"
 toml = "0.7.1"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-winit = { version = "0.29.0-beta.0", default-features = false, features = ["serde"] }

--- a/alacritty_config/src/lib.rs
+++ b/alacritty_config/src/lib.rs
@@ -32,9 +32,6 @@ impl_replace!(
     LevelFilter,
 );
 
-#[cfg(target_os = "macos")]
-impl_replace!(winit::platform::macos::OptionAsAlt,);
-
 fn replace_simple<'de, D>(data: &mut D, value: Value) -> Result<(), Box<dyn Error>>
 where
     D: Deserialize<'de>,

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -215,22 +215,6 @@ impl From<CursorBlinking> for bool {
     }
 }
 
-#[derive(ConfigDeserialize, Default, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OptionAsAlt {
-    /// The left `Option` key is treated as `Alt`.
-    OnlyLeft,
-
-    /// The right `Option` key is treated as `Alt`.
-    OnlyRight,
-
-    /// Both `Option` keys are treated as `Alt`.
-    Both,
-
-    /// No special handling is applied for `Option` key.
-    #[default]
-    None,
-}
-
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Program {

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -215,6 +215,22 @@ impl From<CursorBlinking> for bool {
     }
 }
 
+#[derive(ConfigDeserialize, Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionAsAlt {
+    /// The left `Option` key is treated as `Alt`.
+    OnlyLeft,
+
+    /// The right `Option` key is treated as `Alt`.
+    OnlyRight,
+
+    /// Both `Option` keys are treated as `Alt`.
+    Both,
+
+    /// No special handling is applied for `Option` key.
+    #[default]
+    None,
+}
+
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Program {


### PR DESCRIPTION
The [Zed](https://zed.dev) editor uses the `alacritty_terminal` crate as a library. Currently, that requires that we compile `winit` and its dependencies as part of our build, because the `alacritty_config` depends on `winit` for the `OptionAsAlt` type.

This PR removes the dependency on `winit` from the `alacritty_config` crate. I did this by creating a verbatim copy of the `OptionAsAlt` enum in the `alacritty::config::window` module, and wrote a function that converts this enum into its `winit` equivalent.

It adds a little bit of boilerplate to that module, for converting between the two types, but is pretty simple, and makes the `alacritty_terminal` crate more convenient to use as a library on macOS.