### PR TITLE
Add max_intensity config option for visual bell

### DIFF
--- a/alacritty/src/config/bell.rs
+++ b/alacritty/src/config/bell.rs
@@ -2,10 +2,10 @@ use std::time::Duration;
 
 use alacritty_config_derive::ConfigDeserialize;
 
-use alacritty_terminal::config::Program;
+use alacritty_terminal::config::{Percentage, Program};
 use alacritty_terminal::term::color::Rgb;
 
-#[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Clone, Debug, PartialEq)]
 pub struct BellConfig {
     /// Visual bell animation function.
     pub animation: BellAnimation,
@@ -15,6 +15,9 @@ pub struct BellConfig {
 
     /// Visual bell flash color.
     pub color: Rgb,
+
+    /// Maximum opacity of the flash color, from 0.0 to 1.0.
+    pub max_intensity: Percentage,
 
     /// Visual bell duration in milliseconds.
     duration: u16,
@@ -27,6 +30,7 @@ impl Default for BellConfig {
             animation: Default::default(),
             command: Default::default(),
             duration: Default::default(),
+            max_intensity: Default::default(),
         }
     }
 }

--- a/alacritty/src/display/bell.rs
+++ b/alacritty/src/display/bell.rs
@@ -11,6 +11,9 @@ pub struct VisualBell {
 
     /// The last time the visual bell rang, if at all.
     start_time: Option<Instant>,
+
+    /// Visual bell intensity multiplier
+    intensity_multiplier: f32,
 }
 
 impl VisualBell {
@@ -23,6 +26,7 @@ impl VisualBell {
 
     /// Get the currently intensity of the visual bell. The bell's intensity
     /// ramps down from 1.0 to 0.0 at a rate determined by the bell's duration.
+    /// It is then multiplied with the intensity_multiplier.
     pub fn intensity(&self) -> f64 {
         self.intensity_at_instant(Instant::now())
     }
@@ -42,7 +46,7 @@ impl VisualBell {
 
     /// Get the intensity of the visual bell at a particular instant. The bell's
     /// intensity ramps down from 1.0 to 0.0 at a rate determined by the bell's
-    /// duration.
+    /// duration. It is then multiplied with the intensity_multiplier.
     pub fn intensity_at_instant(&self, instant: Instant) -> f64 {
         // If `duration` is zero, then the VisualBell is disabled; therefore,
         // its `intensity` is zero.
@@ -93,7 +97,7 @@ impl VisualBell {
 
                 // Since we want the `intensity` of the VisualBell to decay over
                 // `time`, we subtract the `inverse_intensity` from 1.0.
-                1.0 - inverse_intensity
+                (1.0 - inverse_intensity) * self.intensity_multiplier as f64
             },
         }
     }
@@ -110,6 +114,7 @@ impl From<&BellConfig> for VisualBell {
             animation: bell_config.animation,
             duration: bell_config.duration(),
             start_time: None,
+            intensity_multiplier: bell_config.max_intensity.as_f32(),
         }
     }
 }

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -453,6 +453,13 @@ This section documents the *[bell]* table of the configuration file.
 
 	Default: _0_
 
+*max_intensity* <float>
+
+	Maximum intensity of the visual flash. This value will be multiplied with the
+	result of the animation function. Valid values range from _0.0_ to _1.0_.
+
+	Default: _1.0_
+
 *color* <string>
 
 	Visual bell animation color.


### PR DESCRIPTION
I like the idea of a visual bell, but I also think that having the flash colour be 100% opaque is a bit too visually jarring. This PR adds a `bell.max_intensity` config option which allows users to set an initial opacity for the flash.