### PR TITLE
Add inline vi mode search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bindings to create and navigate tabs on macOS
 - Support startup notify protocol to raise initial window on Wayland/X11
 - Debug option `prefer_egl` to prioritize EGL over other display APIs
+- Inline vi-mode search using `f`/`F`/`t`/`T`
 
 ### Changed
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -331,6 +331,18 @@ pub enum ViAction {
     Open,
     /// Centers the screen around the vi mode cursor.
     CenterAroundViCursor,
+    /// Search forward within the current line.
+    InlineSearchForward,
+    /// Search backward within the current line.
+    InlineSearchBackward,
+    /// Search forward within the current line, stopping just short of the character.
+    InlineSearchForwardShort,
+    /// Search backward within the current line, stopping just short of the character.
+    InlineSearchBackwardShort,
+    /// Jump to the next inline search match.
+    InlineSearchNext,
+    /// Jump to the previous inline search match.
+    InlineSearchPrevious,
 }
 
 /// Search mode specific actions.
@@ -506,6 +518,12 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         "n",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::SearchPrevious;
         Enter,                              +BindingMode::VI, ~BindingMode::SEARCH; ViAction::Open;
         "z",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::CenterAroundViCursor;
+        "f",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchForward;
+        "f",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchBackward;
+        "t",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchForwardShort;
+        "t",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchBackwardShort;
+        ";",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchNext;
+        ",",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchPrevious;
         "k",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Up;
         "j",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Down;
         "h",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Left;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -889,14 +889,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         // Find next match in this line.
         let vi_point = self.terminal.vi_mode_cursor.point;
         let point = match direction {
-            Direction::Right => {
-                let origin = vi_point.add(self.terminal, Boundary::None, 1);
-                self.terminal.inline_search_right(origin, search_character)
-            },
-            Direction::Left => {
-                let origin = vi_point.sub(self.terminal, Boundary::None, 1);
-                self.terminal.inline_search_left(origin, search_character)
-            },
+            Direction::Right => self.terminal.inline_search_right(vi_point, search_character),
+            Direction::Left => self.terminal.inline_search_left(vi_point, search_character),
         };
 
         // Jump to point if there's a match.

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1024,7 +1024,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return;
         }
 
