### PR TITLE
Bump glutin to 0.31.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c03bcbdb3c865ac10196deaddbcea719e601d2d3eef7541872b8dee3492a36"
+checksum = "eca18d477e18c996c1fd1a50e04c6a745b67e2d512c7fb51f2757d9486a0e3ee"
 dependencies = [
  "bitflags 2.4.0",
  "cfg_aliases",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = "2.2.1"
 clap = { version = "4.2.7", features = ["derive", "env"] }
 copypasta = { version = "0.10.0", default-features = false }
 crossfont = { version = "0.5.0", features = ["force_system_fontconfig"] }
-glutin = { version = "0.31.0", default-features = false, features = ["egl", "wgl"] }
+glutin = { version = "0.31.1", default-features = false, features = ["egl", "wgl"] }
 home = "0.5.5"
 libc = "0.2"
 log = { version = "0.4", features = ["std", "serde"] }


### PR DESCRIPTION
This fixes a crash on startup with macOS Sonoma.

--

Crash is not present with glutin 0.30.x series.