### PR TITLE
Fix clippy warning about `skip(0)`

### DIFF
--- a/alacritty/src/string.rs
+++ b/alacritty/src/string.rs
@@ -50,8 +50,9 @@ impl<'a> StrShortener<'a> {
         }
 
         if direction == ShortenDirection::Right {
+            let skip_chars = 0; // suppress clippy warning about `skip(0)` in Rust 1.73+
             return Self {
-                chars: text.chars().skip(0),
+                chars: text.chars().skip(skip_chars),
                 accumulated_len: 0,
                 text_action: TextAction::Char,
                 max_width,


### PR DESCRIPTION
Another attempt to fix the clippy warning about `skip(0)`. It started affecting stable builds, as Rust 1.73 warns about it. Fortunately, there is an easy workaround that doesn't involve suppressing the warning.