-        let mut text = key.text_with_all_modifiers().unwrap_or_default();
+        let text = key.text_with_all_modifiers().unwrap_or_default();
 
         // All key bindings are disabled while a hint is being selected.
         if self.ctx.display().hint_state.active() {
@@ -1036,19 +1036,16 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         // First key after inline search is captured.
         let inline_state = self.ctx.inline_search_state();
-        if mem::take(&mut inline_state.char_pending) && !text.is_empty() {
-            let mut indices = text.char_indices();
-            let (_, c) = indices.next().unwrap();
-            inline_state.character = Some(c);
+        if mem::take(&mut inline_state.char_pending) {
+            if let Some(c) = text.chars().next() {
+                inline_state.character = Some(c);
 
-            // Immediately move to the captured character.
-            self.ctx.inline_search_next(Direction::Right);
-
-            // Remove captured character if there's multiple.
-            match indices.next() {
-                Some((index, _)) => text = &text[index..],
-                None => return,
+                // Immediately move to the captured character.
+                self.ctx.inline_search_next(Direction::Right);
             }
+
+            // Ignore all other characters in `text`.
+            return;
         }
 
         // Reset search delay when the user is still typing.

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1036,7 +1036,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         // First key after inline search is captured.
         let inline_state = self.ctx.inline_search_state();
-        if !text.is_empty() && mem::take(&mut inline_state.char_pending) {
+        if mem::take(&mut inline_state.char_pending) && !text.is_empty() {
             let mut indices = text.char_indices();
             let (_, c) = indices.next().unwrap();
             inline_state.character = Some(c);

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -127,7 +127,8 @@ pub trait ActionContext<T: EventListener> {
     fn toggle_vi_mode(&mut self) {}
     fn inline_search_state(&mut self) -> &mut InlineSearchState;
     fn start_inline_search(&mut self, _direction: Direction, _stop_short: bool) {}
-    fn inline_search_next(&mut self, _direction: Direction) {}
+    fn inline_search_next(&mut self) {}
+    fn inline_search_previous(&mut self) {}
     fn hint_input(&mut self, _character: char) {}
     fn trigger_hint(&mut self, _hint: &HintMatch) {}
     fn expand_selection(&mut self) {}
@@ -275,8 +276,8 @@ impl<T: EventListener> Execute<T> for Action {
             Action::Vi(ViAction::InlineSearchBackwardShort) => {
                 ctx.start_inline_search(Direction::Left, true)
             },
-            Action::Vi(ViAction::InlineSearchNext) => ctx.inline_search_next(Direction::Right),
-            Action::Vi(ViAction::InlineSearchPrevious) => ctx.inline_search_next(Direction::Left),
+            Action::Vi(ViAction::InlineSearchNext) => ctx.inline_search_next(),
+            Action::Vi(ViAction::InlineSearchPrevious) => ctx.inline_search_previous(),
             action @ Action::Search(_) if !ctx.search_active() => {
                 debug!("Ignoring {action:?}: Search mode inactive");
             },
@@ -1041,7 +1042,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 inline_state.character = Some(c);
 
                 // Immediately move to the captured character.
-                self.ctx.inline_search_next(Direction::Right);
+                self.ctx.inline_search_next();
             }
 
             // Ignore all other characters in `text`.

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1253,6 +1253,7 @@ mod tests {
         pub message_buffer: &'a mut MessageBuffer,
         pub modifiers: Modifiers,
         config: &'a UiConfig,
+        inline_search_state: &'a mut InlineSearchState,
     }
 
     impl<'a, T: EventListener> super::ActionContext<T> for ActionContext<'a, T> {
@@ -1267,6 +1268,10 @@ mod tests {
 
         fn search_direction(&self) -> Direction {
             Direction::Right
+        }
+
+        fn inline_search_state(&mut self) -> &mut InlineSearchState {
+            self.inline_search_state
         }
 
         fn search_active(&self) -> bool {
@@ -1381,6 +1386,7 @@ mod tests {
                     ..Mouse::default()
                 };
 
+                let mut inline_search_state = InlineSearchState::default();
                 let mut message_buffer = MessageBuffer::default();
 
                 let context = ActionContext {
@@ -1390,6 +1396,7 @@ mod tests {
                     clipboard: &mut clipboard,
                     modifiers: Default::default(),
                     message_buffer: &mut message_buffer,
+                    inline_search_state: &mut inline_search_state,
                     config: &cfg,
                 };
 

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -39,7 +39,9 @@ use crate::clipboard::Clipboard;
 use crate::config::UiConfig;
 use crate::display::window::Window;
 use crate::display::Display;
-use crate::event::{ActionContext, Event, EventProxy, Mouse, SearchState, TouchPurpose};
+use crate::event::{
+    ActionContext, Event, EventProxy, InlineSearchState, Mouse, SearchState, TouchPurpose,
+};
 use crate::logging::LOG_TARGET_IPC_CONFIG;
 use crate::message_bar::MessageBuffer;
 use crate::scheduler::Scheduler;
@@ -54,6 +56,7 @@ pub struct WindowContext {
     terminal: Arc<FairMutex<Term<EventProxy>>>,
     cursor_blink_timed_out: bool,
     modifiers: Modifiers,
+    inline_search_state: InlineSearchState,
     search_state: SearchState,
     notifier: Notifier,
     font_size: Size,
@@ -242,15 +245,16 @@ impl WindowContext {
             config,
             notifier: Notifier(loop_tx),
             cursor_blink_timed_out: Default::default(),
+            inline_search_state: Default::default(),
             message_buffer: Default::default(),
             search_state: Default::default(),
             event_queue: Default::default(),
             ipc_config: Default::default(),
             modifiers: Default::default(),
+            occluded: Default::default(),
             mouse: Default::default(),
             touch: Default::default(),
             dirty: Default::default(),
-            occluded: Default::default(),
         })
     }
 
@@ -436,6 +440,7 @@ impl WindowContext {
         let context = ActionContext {
             cursor_blink_timed_out: &mut self.cursor_blink_timed_out,
             message_buffer: &mut self.message_buffer,
+            inline_search_state: &mut self.inline_search_state,
             search_state: &mut self.search_state,
             modifiers: &mut self.modifiers,
             font_size: &mut self.font_size,

--- a/extra/man/alacritty-bindings.5.scd
+++ b/extra/man/alacritty-bindings.5.scd
@@ -161,6 +161,30 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :[
 :  _"Vi|~Search"_
 :  _"CenterAroundViCursor"_
+|  _"F"_
+:[
+:  _"Vi|~Search"_
+:  _"InlineSearchForward"_
+|  _"F"_
+:  _"Shift"_
+:  _"Vi|~Search"_
+:  _"InlineSearchBackward"_
+|  _"T"_
+:[
+:  _"Vi|~Search"_
+:  _"InlineSearchForwardShort"_
+|  _"T"_
+:  _"Shift"_
+:  _"Vi|~Search"_
+:  _"InlineSearchBackwardShort"_
+|  _";"_
+:[
+:  _"Vi|~Search"_
+:  _"InlineSearchNext"_
+|  _","_
+:[
+:  _"Vi|~Search"_
+:  _"InlineSearchPrevious"_
 |  _"K"_
 :[
 :  _"Vi|~Search"_

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -827,6 +827,38 @@ https://docs.rs/winit/\*/winit/keyboard/enum.Key.html
 			Move to end of whitespace separated word.
 		*Bracket*
 			Move to opposing bracket.
+		*ToggleNormalSelection*
+			Toggle normal vi selection.
+		*ToggleLineSelection*
+			Toggle line vi selection.
+		*ToggleBlockSelection*
+			Toggle block vi selection.
+		*ToggleSemanticSelection*
+			Toggle semantic vi selection.
+		*SearchNext*
+			Jump to the beginning of the next match.
+		*SearchPrevious*
+			Jump to the beginning of the previous match.
+		*SearchStart*
+			Jump to the next start of a match to the left of the origin.
+		*SearchEnd*
+			Jump to the next end of a match to the right of the origin.
+		*Open*
+			Launch the URL below the vi mode cursor.
+		*CenterAroundViCursor*
+			Centers the screen around the vi mode cursor.
+		*InlineSearchForward*
+			Search forward within the current line.
+		*InlineSearchBcakward*
+			Search backard within the current line.
+		*InlineSearchForwardShort*
+			Search forward within the current line, stopping just short of the character.
+		*InlineSearchBackwardShort*
+			Search backward within the current line, stopping just short of the character.
+		*InlineSearchNext*
+			Jump to the next inline search match.
+		*InlineSearchPrevious*
+			Jump to the previous inline search match.
 
 		_Search actions:_
 


### PR DESCRIPTION
This patch adds inline search to vi mode using `f`/`F` and `t`/`T` as default bindings. The behavior matches that of vim.

Closes #7203.

---

There's a very good chance I missed an edge case or 16, so this probably needs a bit of manual testing.