### PR TITLE
Fix `window.decorations_theme_variant` reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Scrolling on touchscreens
 - Double clicking on CSD titlebar not always maximizing a window on Wayland
 - Excessive memory usage when using regexes with a large number of possible states
+- `window.decorations_theme_variant` not live reloading
 
 ### Removed
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -35,8 +35,8 @@ use winit::monitor::MonitorHandle;
 use winit::platform::windows::IconExtWindows;
 use winit::window::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use winit::window::{
-    CursorIcon, Fullscreen, ImePurpose, UserAttentionType, Window as WinitWindow, WindowBuilder,
-    WindowId,
+    CursorIcon, Fullscreen, ImePurpose, Theme, UserAttentionType, Window as WinitWindow,
+    WindowBuilder, WindowId,
 };
 
 use alacritty_terminal::index::Point;
@@ -372,6 +372,10 @@ impl Window {
     /// Should be called right before presenting to the window with e.g. `eglSwapBuffers`.
     pub fn pre_present_notify(&self) {
         self.window.pre_present_notify();
+    }
+
+    pub fn set_theme(&self, theme: Option<Theme>) {
+        self.window.set_theme(theme);
     }
 
     #[cfg(target_os = "macos")]

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -303,6 +303,9 @@ impl WindowContext {
             self.display.pending_update.set_font(font);
         }
 
+        // Always reload the theme to account for auto-theme switching.
+        self.display.window.set_theme(self.config.window.decorations_theme_variant);
+
         // Update display if either padding options or resize increments were changed.
         let window_config = &old_config.window;
         if window_config.padding(1.) != self.config.window.padding(1.)


### PR DESCRIPTION
The live reload handling wasn't introduced when the option got added.

Fixes #7295.