### PR TITLE
Add support for OSC 22 escape sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bindings to create and navigate tabs on macOS
 - Support startup notify protocol to raise initial window on Wayland/X11
 - Debug option `prefer_egl` to prioritize EGL over other display APIs
+- Escape sequence to change mouse cursor shape (OSC 22);
+    use `terminal.osc22` to enable it
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "alacritty_config_derive",
  "base64",
  "bitflags 2.3.3",
+ "cursor-icon",
  "home",
  "libc",
  "log",

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1244,6 +1244,10 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         let text = format(self.ctx.size_info().into());
                         self.ctx.write_to_pty(text.into_bytes());
                     },
+                    TerminalEvent::MouseCursorIcon(icon) => {
+                        self.ctx.display().osc22_cursor = icon;
+                        self.reset_mouse_cursor();
+                    },
                     TerminalEvent::PtyWrite(text) => self.ctx.write_to_pty(text.into_bytes()),
                     TerminalEvent::MouseCursorDirty => self.reset_mouse_cursor(),
                     TerminalEvent::CursorBlinkingChange => self.ctx.update_cursor_blinking(),

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1149,6 +1149,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             mouse_state
         } else if self.ctx.display().highlighted_hint.as_ref().map_or(false, hint_highlighted) {
             CursorIcon::Pointer
+        } else if let Some(cursor) = self.ctx.display().osc22_cursor {
+            cursor
         } else if !self.ctx.modifiers().state().shift_key() && self.ctx.mouse_mode() {
             CursorIcon::Default
         } else {

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.1.2-dev"
 [dependencies]
 base64 = "0.13.0"
 bitflags = { version = "2.2.1", features = ["serde"] }
+cursor-icon = "1.0.0"
 home = "0.5.5"
 libc = "0.2"
 log = "0.4"

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -40,8 +40,11 @@ pub struct Config {
 
 #[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq, Default)]
 pub struct Terminal {
-    // OSC 52 handling (clipboard handling).
+    /// OSC 52 handling (clipboard handling).
     pub osc52: Osc52,
+
+    /// Allow to set cursor shape with the OSC 22 escape.
+    pub osc22: bool,
 }
 
 #[derive(ConfigDeserialize, Clone, Debug, PartialEq, Eq, Default)]

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
+use cursor_icon::CursorIcon;
+
 use crate::term::color::Rgb;
 use crate::term::ClipboardType;
 
@@ -16,6 +18,11 @@ pub enum Event {
 
     /// Window title change.
     Title(String),
+
+    /// Mouse cursor icon change.
+    ///
+    /// `None` indicates that it was unset.
+    MouseCursorIcon(Option<CursorIcon>),
 
     /// Reset to the default window title.
     ResetTitle,
@@ -65,6 +72,7 @@ impl Debug for Event {
             Event::Title(title) => write!(f, "Title({title})"),
             Event::CursorBlinkingChange => write!(f, "CursorBlinkingChange"),
             Event::MouseCursorDirty => write!(f, "MouseCursorDirty"),
+            Event::MouseCursorIcon(icon) => write!(f, "MouseCursorIcon({icon:?})"),
             Event::ResetTitle => write!(f, "ResetTitle"),
             Event::Wakeup => write!(f, "Wakeup"),
             Event::Bell => write!(f, "Bell"),

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -94,6 +94,7 @@ brevity.
 | `OSC 10`  | IMPLEMENTED |                                                    |
 | `OSC 11`  | IMPLEMENTED |                                                    |
 | `OSC 12`  | IMPLEMENTED |                                                    |
+| `OSC 22`  | IMPLEMENTED |                                                    |
 | `OSC 50`  | IMPLEMENTED | Only `CursorShape` is supported                    |
 | `OSC 52`  | IMPLEMENTED | Only Clipboard and primary selection supported     |
 | `OSC 104` | IMPLEMENTED |                                                    |

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -568,6 +568,13 @@ This section documents the *[terminal]* table of the configuration file.
 
 	Default: _"OnlyCopy"_
 
+*osc22* <boolean>
+
+	Controls the ability to change the mouse cursor shape with the escape
+	sequences trying to improve application mouse mode user experience.
+
+	Default: _false_
+
 # Mouse
 
 This section documents the *[mouse]* table of the configuration file.


### PR DESCRIPTION
Add support for OSC 22 escape sequence to allow changing mouse cursor shapes. While the escape sequence could help some users with the mouse UX in TUI applications using mouse mode, it could obscure common mouse mode indication which is the `Text` cursor. Thus OSC 22 is disabled by default and could be enabled with `terminal.osc22` configuration option.

Fixes #7119.

--

I'm not sure from where to `re-export` the `CursorIcon` inside the `alacritty_terminal`.