### PR TITLE
Fix crash when leaving search after resize

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -154,6 +154,11 @@ impl SearchState {
         self.focused_match.as_ref()
     }
 
+    /// Clear the focused match.
+    pub fn clear_focused_match(&mut self) {
+        self.focused_match = None;
+    }
+
     /// Active search dfas.
     pub fn dfas(&mut self) -> Option<&mut RegexSearch> {
         self.dfas.as_mut()

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -480,7 +480,7 @@ impl WindowContext {
                 &mut self.display,
                 &mut self.notifier,
                 &self.message_buffer,
-                &self.search_state,
+                &mut self.search_state,
                 old_is_searching,
                 &self.config,
             );
@@ -546,7 +546,7 @@ impl WindowContext {
         display: &mut Display,
         notifier: &mut Notifier,
         message_buffer: &MessageBuffer,
-        search_state: &SearchState,
+        search_state: &mut SearchState,
         old_is_searching: bool,
         config: &UiConfig,
     ) {
@@ -563,7 +563,7 @@ impl WindowContext {
             terminal,
             notifier,
             message_buffer,
-            search_state.history_index.is_some(),
+            search_state,
             config,
         );
 


### PR DESCRIPTION
This fixes a crash which could occur when leaving search with a visible match after shrinking the terminal height to be lower than the original line the focused match was in.

Closes #7054.