### PR TITLE
Fix crash with anchored searches

### DIFF
--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -8,6 +8,7 @@ use regex_automata::dfa::Automaton;
 use regex_automata::nfa::thompson::Config as ThompsonConfig;
 use regex_automata::util::syntax::Config as SyntaxConfig;
 use regex_automata::Anchored;
+use regex_automata::Input;
 
 use crate::grid::{BidirectionalIterator, Dimensions, GridIterator, Indexed};
 use crate::index::{Boundary, Column, Direction, Point, Side};
@@ -215,7 +216,8 @@ impl<T> Term<T> {
 
         // Get start state for the DFA.
         let regex_anchored = if anchored { Anchored::Yes } else { Anchored::No };
-        let start_state = regex.universal_start_state(regex_anchored).unwrap();
+        let input = Input::new(&[]).anchored(regex_anchored);
+        let start_state = regex.start_state_forward(&input).unwrap();
         let mut state = start_state;
 
         let mut iter = self.grid.iter_from(start);

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -7,8 +7,7 @@ use regex_automata::dfa::dense::{Builder, Config, DFA};
 use regex_automata::dfa::Automaton;
 use regex_automata::nfa::thompson::Config as ThompsonConfig;
 use regex_automata::util::syntax::Config as SyntaxConfig;
-use regex_automata::Anchored;
-use regex_automata::Input;
+use regex_automata::{Anchored, Input};
 
 use crate::grid::{BidirectionalIterator, Dimensions, GridIterator, Indexed};
 use crate::index::{Boundary, Column, Direction, Point, Side};


### PR DESCRIPTION
While this does **not** enable the use of anchors (`^`) in user regexes, it does prevent Alacritty from crashing when attempting to do so.