### PR TITLE
Added mouse "leader_mod" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bindings to create and navigate tabs on macOS
 - Support startup notify protocol to raise initial window on Wayland/X11
 - Debug option `prefer_egl` to prioritize EGL over other display APIs
+- Mouse option 'leader_mod' to set the prefix modifier for mouse bindings
 
 ### Changed
 

--- a/alacritty/src/config/mouse.rs
+++ b/alacritty/src/config/mouse.rs
@@ -1,14 +1,27 @@
 use serde::{Deserialize, Deserializer};
 
+use super::bindings::ModsWrapper;
 use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
+use winit::keyboard::ModifiersState;
 
 use crate::config::bindings::{self, MouseBinding};
 use crate::config::ui_config;
 
-#[derive(ConfigDeserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Mouse {
     pub hide_when_typing: bool,
     pub bindings: MouseBindings,
+    pub leader_mod: ModsWrapper,
+}
+
+impl Default for Mouse {
+    fn default() -> Self {
+        Self {
+            hide_when_typing: false,
+            bindings: MouseBindings::default(),
+            leader_mod: ModsWrapper(ModifiersState::SHIFT),
+        }
+    }
 }
 
 #[derive(SerdeReplace, Clone, Debug, PartialEq, Eq)]

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -371,7 +371,7 @@ pub fn highlighted_at<T>(
         let highlight = hint.mouse.map_or(false, |mouse| {
             mouse.enabled
                 && mouse_mods.contains(mouse.mods.0)
-                && (!mouse_mode || mouse_mods.contains(ModifiersState::SHIFT))
+                && (!mouse_mode || mouse_mods.contains(config.mouse.leader_mod.into_inner()))
         });
         if !highlight {
             return None;

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -568,14 +568,23 @@ This section documents the *[mouse]* table of the configuration file.
 
 	Default: _false_
 
+*leader_mod* <mods>
+
+	See _keyboard.bindings_ for full documentation on _mods_.
+
+	Set this option to change the prefix modifier for mouse bindings when an
+	application running within Alacritty captures the mouse.
+
+	Default: _Shift_
+
 *bindings*: [{ <mouse>, <mods>, <mode>, <action> | chars = <string> },]
 
 	See _keyboard.bindings_ for full documentation on _mods_, _mode_, _action_,
 	and _chars_.
 
 	To trigger mouse bindings when an application running within Alacritty
-	captures the mouse, the `Shift` modifier is automatically added as a
-	requirement.
+	captures the mouse, the `leader_mod` modifier key is automatically added as
+	a requirement.
 
 	*mouse* "Middle" | "Left" | "Right" | "Back" | "Forward" | <number>
 


### PR DESCRIPTION
Previously, to use a mouse binding (or for executing a hint action) the used needed to press the "Shift" modifier. This new option allows to change this prefix/leader modifier.

As a Mac user, I prefer to use `Command+Click` to open a URL instead of `Shift+Click`, so this change could fix this preference issue.