### PR TITLE
feat: match colorscheme with system display mode

### DIFF
--- a/alacritty/src/config/color.rs
+++ b/alacritty/src/config/color.rs
@@ -19,7 +19,7 @@ pub struct Colors {
     pub hints: HintColors,
     pub transparent_background_colors: bool,
     pub draw_bold_text_with_bright_colors: bool,
-    footer_bar: BarColors,
+    pub footer_bar: BarColors,
 }
 
 impl Colors {

--- a/alacritty/src/config/colorscheme.rs
+++ b/alacritty/src/config/colorscheme.rs
@@ -1,11 +1,7 @@
 use alacritty_config_derive::ConfigDeserialize;
 use alacritty_terminal::term::color::{CellRgb, Rgb};
 
-use crate::config::color::BrightColors;
-use crate::config::color::Colors;
-use crate::config::color::InvertedCellColors;
-use crate::config::color::NormalColors;
-use crate::config::color::PrimaryColors;
+use crate::config::color::{BrightColors, Colors, InvertedCellColors, NormalColors, PrimaryColors};
 
 #[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ThemeVariant {

--- a/alacritty/src/config/colorscheme.rs
+++ b/alacritty/src/config/colorscheme.rs
@@ -1,0 +1,81 @@
+use alacritty_terminal::term::color::Rgb;
+
+use super::color::{BrightColors, Colors, NormalColors, PrimaryColors};
+
+pub enum ThemeVariant {
+    Light,
+    Dark,
+    System,
+}
+
+pub struct ColorScheme {
+    pub theme_variant: ThemeVariant,
+    pub light_colors: Colors,
+    pub dark_colors: Colors,
+}
+
+impl Default for ColorScheme {
+    fn default() -> ColorScheme {
+        let light_colors = Colors {
+            primary: PrimaryColors {
+                foreground: Rgb::new(0x00, 0x00, 0x00),
+                background: Rgb::new(0xff, 0xff, 0xff),
+                bright_foreground: Default::default(),
+                dim_foreground: Default::default(),
+            },
+            normal: NormalColors {
+                black: Rgb::new(0xd7, 0xd7, 0xd7),
+                red: Rgb::new(0x97, 0x25, 0x00),
+                green: Rgb::new(0x31, 0x5b, 0x00),
+                yellow: Rgb::new(0x70, 0x48, 0x0f),
+                blue: Rgb::new(0x25, 0x44, 0xbb),
+                magenta: Rgb::new(0x8f, 0x00, 0x75),
+                cyan: Rgb::new(0x30, 0x51, 0x7f),
+                white: Rgb::new(0x00, 0x00, 0x00),
+            },
+            bright: BrightColors {
+                black: Rgb::new(0x50, 0x50, 0x50),
+                red: Rgb::new(0xa6, 0x00, 0x00),
+                green: Rgb::new(0x00, 0x5e, 0x00),
+                yellow: Rgb::new(0x81, 0x3e, 0x00),
+                blue: Rgb::new(0x00, 0x31, 0xa9),
+                magenta: Rgb::new(0x72, 0x10, 0x45),
+                cyan: Rgb::new(0x00, 0x53, 0x8b),
+                white: Rgb::new(0x00, 0x00, 0x00),
+            },
+            ..Default::default()
+        };
+
+        let dark_colors = Colors {
+            primary: PrimaryColors {
+                foreground: Rgb::new(0xff, 0xff, 0xff),
+                background: Rgb::new(0x00, 0x00, 0x00),
+                bright_foreground: Default::default(),
+                dim_foreground: Default::default(),
+            },
+            normal: NormalColors {
+                black: Rgb::new(0x32, 0x32, 0x32),
+                red: Rgb::new(0xff, 0x80, 0x59),
+                green: Rgb::new(0x44, 0xbc, 0x44),
+                yellow: Rgb::new(0xd0, 0xbc, 0x00),
+                blue: Rgb::new(0x2f, 0xaf, 0xff),
+                magenta: Rgb::new(0xfe, 0xac, 0xd0),
+                cyan: Rgb::new(0x00, 0xd3, 0xd0),
+                white: Rgb::new(0xff, 0xff, 0xff),
+            },
+            bright: BrightColors {
+                black: Rgb::new(0x53, 0x53, 0x53),
+                red: Rgb::new(0xef, 0x8b, 0x50),
+                green: Rgb::new(0x70, 0xb9, 0x00),
+                yellow: Rgb::new(0xc0, 0xc5, 0x30),
+                blue: Rgb::new(0x79, 0xa8, 0xff),
+                magenta: Rgb::new(0xf7, 0x8f, 0xe7),
+                cyan: Rgb::new(0x4a, 0xe2, 0xf0),
+                white: Rgb::new(0xff, 0xff, 0xff),
+            },
+            ..Default::default()
+        };
+
+        ColorScheme { theme_variant: ThemeVariant::System, light_colors, dark_colors }
+    }
+}

--- a/alacritty/src/config/colorscheme.rs
+++ b/alacritty/src/config/colorscheme.rs
@@ -1,5 +1,5 @@
-use alacritty_terminal::term::color::{CellRgb, Rgb};
 use alacritty_config_derive::ConfigDeserialize;
+use alacritty_terminal::term::color::{CellRgb, Rgb};
 
 use crate::config::color::BrightColors;
 use crate::config::color::Colors;
@@ -24,9 +24,9 @@ pub struct ColorScheme {
 impl Default for ColorScheme {
     fn default() -> ColorScheme {
         let cursor_colors = InvertedCellColors {
-                foreground: CellRgb::Rgb(Rgb::new(0x28, 0x28, 0x28)),
-                background: CellRgb::Rgb(Rgb::new(0x00, 0x00, 0x00)),
-            };
+            foreground: CellRgb::Rgb(Rgb::new(0x28, 0x28, 0x28)),
+            background: CellRgb::Rgb(Rgb::new(0x00, 0x00, 0x00)),
+        };
         let light_colors = Colors {
             primary: PrimaryColors {
                 foreground: Rgb::new(0x00, 0x00, 0x00),

--- a/alacritty/src/config/colorscheme.rs
+++ b/alacritty/src/config/colorscheme.rs
@@ -7,14 +7,14 @@ use crate::config::color::InvertedCellColors;
 use crate::config::color::NormalColors;
 use crate::config::color::PrimaryColors;
 
-#[derive(ConfigDeserialize, Clone, Debug, PartialEq)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ThemeVariant {
     Light,
     Dark,
     System,
 }
 
-#[derive(ConfigDeserialize, Clone, Debug, PartialEq)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ColorScheme {
     pub mode: ThemeVariant,
     pub light: Colors,

--- a/alacritty/src/config/colorscheme.rs
+++ b/alacritty/src/config/colorscheme.rs
@@ -1,22 +1,24 @@
 use alacritty_terminal::term::color::{CellRgb, Rgb};
+use alacritty_config_derive::ConfigDeserialize;
 
-use super::color::List;
 use crate::config::color::BrightColors;
 use crate::config::color::Colors;
 use crate::config::color::InvertedCellColors;
 use crate::config::color::NormalColors;
 use crate::config::color::PrimaryColors;
 
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq)]
 pub enum ThemeVariant {
     Light,
     Dark,
     System,
 }
 
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq)]
 pub struct ColorScheme {
-    pub theme_variant: ThemeVariant,
-    pub light_colors: List,
-    pub dark_colors: List,
+    pub mode: ThemeVariant,
+    pub light: Colors,
+    pub dark: Colors,
 }
 
 impl Default for ColorScheme {
@@ -25,7 +27,7 @@ impl Default for ColorScheme {
                 foreground: CellRgb::Rgb(Rgb::new(0x28, 0x28, 0x28)),
                 background: CellRgb::Rgb(Rgb::new(0x00, 0x00, 0x00)),
             };
-        let light_colors = List::from(&Colors {
+        let light_colors = Colors {
             primary: PrimaryColors {
                 foreground: Rgb::new(0x00, 0x00, 0x00),
                 background: Rgb::new(0xff, 0xff, 0xff),
@@ -56,10 +58,10 @@ impl Default for ColorScheme {
                 white: Rgb::new(0x00, 0x00, 0x00),
             },
             ..Default::default()
-        });
+        };
 
-        let dark_colors = List::from(&Colors::default());
+        let dark_colors = Colors::default();
 
-        ColorScheme { theme_variant: ThemeVariant::System, light_colors, dark_colors }
+        ColorScheme { mode: ThemeVariant::System, light: light_colors, dark: dark_colors }
     }
 }

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -14,6 +14,7 @@ use alacritty_terminal::config::LOG_TARGET_CONFIG;
 
 pub mod bell;
 pub mod color;
