### PR TITLE
Add `--option` argument to `create-window`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Debug option `prefer_egl` to prioritize EGL over other display APIs
 - Inline vi-mode search using `f`/`F`/`t`/`T`
 - `window.blur` config option to request blur for transparent windows
+- `--option` argument for `alacritty msg create-window`
 
 ### Changed
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -126,7 +126,7 @@ impl From<YamlError> for Error {
 }
 
 /// Load the configuration file.
-pub fn load(options: &Options) -> UiConfig {
+pub fn load(options: &mut Options) -> UiConfig {
     let config_path = options
         .config_file
         .clone()
@@ -155,7 +155,7 @@ pub fn load(options: &Options) -> UiConfig {
 }
 
 /// Attempt to reload the configuration file.
-pub fn reload(config_path: &Path, options: &Options) -> Result<UiConfig> {
+pub fn reload(config_path: &Path, options: &mut Options) -> Result<UiConfig> {
     debug!("Reloading configuration file: {:?}", config_path);
 
     // Load config, propagating errors.
@@ -167,7 +167,7 @@ pub fn reload(config_path: &Path, options: &Options) -> Result<UiConfig> {
 }
 
 /// Modifications after the `UiConfig` object is created.
-fn after_loading(config: &mut UiConfig, options: &Options) {
+fn after_loading(config: &mut UiConfig, options: &mut Options) {
     // Override config with CLI options.
     options.override_config(config);
 

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -20,8 +20,8 @@ use crate::cli::Options;
 use crate::event::{Event, EventType};
 use crate::message_bar::{Message, MessageType};
 
-/// Logging target for per-window config error messages.
-pub const LOG_TARGET_WINDOW_CONFIG: &str = "alacritty_log_window_config";
+/// Logging target for IPC config error messages.
+pub const LOG_TARGET_IPC_CONFIG: &str = "alacritty_log_window_config";
 
 /// Name for the environment variable containing the log file's path.
 const ALACRITTY_LOG_ENV: &str = "ALACRITTY_LOG";
@@ -42,7 +42,7 @@ static EXTRA_LOG_TARGETS: Lazy<Vec<String>> = Lazy::new(|| {
 
 /// List of targets which will be logged by Alacritty.
 const ALLOWED_TARGETS: &[&str] = &[
-    LOG_TARGET_WINDOW_CONFIG,
+    LOG_TARGET_IPC_CONFIG,
     LOG_TARGET_CONFIG,
     "alacritty_config_derive",
     "alacritty_terminal",
@@ -50,6 +50,7 @@ const ALLOWED_TARGETS: &[&str] = &[
     "crossfont",
 ];
 
+/// Initialize the logger to its defaults.
 pub fn initialize(
     options: &Options,
     event_proxy: EventLoopProxy<Event>,

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -20,8 +20,8 @@ use crate::cli::Options;
 use crate::event::{Event, EventType};
 use crate::message_bar::{Message, MessageType};
 
-/// Logging target for IPC config error messages.
-pub const LOG_TARGET_IPC_CONFIG: &str = "alacritty_log_ipc_config";
+/// Logging target for per-window config error messages.
+pub const LOG_TARGET_WINDOW_CONFIG: &str = "alacritty_log_window_config";
 
 /// Name for the environment variable containing the log file's path.
 const ALACRITTY_LOG_ENV: &str = "ALACRITTY_LOG";
@@ -42,7 +42,7 @@ static EXTRA_LOG_TARGETS: Lazy<Vec<String>> = Lazy::new(|| {
 
 /// List of targets which will be logged by Alacritty.
 const ALLOWED_TARGETS: &[&str] = &[
-    LOG_TARGET_IPC_CONFIG,
+    LOG_TARGET_WINDOW_CONFIG,
     LOG_TARGET_CONFIG,
     "alacritty_config_derive",
     "alacritty_terminal",

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -122,7 +122,7 @@ impl Drop for TemporaryFiles {
 ///
 /// Creates a window, the terminal state, PTY, I/O event loop, input processor,
 /// config change monitor, and runs the main display loop.
-fn alacritty(options: Options) -> Result<(), Box<dyn Error>> {
+fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
     // Setup winit event loop.
     let window_event_loop = WinitEventLoopBuilder::<Event>::with_user_event().build()?;
 
@@ -139,7 +139,7 @@ fn alacritty(options: Options) -> Result<(), Box<dyn Error>> {
     info!("Running on Wayland");
 
     // Load configuration file.
-    let config = config::load(&options);
+    let config = config::load(&mut options);
     log_config_path(&config);
 
     // Update the log level from config.

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -69,7 +69,7 @@ impl Scheduler {
             }
         }
 
-        self.timers.get(0).map(|timer| timer.deadline)
+        self.timers.front().map(|timer| timer.deadline)
     }
 
     /// Schedule a new event.

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -14,14 +14,13 @@ use glutin::config::GetGlConfig;
 use glutin::display::GetGlDisplay;
 #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
 use glutin::platform::x11::X11GlConfigExt;
-use log::{error, info};
+use log::info;
 use raw_window_handle::HasRawDisplayHandle;
 use serde_json as json;
 use winit::event::{Event as WinitEvent, Modifiers, WindowEvent};
 use winit::event_loop::{EventLoopProxy, EventLoopWindowTarget};
 use winit::window::WindowId;
 
-use alacritty_config::SerdeReplace;
 use alacritty_terminal::event::Event as TerminalEvent;
 use alacritty_terminal::event_loop::{EventLoop as PtyEventLoop, Msg, Notifier};
 use alacritty_terminal::grid::{Dimensions, Scroll};
@@ -31,7 +30,7 @@ use alacritty_terminal::term::test::TermSize;
 use alacritty_terminal::term::{Term, TermMode};
 use alacritty_terminal::tty;
 
-use crate::cli::WindowOptions;
+use crate::cli::{ParsedOptions, WindowOptions};
 use crate::clipboard::Clipboard;
 use crate::config::UiConfig;
 use crate::display::window::Window;
@@ -39,7 +38,8 @@ use crate::display::Display;
 use crate::event::{
     ActionContext, Event, EventProxy, InlineSearchState, Mouse, SearchState, TouchPurpose,
 };
-use crate::logging::LOG_TARGET_WINDOW_CONFIG;
+#[cfg(unix)]
+use crate::logging::LOG_TARGET_IPC_CONFIG;
 use crate::message_bar::MessageBuffer;
 use crate::scheduler::Scheduler;
 use crate::{input, renderer};
@@ -65,7 +65,7 @@ pub struct WindowContext {
     master_fd: RawFd,
     #[cfg(not(windows))]
     shell_pid: u32,
-    window_config: Vec<toml::Value>,
+    window_config: ParsedOptions,
     config: Rc<UiConfig>,
 }
 
@@ -126,6 +126,7 @@ impl WindowContext {
         proxy: EventLoopProxy<Event>,
         config: Rc<UiConfig>,
         options: WindowOptions,
+        config_overrides: ParsedOptions,
     ) -> Result<Self, Box<dyn Error>> {
         // Get any window and take its GL config and display to build a new context.
         let (gl_display, gl_config) = {
@@ -162,7 +163,14 @@ impl WindowContext {
 
         let display = Display::new(window, gl_context, &config, tabbed)?;
 
-        Self::new(display, config, options, proxy)
+        let mut window_context = Self::new(display, config, options, proxy)?;
+
+        // Set the config overrides at startup.
+        //
+        // These are already applied to `config`, so no update is necessary.
+        window_context.window_config = config_overrides;
+
+        Ok(window_context)
     }
 
     /// Create a new terminal window context.
@@ -248,9 +256,9 @@ impl WindowContext {
             cursor_blink_timed_out: Default::default(),
             inline_search_state: Default::default(),
             message_buffer: Default::default(),
+            window_config: Default::default(),
             search_state: Default::default(),
             event_queue: Default::default(),
-            window_config: Default::default(),
             modifiers: Default::default(),
             occluded: Default::default(),
             mouse: Default::default(),
@@ -264,27 +272,7 @@ impl WindowContext {
         let old_config = mem::replace(&mut self.config, new_config);
 
         // Apply ipc config if there are overrides.
-        if !self.window_config.is_empty() {
-            let mut config = (*self.config).clone();
-
-            // Apply each option, removing broken ones.
-            let mut i = 0;
-            while i < self.window_config.len() {
-                let option = &self.window_config[i];
-                match config.replace(option.clone()) {
-                    Err(err) => {
-                        error!(
-                            target: LOG_TARGET_WINDOW_CONFIG,
-                            "Unable to override option '{}': {}", option, err
-                        );
-                        self.window_config.swap_remove(i);
-                    },
-                    Ok(_) => i += 1,
-                }
-            }
-
-            self.config = Rc::new(config);
-        }
+        self.config = self.window_config.override_config_rc(self.config.clone());
 
         self.display.update_config(&self.config);
         self.terminal.lock().set_options(self.config.term_options());
@@ -357,7 +345,7 @@ impl WindowContext {
     #[cfg(unix)]
     pub fn reset_window_config(&mut self, config: Rc<UiConfig>) {
         // Clear previous window errors.
-        self.message_buffer.remove_target(LOG_TARGET_WINDOW_CONFIG);
+        self.message_buffer.remove_target(LOG_TARGET_IPC_CONFIG);
 
         self.window_config.clear();
 
@@ -367,20 +355,11 @@ impl WindowContext {
 
     /// Add new window config overrides.
     #[cfg(unix)]
-    pub fn add_window_config(&mut self, config: Rc<UiConfig>, options: &[String]) {
+    pub fn add_window_config(&mut self, config: Rc<UiConfig>, options: &ParsedOptions) {
         // Clear previous window errors.
-        self.message_buffer.remove_target(LOG_TARGET_WINDOW_CONFIG);
+        self.message_buffer.remove_target(LOG_TARGET_IPC_CONFIG);
 
-        for option in options {
-            // Try and parse option as toml.
-            match toml::from_str(option) {
-                Ok(value) => self.window_config.push(value),
-                Err(err) => error!(
-                    target: LOG_TARGET_WINDOW_CONFIG,
-                    "'{}': Invalid window config value: {:?}", option, err
-                ),
-            }
-        }
+        self.window_config.extend_from_slice(options);
 
         // Reload current config to pull new IPC config.
         self.update_config(config);

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -104,8 +104,8 @@ fn ref_test(dir: &Path) {
     let grid: Grid<Cell> = json::from_str(&serialized_grid).unwrap();
     let ref_config: RefConfig = json::from_str(&serialized_cfg).unwrap();
 
-    let mut options = Config::default();
-    options.scrolling_history = ref_config.history_size as usize;
+    let options =
+        Config { scrolling_history: ref_config.history_size as usize, ..Default::default() };
 
     let mut terminal = Term::new(options, &size, Mock);
     let mut parser: ansi::Processor = ansi::Processor::new();

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -18,14 +18,14 @@ _alacritty() {
 '--embed=[X11 window ID to embed Alacritty within (decimal or hexadecimal with "0x" prefix)]:EMBED: ' \
 '--config-file=[Specify alternative configuration file \[default\: \$XDG_CONFIG_HOME/alacritty/alacritty.toml\]]:CONFIG_FILE:_files' \
 '--socket=[Path for IPC socket creation]:SOCKET:_files' \
-'*-o+[Override configuration file options \[example\: cursor.style=Beam\]]:OPTION: ' \
-'*--option=[Override configuration file options \[example\: cursor.style=Beam\]]:OPTION: ' \
 '--working-directory=[Start the shell in the specified working directory]:WORKING_DIRECTORY:_files' \
 '*-e+[Command and args to execute (must be last argument)]:COMMAND: ' \
 '*--command=[Command and args to execute (must be last argument)]:COMMAND: ' \
 '-T+[Defines the window title \[default\: Alacritty\]]:TITLE: ' \
 '--title=[Defines the window title \[default\: Alacritty\]]:TITLE: ' \
 '--class=[Defines window class/app_id on X11/Wayland \[default\: Alacritty\]]:general> | <general>,<instance: ' \
+'*-o+[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION: ' \
+'*--option=[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION: ' \
 '--print-events[Print all events to stdout]' \
 '--ref-test[Generates ref test]' \
 '(-v)*-q[Reduces the level of verbosity (the min level is -qq)]' \
@@ -68,6 +68,8 @@ _arguments "${_arguments_options[@]}" \
 '-T+[Defines the window title \[default\: Alacritty\]]:TITLE: ' \
 '--title=[Defines the window title \[default\: Alacritty\]]:TITLE: ' \
 '--class=[Defines window class/app_id on X11/Wayland \[default\: Alacritty\]]:general> | <general>,<instance: ' \
+'*-o+[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION: ' \
+'*--option=[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION: ' \
 '--hold[Remain open after child process exit]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -81,7 +83,7 @@ _arguments "${_arguments_options[@]}" \
 '()--reset[Clear all runtime configuration changes]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-'*::options -- Configuration file options \[example\: cursor.style=Beam\]:' \
+'*::options -- Configuration file options \[example\: '\''cursor.style="Beam"'\''\]:' \
 && ret=0
 ;;
 (help)

--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -61,7 +61,7 @@ _alacritty() {
 
     case "${cmd}" in
         alacritty)
-            opts="-q -v -o -e -T -h -V --print-events --ref-test --embed --config-file --socket --option --working-directory --hold --command --title --class --help --version msg migrate help"
+            opts="-q -v -e -T -o -h -V --print-events --ref-test --embed --config-file --socket --working-directory --hold --command --title --class --option --help --version msg migrate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -76,14 +76,6 @@ _alacritty() {
                     return 0
                     ;;
                 --socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --option)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -o)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -108,6 +100,14 @@ _alacritty() {
                     return 0
                     ;;
                 --class)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --option)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -o)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -269,7 +269,7 @@ _alacritty() {
             return 0
             ;;
         alacritty__msg__create__window)
-            opts="-e -T -h --working-directory --hold --command --title --class --help"
+            opts="-e -T -o -h --working-directory --hold --command --title --class --option --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -296,6 +296,14 @@ _alacritty() {
                     return 0
                     ;;
                 --class)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --option)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -o)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -1,11 +1,11 @@
 complete -c alacritty -n "__fish_use_subcommand" -l embed -d 'X11 window ID to embed Alacritty within (decimal or hexadecimal with "0x" prefix)' -r
 complete -c alacritty -n "__fish_use_subcommand" -l config-file -d 'Specify alternative configuration file [default: $XDG_CONFIG_HOME/alacritty/alacritty.toml]' -r -F
 complete -c alacritty -n "__fish_use_subcommand" -l socket -d 'Path for IPC socket creation' -r -F
-complete -c alacritty -n "__fish_use_subcommand" -s o -l option -d 'Override configuration file options [example: cursor.style=Beam]' -r
 complete -c alacritty -n "__fish_use_subcommand" -l working-directory -d 'Start the shell in the specified working directory' -r -F
 complete -c alacritty -n "__fish_use_subcommand" -s e -l command -d 'Command and args to execute (must be last argument)' -r
 complete -c alacritty -n "__fish_use_subcommand" -s T -l title -d 'Defines the window title [default: Alacritty]' -r
 complete -c alacritty -n "__fish_use_subcommand" -l class -d 'Defines window class/app_id on X11/Wayland [default: Alacritty]' -r
+complete -c alacritty -n "__fish_use_subcommand" -s o -l option -d 'Override configuration file options [example: \'cursor.style="Beam"\']' -r
 complete -c alacritty -n "__fish_use_subcommand" -l print-events -d 'Print all events to stdout'
 complete -c alacritty -n "__fish_use_subcommand" -l ref-test -d 'Generates ref test'
 complete -c alacritty -n "__fish_use_subcommand" -s q -d 'Reduces the level of verbosity (the min level is -qq)'
@@ -25,6 +25,7 @@ complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subco
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s e -l command -d 'Command and args to execute (must be last argument)' -r
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s T -l title -d 'Defines the window title [default: Alacritty]' -r
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -l class -d 'Defines window class/app_id on X11/Wayland [default: Alacritty]' -r
+complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s o -l option -d 'Override configuration file options [example: \'cursor.style="Beam"\']' -r
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -l hold -d 'Remain open after child process exit'
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from create-window" -s h -l help -d 'Print help'
 complete -c alacritty -n "__fish_seen_subcommand_from msg; and __fish_seen_subcommand_from config" -s w -l window-id -d 'Window ID for the new config' -r

--- a/extra/man/alacritty-msg.1.scd
+++ b/extra/man/alacritty-msg.1.scd
@@ -19,14 +19,24 @@ making it possible to control Alacritty without directly accessing it.
 *create-window*
 	Create a new window in the same Alacritty process
 
-	*OPTIONS*
+	*FLAGS*
 		*--hold*
 			Remain open after child process exits
 
+	*OPTIONS*
 		*--working-directory* <working-directory>
 			Start the shell in the specified working directory
 
-		*command* <command>...
+		*-T, --title* <TITLE>
+			Defines the window title [default: Alacritty]
+
+		*--class* <GENERAL> | <GENERAL>,<INSTANCE>
+			Defines window class/app_id on X11/Wayland [default: Alacritty]
+
+		*-o, --option* <OPTION>...
+			Override configuration file options [example: 'cursor.style="Beam"']
+
+		*-e, --command* <COMMAND>...
 			Command and args to execute (must be last argument)
 
 *config*
@@ -34,7 +44,11 @@ making it possible to control Alacritty without directly accessing it.
 
 	*ARGS*
 		*<CONFIG_OPTIONS>...*
-			Configuration file options [example: cursor.style=Beam]
+			Configuration file options [example: 'cursor.style="Beam"']
+
+	*FLAGS*
+		*-r, --reset*
+			Clear all runtime configuration changes
 
 	*OPTIONS*
 		*-w, --window-id* <WINDOW_ID>

--- a/extra/man/alacritty.1.scd
+++ b/extra/man/alacritty.1.scd
@@ -61,7 +61,7 @@ set of features with high performance.
 	X11 window ID to embed Alacritty within (decimal or hexadecimal with _0x_ prefix)
 
 *-o, --option* <option>...
-	Override configuration file options [example: cursor.style=Beam]
+	Override configuration file options [example: 'cursor.style="Beam"']
 
 *--socket* <socket>
 	Path for IPC socket creation


### PR DESCRIPTION
This patch adds a new CLI parameter to the `create-window` subcommand,
matching the existing `--option` parameter when creating a new Alacritty
instance.

This parameter allows setting up the initial window configuration from
the CLI without having to call `alacritty msg config`, making sure that
all options are set appropriately right from the start.

Closes #6238.

---

This is split into two patches, the first one being technically optional. However it hopefully makes understanding these changes a little easier.