### PR TITLE
Allow x padding to go over 255

### DIFF
--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -57,7 +57,7 @@ pub struct WindowConfig {
     pub resize_increments: bool,
 
     /// Pixel padding.
-    padding: Delta<u8>,
+    padding: Delta<u16>,
 
     /// Initial dimensions.
     dimensions: Dimensions,


### PR DESCRIPTION
Extremely simple fix that just changes padding type to `u16` as requested by #6900. 