+pub mod colorscheme;
 pub mod debug;
 pub mod font;
 pub mod monitor;

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -14,7 +14,6 @@ use alacritty_terminal::config::LOG_TARGET_CONFIG;
 
 pub mod bell;
 pub mod color;
-pub mod colorscheme;
 pub mod debug;
 pub mod font;
 pub mod monitor;

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -18,11 +18,11 @@ use crate::config::bindings::{
     self, Action, Binding, BindingKey, KeyBinding, ModeWrapper, ModsWrapper, MouseBinding,
 };
 use crate::config::color::Colors;
+use crate::config::colorscheme::ColorScheme;
 use crate::config::debug::Debug;
 use crate::config::font::Font;
 use crate::config::mouse::{Mouse, MouseBindings};
 use crate::config::window::WindowConfig;
-use crate::config::colorscheme::ColorScheme;
 
 /// Regex used for the default URL hint.
 #[rustfmt::skip]

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -22,6 +22,7 @@ use crate::config::debug::Debug;
 use crate::config::font::Font;
 use crate::config::mouse::{Mouse, MouseBindings};
 use crate::config::window::WindowConfig;
+use crate::config::colorscheme::ColorScheme;
 
 /// Regex used for the default URL hint.
 #[rustfmt::skip]
@@ -55,6 +56,8 @@ pub struct UiConfig {
 
     /// RGB values for colors.
     pub colors: Colors,
+
+    pub colorscheme: ColorScheme,
 
     /// Path where config was loaded from.
     #[config(skip)]
@@ -105,6 +108,7 @@ impl Default for UiConfig {
             config_paths: Default::default(),
             key_bindings: Default::default(),
             alt_send_esc: Default::default(),
+            colorscheme: Default::default(),
             keyboard: Default::default(),
             import: Default::default(),
             window: Default::default(),

--- a/alacritty/src/display/colorscheme.rs
+++ b/alacritty/src/display/colorscheme.rs
@@ -1,8 +1,9 @@
-use alacritty_terminal::term::color::Rgb;
+use alacritty_terminal::term::color::{CellRgb, Rgb};
 
 use super::color::List;
-use crate::config::color::Colors;
 use crate::config::color::BrightColors;
+use crate::config::color::Colors;
+use crate::config::color::InvertedCellColors;
 use crate::config::color::NormalColors;
 use crate::config::color::PrimaryColors;
 
@@ -20,6 +21,10 @@ pub struct ColorScheme {
 
 impl Default for ColorScheme {
     fn default() -> ColorScheme {
+        let cursor_colors = InvertedCellColors {
+                foreground: CellRgb::Rgb(Rgb::new(0x28, 0x28, 0x28)),
+                background: CellRgb::Rgb(Rgb::new(0x00, 0x00, 0x00)),
+            };
         let light_colors = List::from(&Colors {
             primary: PrimaryColors {
                 foreground: Rgb::new(0x00, 0x00, 0x00),
@@ -27,6 +32,9 @@ impl Default for ColorScheme {
                 bright_foreground: Default::default(),
                 dim_foreground: Default::default(),
             },
+            cursor: cursor_colors,
+            vi_mode_cursor: cursor_colors,
+            selection: cursor_colors,
             normal: NormalColors {
                 black: Rgb::new(0xd7, 0xd7, 0xd7),
                 red: Rgb::new(0x97, 0x25, 0x00),

--- a/alacritty/src/display/colorscheme.rs
+++ b/alacritty/src/display/colorscheme.rs
@@ -1,6 +1,10 @@
 use alacritty_terminal::term::color::Rgb;
 
-use super::color::{BrightColors, Colors, NormalColors, PrimaryColors};
+use super::color::List;
+use crate::config::color::Colors;
+use crate::config::color::BrightColors;
+use crate::config::color::NormalColors;
+use crate::config::color::PrimaryColors;
 
 pub enum ThemeVariant {
     Light,
@@ -10,13 +14,13 @@ pub enum ThemeVariant {
 
 pub struct ColorScheme {
     pub theme_variant: ThemeVariant,
-    pub light_colors: Colors,
-    pub dark_colors: Colors,
+    pub light_colors: List,
+    pub dark_colors: List,
 }
 
 impl Default for ColorScheme {
     fn default() -> ColorScheme {
-        let light_colors = Colors {
+        let light_colors = List::from(&Colors {
             primary: PrimaryColors {
                 foreground: Rgb::new(0x00, 0x00, 0x00),
                 background: Rgb::new(0xff, 0xff, 0xff),
@@ -44,37 +48,9 @@ impl Default for ColorScheme {
                 white: Rgb::new(0x00, 0x00, 0x00),
             },
             ..Default::default()
-        };
+        });
 
-        let dark_colors = Colors {
-            primary: PrimaryColors {
-                foreground: Rgb::new(0xff, 0xff, 0xff),
-                background: Rgb::new(0x00, 0x00, 0x00),
-                bright_foreground: Default::default(),
-                dim_foreground: Default::default(),
-            },
-            normal: NormalColors {
-                black: Rgb::new(0x32, 0x32, 0x32),
-                red: Rgb::new(0xff, 0x80, 0x59),
-                green: Rgb::new(0x44, 0xbc, 0x44),
-                yellow: Rgb::new(0xd0, 0xbc, 0x00),
-                blue: Rgb::new(0x2f, 0xaf, 0xff),
-                magenta: Rgb::new(0xfe, 0xac, 0xd0),
-                cyan: Rgb::new(0x00, 0xd3, 0xd0),
-                white: Rgb::new(0xff, 0xff, 0xff),
-            },
-            bright: BrightColors {
-                black: Rgb::new(0x53, 0x53, 0x53),
-                red: Rgb::new(0xef, 0x8b, 0x50),
-                green: Rgb::new(0x70, 0xb9, 0x00),
-                yellow: Rgb::new(0xc0, 0xc5, 0x30),
-                blue: Rgb::new(0x79, 0xa8, 0xff),
-                magenta: Rgb::new(0xf7, 0x8f, 0xe7),
-                cyan: Rgb::new(0x4a, 0xe2, 0xf0),
-                white: Rgb::new(0xff, 0xff, 0xff),
-            },
-            ..Default::default()
-        };
+        let dark_colors = List::from(&Colors::default());
 
         ColorScheme { theme_variant: ThemeVariant::System, light_colors, dark_colors }
     }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -19,7 +19,7 @@ use raw_window_handle::RawWindowHandle;
 use serde::{Deserialize, Serialize};
 use winit::dpi::PhysicalSize;
 use winit::keyboard::ModifiersState;
-use winit::window::CursorIcon;
+use winit::window::{CursorIcon, Theme};
 
 use crossfont::{self, Rasterize, Rasterizer};
 use unicode_width::UnicodeWidthChar;
@@ -41,6 +41,7 @@ use crate::config::window::StartupMode;
 use crate::config::UiConfig;
 use crate::display::bell::VisualBell;
 use crate::display::color::List;
+use crate::display::colorscheme::ColorScheme;
 use crate::display::content::{RenderableContent, RenderableCursor};
 use crate::display::cursor::IntoRects;
 use crate::display::damage::RenderDamageIterator;
@@ -500,6 +501,14 @@ impl Display {
             info!("Failed to disable vsync: {}", err);
         }
 
+        let colors = match window.theme() {
+            Some(theme) => match theme {
+                Theme::Light => ColorScheme::default().light_colors,
+                Theme::Dark => ColorScheme::default().dark_colors,
+            }
+            None => ColorScheme::default().dark_colors,
+        };
+
         Ok(Self {
             window,
             context: ManuallyDrop::new(Replaceable::new(context)),
@@ -516,7 +525,7 @@ impl Display {
             cursor_hidden: false,
             frame_timer: FrameTimer::new(),
             visual_bell: VisualBell::from(&config.bell),
-            colors: List::from(&config.colors),
+            colors,
             pending_update: Default::default(),
             pending_renderer_update: Default::default(),
             debug_damage,

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -1020,7 +1020,20 @@ impl Display {
     pub fn update_config(&mut self, config: &UiConfig) {
         self.debug_damage = config.debug.highlight_damage;
         self.visual_bell.update_config(&config.bell);
-        self.colors = List::from(&config.colors);
+
+        self.colors = if config.colorscheme.mode == ThemeVariant::Light {
+            List::from(&config.colorscheme.light)
+        } else if config.colorscheme.mode == ThemeVariant::Dark {
+            List::from(&config.colorscheme.dark)
+        } else {
+            match self.window.theme() {
+                Some(theme) => match theme {
+                    Theme::Light => List::from(&config.colorscheme.light),
+                    Theme::Dark => List::from(&config.colorscheme.dark),
+                },
+                None => List::from(&config.colorscheme.dark),
+            }
+        };
     }
 
     /// Update the mouse/vi mode cursor hint highlighting.

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -55,8 +55,8 @@ use crate::renderer::{self, GlyphCache, Renderer};
 use crate::scheduler::{Scheduler, TimerId, Topic};
 use crate::string::{ShortenDirection, StrShortener};
 
-pub mod content;
 pub mod color;
+pub mod content;
 pub mod cursor;
 pub mod hint;
 pub mod window;
@@ -509,7 +509,7 @@ impl Display {
                 Some(theme) => match theme {
                     Theme::Light => List::from(&config.colorscheme.light),
                     Theme::Dark => List::from(&config.colorscheme.dark),
-                }
+                },
                 None => List::from(&config.colorscheme.dark),
             }
         };

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -55,6 +55,7 @@ use crate::scheduler::{Scheduler, TimerId, Topic};
 use crate::string::{ShortenDirection, StrShortener};
 
 pub mod content;
+pub mod colorscheme;
 pub mod cursor;
 pub mod hint;
 pub mod window;

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -35,14 +35,14 @@ use {
 
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
-use winit::{dpi::{PhysicalPosition, PhysicalSize}, window::Theme};
+use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event_loop::EventLoopWindowTarget;
 use winit::monitor::MonitorHandle;
 #[cfg(windows)]
 use winit::platform::windows::IconExtWindows;
 use winit::window::{
-    CursorIcon, Fullscreen, ImePurpose, UserAttentionType, Window as WinitWindow, WindowBuilder,
-    WindowId,
+    CursorIcon, Fullscreen, ImePurpose, Theme, UserAttentionType, Window as WinitWindow,
+    WindowBuilder, WindowId,
 };
 
 use alacritty_terminal::index::Point;

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -35,7 +35,7 @@ use {
 
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
-use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::{dpi::{PhysicalPosition, PhysicalSize}, window::Theme};
 use winit::event_loop::EventLoopWindowTarget;
 use winit::monitor::MonitorHandle;
 #[cfg(windows)]
@@ -212,6 +212,11 @@ impl Window {
             wayland_surface,
             scale_factor,
         })
+    }
+
+    #[inline]
+    pub fn theme(&self) -> Option<Theme> {
+        self.window.theme()
     }
 
     #[inline]

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1369,6 +1369,18 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                             *self.ctx.dirty = true;
                         },
                     },
+                    WindowEvent::ThemeChanged(theme) => {
+                        use crate::display::colorscheme::ColorScheme;
+                        let colorscheme = ColorScheme::default();
+                        match theme {
+                            winit::window::Theme::Light => {
+                                self.ctx.display.colors = colorscheme.light_colors;
+                            },
+                            winit::window::Theme::Dark => {
+                                self.ctx.display.colors = colorscheme.dark_colors;
+                            },
+                        }
+                    },
                     WindowEvent::KeyboardInput { is_synthetic: true, .. }
                     | WindowEvent::TouchpadPressure { .. }
                     | WindowEvent::TouchpadMagnify { .. }
@@ -1379,7 +1391,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     | WindowEvent::AxisMotion { .. }
                     | WindowEvent::HoveredFileCancelled
                     | WindowEvent::Destroyed
-                    | WindowEvent::ThemeChanged(_)
                     | WindowEvent::HoveredFile(_)
                     | WindowEvent::Moved(_) => (),
                 }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1373,10 +1373,12 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         use crate::display::color::List;
                         match theme {
                             winit::window::Theme::Light => {
-                                self.ctx.display.colors = List::from(&self.ctx.config.colorscheme.light)
+                                self.ctx.display.colors =
+                                    List::from(&self.ctx.config.colorscheme.light)
                             },
                             winit::window::Theme::Dark => {
-                                self.ctx.display.colors = List::from(&self.ctx.config.colorscheme.dark)
+                                self.ctx.display.colors =
+                                    List::from(&self.ctx.config.colorscheme.dark)
                             },
                         }
                     },

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1370,14 +1370,13 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         },
                     },
                     WindowEvent::ThemeChanged(theme) => {
-                        use crate::display::colorscheme::ColorScheme;
-                        let colorscheme = ColorScheme::default();
+                        use crate::display::color::List;
                         match theme {
                             winit::window::Theme::Light => {
-                                self.ctx.display.colors = colorscheme.light_colors;
+                                self.ctx.display.colors = List::from(&self.ctx.config.colorscheme.light)
                             },
                             winit::window::Theme::Dark => {
-                                self.ctx.display.colors = colorscheme.dark_colors;
+                                self.ctx.display.colors = List::from(&self.ctx.config.colorscheme.dark)
                             },
                         }
                     },


### PR DESCRIPTION
As discusses in #7135 this commit adds the ability to define different color schemes for light and dark mode and change the theme of alacritty based on system display mode.