### PR TITLE
Add EGL_OVER_GLX environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Copy global IPC options (`-w -1`) for new windows
 - Bindings to create and navigate tabs on macOS
 - Support startup notify protocol to raise initial window on Wayland/X11
+- Debug option `prefer_egl` to prioritize EGL over other display APIs
 
 ### Changed
 

--- a/alacritty/src/config/debug.rs
+++ b/alacritty/src/config/debug.rs
@@ -23,6 +23,9 @@ pub struct Debug {
     /// The renderer alacritty should be using.
     pub renderer: Option<RendererPreference>,
 
+    /// Use EGL as display API if the current platform allows it.
+    pub prefer_egl: bool,
+
     /// Record ref test.
     #[config(skip)]
     pub ref_test: bool,
@@ -38,6 +41,7 @@ impl Default for Debug {
             highlight_damage: Default::default(),
             ref_test: Default::default(),
             renderer: Default::default(),
+            prefer_egl: Default::default(),
         }
     }
 }

--- a/alacritty/src/renderer/platform.rs
+++ b/alacritty/src/renderer/platform.rs
@@ -21,15 +21,24 @@ use winit::window::raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 pub fn create_gl_display(
     raw_display_handle: RawDisplayHandle,
     _raw_window_handle: Option<RawWindowHandle>,
+    _prefer_egl: bool,
 ) -> GlutinResult<Display> {
     #[cfg(target_os = "macos")]
     let preference = DisplayApiPreference::Cgl;
 
     #[cfg(windows)]
-    let preference = DisplayApiPreference::Wgl(Some(_raw_window_handle.unwrap()));
+    let preference = if _prefer_egl {
+        DisplayApiPreference::EglThenWgl(Some(_raw_window_handle.unwrap()))
+    } else {
+        DisplayApiPreference::WglThenEgl(Some(_raw_window_handle.unwrap()))
+    };
 
     #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
-    let preference = DisplayApiPreference::GlxThenEgl(Box::new(x11::register_xlib_error_hook));
+    let preference = if _prefer_egl {
+        DisplayApiPreference::EglThenGlx(Box::new(x11::register_xlib_error_hook))
+    } else {
+        DisplayApiPreference::GlxThenEgl(Box::new(x11::register_xlib_error_hook))
+    };
 
     #[cfg(all(not(feature = "x11"), not(any(target_os = "macos", windows))))]
     let preference = DisplayApiPreference::Egl;

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -92,8 +92,11 @@ impl WindowContext {
         #[cfg(not(windows))]
         let raw_window_handle = None;
 
-        let gl_display =
-            renderer::platform::create_gl_display(raw_display_handle, raw_window_handle)?;
+        let gl_display = renderer::platform::create_gl_display(
+            raw_display_handle,
+            raw_window_handle,
+            config.debug.prefer_egl,
+        )?;
         let gl_config = renderer::platform::pick_gl_config(&gl_display, raw_window_handle)?;
 
         #[cfg(not(windows))]

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -935,6 +935,13 @@ relied upon.
 
 	Default: _false_
 
+*prefer_egl* <boolean>
+
+    Use EGL as display API if the current platform allows it. Note that
+    transparency may not work with EGL on Linux/BSD.
+
+    Default: _false_
+
 # SEE ALSO
 
 *alacritty*(1), *alacritty-msg*(1), *alacritty-bindings*(5)


### PR DESCRIPTION
After v0.11.0 rendering sometimes paused indefinitely until a keystroke was registered, but not necessarily rendering the change caused by the new keystroke. This issue seems to be related to GLX in conjunction with Nvidia drivers on linux systems, and using EGL instead fixes the issue.

Closes #7056