### PR TITLE
Fix clippy warnings

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -25,11 +25,11 @@ mod bindings;
 mod mouse;
 
 use crate::cli::Options;
-pub use crate::config::bindings::{
-    Action, Binding, BindingKey, BindingMode, MouseAction, SearchAction, ViAction,
-};
 #[cfg(test)]
-pub use crate::config::mouse::Mouse;
+pub use crate::config::bindings::Binding;
+pub use crate::config::bindings::{
+    Action, BindingKey, BindingMode, MouseAction, SearchAction, ViAction,
+};
 pub use crate::config::ui_config::UiConfig;
 
 /// Maximum number of depth for the configuration file imports.

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2982,7 +2982,7 @@ mod tests {
         term.push_title();
         term.set_title(Some("Next".into()));
         assert_eq!(term.title, Some("Next".into()));
-        assert_eq!(term.title_stack.get(0).unwrap(), &Some("Test".into()));
+        assert_eq!(term.title_stack.first().unwrap(), &Some("Test".into()));
 
         // Title can be popped from stack and set as the window title.
         term.pop_title();


### PR DESCRIPTION
Tested in 8 combinations:
```
cargo {+stable,+nightly} clippy {,--all-targets} {,--release}
```

* Fixed warnings about unused imports. One import is only used for tests, another import is not needed at all.
* Replaced `get(0)` with `first()` in tests as suggested by nightly clippy.