### PR TITLE
Fix display freeze on Windows during bell animation

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -989,7 +989,10 @@ impl Display {
         // time to finish OpenGL operations is accounted for in the timeout.
         if matches!(
             self.raw_window_handle,
-            RawWindowHandle::AppKit(_) | RawWindowHandle::Xlib(_) | RawWindowHandle::Xcb(_)
+            RawWindowHandle::AppKit(_)
+                | RawWindowHandle::Xlib(_)
+                | RawWindowHandle::Xcb(_)
+                | RawWindowHandle::Win32(_)
         ) {
             self.request_frame(scheduler);
         }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -987,13 +987,9 @@ impl Display {
 
         // XXX: Request the new frame after swapping buffers, so the
         // time to finish OpenGL operations is accounted for in the timeout.
-        if matches!(
-            self.raw_window_handle,
-            RawWindowHandle::AppKit(_)
-                | RawWindowHandle::Xlib(_)
-                | RawWindowHandle::Xcb(_)
-                | RawWindowHandle::Win32(_)
-        ) {
+        //
+        // Wayland uses winit to throttle frames, so ignore it here.
+        if !matches!(self.raw_window_handle, RawWindowHandle::Wayland(_)) {
             self.request_frame(scheduler);
         }
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -238,8 +238,8 @@ impl Window {
 
     #[inline]
     pub fn request_redraw(&mut self) {
-        // Don't need to request a frame when we don't have a frame, since we'll get a `Frame`
-        // event back, which will check the `dirty` on the display and do an actual request.
+        // No need to request a frame when we don't have one. The next `Frame` event will check the
+        // `dirty` flag on the display and submit a redraw request.
         if self.has_frame && !self.requested_redraw {
             self.requested_redraw = true;
             self.window.request_redraw();

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -238,7 +238,9 @@ impl Window {
 
     #[inline]
     pub fn request_redraw(&mut self) {
-        if !self.requested_redraw {
+        // Don't need to request a frame when we don't have a frame, since we'll get a `Frame`
+        // event back, which will check the `dirty` on the display and do an actual request.
+        if self.has_frame && !self.requested_redraw {
             self.requested_redraw = true;
             self.window.request_redraw();
         }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1481,6 +1481,9 @@ impl Processor {
                 return;
             }
 
+            // NOTE when moving event to be handled without batching, the `dirty` must be changed
+            // to `display.window.request_redraw`, otherwise we could have a situation with an
+            // empty queue, but dirty bit being set.
             match event {
                 // The event loop just got initialized. Create a window.
                 WinitEvent::Resumed => {
@@ -1512,9 +1515,7 @@ impl Processor {
                 }) => {
                     if let Some(window_context) = self.windows.get_mut(&window_id) {
                         window_context.dirty = true;
-                        if window_context.display.window.has_frame {
-                            window_context.display.window.request_redraw();
-                        }
+                        window_context.display.window.request_redraw();
                     }
                 },
                 // NOTE: This event bypasses batching to minimize input latency.
@@ -1567,7 +1568,7 @@ impl Processor {
                         WinitEvent::RedrawRequested(window_id),
                     );
 
-                    window_context.draw(&mut scheduler);
+                    window_context.draw(&proxy, &mut scheduler);
                 },
                 // Process all pending events.
                 WinitEvent::AboutToWait => {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -99,6 +99,7 @@ pub enum EventType {
     BlinkCursor,
     BlinkCursorTimeout,
     SearchNext,
+    Redraw,
     Frame,
 }
 
@@ -1254,6 +1255,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                 EventType::Message(_)
                 | EventType::ConfigReload(_)
                 | EventType::CreateWindow(_)
+                | EventType::Redraw
                 | EventType::Frame => (),
             },
             WinitEvent::WindowEvent { event, .. } => {
@@ -1505,8 +1507,12 @@ impl Processor {
 
                     info!("Initialisation complete");
                 },
-                // NOTE: This event bypasses batching to minimize input latency.
+                // NOTE: These events bypasses batching to minimize input latency.
                 WinitEvent::UserEvent(Event {
+                    window_id: Some(window_id),
+                    payload: EventType::Redraw,
+                })
+                | WinitEvent::UserEvent(Event {
                     window_id: Some(window_id),
                     payload: EventType::Terminal(TerminalEvent::Wakeup),
                 }) => {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1481,9 +1481,6 @@ impl Processor {
                 return;
             }
 
-            // NOTE when moving event to be handled without batching, the `dirty` must be changed
-            // to `display.window.request_redraw`, otherwise we could have a situation with an
-            // empty queue, but dirty bit being set.
             match event {
                 // The event loop just got initialized. Create a window.
                 WinitEvent::Resumed => {

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -393,10 +393,9 @@ impl WindowContext {
         // Request immediate re-draw if visual bell animation is not finished yet.
         if !self.display.visual_bell.completed() {
             let window_id = Some(self.display.window.id());
-            // Winit on Windows discards `redraw_requested` calls from the `RedrawRequested` event,
-            // thus use a `Wakeup` which is delivered reliably and also sets the `dirty` flag.
-            let _ = event_proxy
-                .send_event(Event::new(EventType::Terminal(TerminalEvent::Wakeup), window_id));
+            // Winit states that requesting a redraw from `RedrawRequested` doesn't work on
+            // Windows, so use a user event to force the redraw instead.
+            let _ = event_proxy.send_event(Event::new(EventType::Redraw, window_id));
         }
 
         // Redraw the window.
@@ -420,21 +419,7 @@ impl WindowContext {
         event: WinitEvent<Event>,
     ) {
         match event {
-            WinitEvent::AboutToWait => {
-                // Skip further event handling with no staged updates.
-                if self.event_queue.is_empty() {
-                    // Request a redraw in-case we have dirty flag set without events in the queue.
-                    // This could happen when event excluded from batching set `dirty` flag, but
-                    // forgot to call `redraw_requested`.
-                    if self.dirty && !self.occluded {
-                        self.display.window.request_redraw();
-                    }
-                    return;
-                }
-
-                // Continue to process all pending events.
-            },
-            WinitEvent::RedrawRequested(_) => {
+            WinitEvent::AboutToWait | WinitEvent::RedrawRequested(_) => {
                 // Skip further event handling with no staged updates.
                 if self.event_queue.is_empty() {
                     return;
@@ -507,7 +492,7 @@ impl WindowContext {
         }
 
         // Don't call `request_redraw` when event is `RedrawRequested` since the `dirty` flag
-        // represents the current frame, but redraw is for the `next` frame.
+        // represents the current frame, but redraw is for the next frame.
         if self.dirty && !self.occluded && !matches!(event, WinitEvent::RedrawRequested(_)) {
             self.display.window.request_redraw();
         }


### PR DESCRIPTION
This also fixes an issue of `RedrawRequested` not being throttled for regular events when timer was in use.

Measuring time between `RedrawRequsted` on Windows also showed that events are not throttled, thus we still need our timer.

Fixes #7236.