### PR TITLE
Avoid maximizing window when creating new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Blocking paste freezing alacritty on Wayland
 - `Command` modifier persisting after `Cmd + Tab` on macOS
 - Crash on exit when using NVIDIA binary drivers on Wayland
+- `window.startup_mode` applied to window again when creating new tab
 
 ### Removed
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -392,7 +392,7 @@ impl Display {
         window: Window,
         gl_context: NotCurrentContext,
         config: &UiConfig,
-        tabbed: bool,
+        _tabbed: bool,
     ) -> Result<Display, Error> {
         let raw_window_handle = window.raw_window_handle();
 
@@ -477,7 +477,7 @@ impl Display {
 
         #[allow(clippy::single_match)]
         #[cfg(not(windows))]
-        if !tabbed {
+        if !_tabbed {
             match config.window.startup_mode {
                 #[cfg(target_os = "macos")]
                 StartupMode::SimpleFullscreen => window.set_simple_fullscreen(true),

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -392,6 +392,7 @@ impl Display {
         window: Window,
         gl_context: NotCurrentContext,
         config: &UiConfig,
+        tabbed: bool,
     ) -> Result<Display, Error> {
         let raw_window_handle = window.raw_window_handle();
 
@@ -476,11 +477,13 @@ impl Display {
 
         #[allow(clippy::single_match)]
         #[cfg(not(windows))]
-        match config.window.startup_mode {
-            #[cfg(target_os = "macos")]
-            StartupMode::SimpleFullscreen => window.set_simple_fullscreen(true),
-            StartupMode::Maximized if !is_wayland => window.set_maximized(true),
-            _ => (),
+        if !tabbed {
+            match config.window.startup_mode {
+                #[cfg(target_os = "macos")]
+                StartupMode::SimpleFullscreen => window.set_simple_fullscreen(true),
+                StartupMode::Maximized if !is_wayland => window.set_maximized(true),
+                _ => (),
+            }
         }
 
         let hint_state = HintState::new(config.hints.alphabet());


### PR DESCRIPTION
This patch clears the startup mode when creating a new tab on macOS to avoid maximizing an existing window.

Fixes #7313