### PR TITLE
Fix regex matches ending on multiline

### DIFF
--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -47,7 +47,7 @@ impl RegexSearch {
         let right_fdfa = LazyDfa::new(
             search,
             config.clone(),
-            syntax_config.clone(),
+            syntax_config,
             thompson_config.clone(),
             Direction::Right,
             false,
@@ -55,7 +55,7 @@ impl RegexSearch {
         let right_rdfa = LazyDfa::new(
             search,
             config.clone(),
-            syntax_config.clone(),
+            syntax_config,
             thompson_config.clone(),
             Direction::Left,
             true,
@@ -65,7 +65,7 @@ impl RegexSearch {
         let left_fdfa = LazyDfa::new(
             search,
             config.clone(),
-            syntax_config.clone(),
+            syntax_config,
             thompson_config.clone(),
             Direction::Left,
             false,

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -836,6 +836,28 @@ mod tests {
     }
 
     #[test]
+    fn multiline() {
+        #[rustfmt::skip]
+        let term = mock_term("\
+            hello/world \r\n\
+            hello/world\
+        ");
+
+        const PATTERN: &str = "([\\-\\._a-z0-9]*/[^/ ]*)+/?";
+        let mut regex = RegexSearch::new(PATTERN).unwrap();
+        let start = Point::new(Line(0), Column(0));
+        let end = Point::new(Line(0), Column(10));
+        let match_start = Point::new(Line(0), Column(0));
+        assert_eq!(term.regex_search_right(&mut regex, start, end), Some(match_start..=end));
+
+        let mut regex = RegexSearch::new(PATTERN).unwrap();
+        let start = Point::new(Line(0), Column(11));
+        let match_start = Point::new(Line(1), Column(0));
+        let match_end = Point::new(Line(1), Column(10));
+        assert_eq!(term.regex_search_right(&mut regex, start, end), Some(match_start..=match_end));
+    }
+
+    #[test]
     fn wrapping_into_fullwidth() {
         #[rustfmt::skip]
         let term = mock_term("\

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -291,6 +291,9 @@ impl<T> Term<T> {
                 // Matches require one additional BYTE of lookahead, so we check the match state for
                 // the first byte of every new character to determine if the last character was a
                 // match.
+                //
+                // We ignore it on the first character to avoid reporting matches for regexes
+                // matching an empty string.
                 if i == 0 && state.is_match() && point != start {
                     regex_match = Some(last_point);
                 }


### PR DESCRIPTION
This fixes an issue where the reverse search for the regex start would
truncate a character when ending on a newline, since it was omitting the
EOI check in that case.

This also fixes a separate issue which caused regexes which capture
empty strings (e.g.: `.*`) to always report a match.

This is a regression introduced in 73276b6.