### PR TITLE
updated README.md to show the correct config file name under windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ following locations:
 
 On Windows, the config file should be located at:
 
-`%APPDATA%\alacritty\alacritty.toml`
+`%APPDATA%\alacritty\alacritty.yml`
 
 ## Contributing
 


### PR DESCRIPTION
the correct file extension is 'yml' and not 'toml', creating a file with the extension 'toml' doesn't work and isn't recognized by alacritty (under windows at least, I haven't tested any other OS).