### PR TITLE
fix alacritty.5.scd (spaces -> tabs)

### DIFF
--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -937,10 +937,10 @@ relied upon.
 
 *prefer_egl* <boolean>
 
-    Use EGL as display API if the current platform allows it. Note that
-    transparency may not work with EGL on Linux/BSD.
+	Use EGL as display API if the current platform allows it. Note that
+	transparency may not work with EGL on Linux/BSD.
 
-    Default: _false_
+	Default: _false_
 
 # SEE ALSO
 


### PR DESCRIPTION
```
Error: Tabs are required for indentation
 * The specific snippet of code:
 *       scdoc < ./extra/man/alacritty.5.scd > ./alacritty.5 || die;
 *
```