### PR TITLE
Fix warnings about unused imports

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -25,11 +25,11 @@ mod bindings;
 mod mouse;
 
 use crate::cli::Options;
-pub use crate::config::bindings::{
-    Action, Binding, BindingKey, BindingMode, MouseAction, SearchAction, ViAction,
-};
 #[cfg(test)]
-pub use crate::config::mouse::Mouse;
+pub use crate::config::bindings::Binding;
+pub use crate::config::bindings::{
+    Action, BindingKey, BindingMode, MouseAction, SearchAction, ViAction,
+};
 pub use crate::config::ui_config::UiConfig;
 
 /// Maximum number of depth for the configuration file imports.


### PR DESCRIPTION
`pub use crate::config::mouse::Mouse` is not needed even for tests.
`pub use crate::config::bindings::Binding` is only needed for tests.

Tested in 8 combinations:
```
cargo {+stable,+nightly} clippy {,--all-targets} {,--release}
```