### PR TITLE
Prefer exact matches for bindings in mouse mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Apply `colors.transparent_background_colors` for selections, hints, and search matches
 - Underline full hint during keyboard selection
 - Synchronized updates now use `CSI 2026` instead of legacy `DCS` variant
+- In mouse mode with `Shift` pressed, mouse bindings without `Shift` are only triggered
+    if no exact binding (i.e. one with `Shift`) is found.
 
 ### Fixed
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -1003,17 +1003,24 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let mode = BindingMode::new(self.ctx.terminal().mode(), self.ctx.search_active());
         let mouse_mode = self.ctx.mouse_mode();
         let mods = self.ctx.modifiers().state();
+        let mouse_bindings = self.ctx.config().mouse_bindings().to_owned();
 
-        for i in 0..self.ctx.config().mouse_bindings().len() {
-            let mut binding = self.ctx.config().mouse_bindings()[i].clone();
+        // If mouse mode is active, also look for bindings without shift.
+        let mut check_fallback = mouse_mode && mods.contains(ModifiersState::SHIFT);
 
-            // Require shift for all modifiers when mouse mode is active.
-            if mouse_mode {
-                binding.mods |= ModifiersState::SHIFT;
-            }
-
+        for binding in &mouse_bindings {
             if binding.is_triggered_by(mode, mods, &button) {
                 binding.action.execute(&mut self.ctx);
+                check_fallback = false;
+            }
+        }
+
+        if check_fallback {
+            let fallback_mods = mods & !ModifiersState::SHIFT;
+            for binding in &mouse_bindings {
+                if binding.is_triggered_by(mode, fallback_mods, &button) {
+                    binding.action.execute(&mut self.ctx);
+                }
             }
         }
     }

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -583,9 +583,10 @@ This section documents the *[mouse]* table of the configuration file.
 	See _keyboard.bindings_ for full documentation on _mods_, _mode_, _action_,
 	and _chars_.
 
-	To trigger mouse bindings when an application running within Alacritty
-	captures the mouse, the `Shift` modifier is automatically added as a
-	requirement.
+	When an application running within Alacritty captures the mouse, the `Shift`
+	modifier can be used to suppress mouse reporting. If no action is found for
+	the event, actions for the event without the `Shift` modifier are triggered
+	instead.
 
 	*mouse* "Middle" | "Left" | "Right" | "Back" | "Forward" | <number>
 


### PR DESCRIPTION
Only consider bindings without Shift if there are no actions defined for the actual mouse event.

Fixes #7292