### PR TITLE
Simplify powerline drawing algorithm

### DIFF
--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -1,7 +1,7 @@
 //! Hand-rolled drawing of unicode [box drawing](http://www.unicode.org/charts/PDF/U2500.pdf)
 //! and [block elements](https://www.unicode.org/charts/PDF/U2580.pdf), and also powerline symbols.
 
-use std::{cmp, mem, ops};
+use std::{cmp, iter, mem, ops};
 
 use crossfont::{BitmapBuffer, Metrics, RasterizedGlyph};
 
@@ -519,8 +519,8 @@ fn powerline_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> 
     // x = H/2 - 1.
     let intersection = (height as i32 + 1) / 2 - 1;
 
-    let mut f_x = LineEquation::new(slope, f_y0, 0, intersection);
-    let mut g_x = LineEquation::new(-slope, g_y0, 0, intersection);
+    let f_x = LineEquation::new(slope, f_y0, 0, intersection);
+    let g_x = LineEquation::new(-slope, g_y0, 0, intersection);
 
     // Inner functions to make arrows thicker.
     let mut f_x_inner =
@@ -528,7 +528,8 @@ fn powerline_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> 
     let mut g_x_inner =
         LineEquation::new(-slope, g_y0 - extra_thickness, 0, intersection - extra_thickness);
 
-    while let (Some(p1), Some(p2)) = (f_x.next(), g_x.next()) {
+    // NOTE f_x and g_x have the same amount of iterations.
+    for (p1, p2) in iter::zip(f_x, g_x) {
         if character == POWERLINE_TRIANGLE || character == POWERLINE_TRIANGLE_FLIPPED {
             canvas.draw_rect(0., p1.1, p1.0 + 1., 1., COLOR_FILL);
             canvas.draw_rect(0., p2.1, p2.0 + 1., 1., COLOR_FILL);

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -15,6 +15,11 @@ const COLOR_FILL_ALPHA_STEP_3: Pixel = Pixel { _r: 64, _g: 64, _b: 64 };
 /// Default color used for filling.
 const COLOR_FILL: Pixel = Pixel { _r: 255, _g: 255, _b: 255 };
 
+const POWERLINE_TRIANGLE: char = '\u{e0b0}';
+const POWERLINE_ARROW: char = '\u{e0b1}';
+const POWERLINE_TRIANGLE_FLIPPED: char = '\u{e0b2}';
+const POWERLINE_ARROW_FLIPPED: char = '\u{e0b3}';
+
 /// Returns the rasterized glyph if the character is part of the built-in font.
 pub fn builtin_glyph(
     character: char,
@@ -26,7 +31,9 @@ pub fn builtin_glyph(
         // Box drawing characters and block elements.
         '\u{2500}'..='\u{259f}' => box_drawing(character, metrics, offset),
         // Powerline symbols: '','','',''
-        '\u{e0b0}'..='\u{e0b3}' => powerline_drawing(character, metrics, offset),
+        POWERLINE_TRIANGLE..=POWERLINE_ARROW_FLIPPED => {
+            powerline_drawing(character, metrics, offset)
+        },
         _ => return None,
     };
 
@@ -42,8 +49,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
     // Ensure that width and height is at least one.
     let height = (metrics.line_height as i32 + offset.y as i32).max(1) as usize;
     let width = (metrics.average_advance as i32 + offset.x as i32).max(1) as usize;
-    // Use one eight of the cell width, since this is used as a step size for block elements.
-    let stroke_size = cmp::max((width as f32 / 8.).round() as usize, 1);
+    let stroke_size = calculate_stroke_size(width);
     let heavy_stroke_size = stroke_size * 2;
 
     // Certain symbols require larger canvas than the cell itself, since for proper contiguous
@@ -500,106 +506,49 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
 fn powerline_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> RasterizedGlyph {
     let height = (metrics.line_height as i32 + offset.y as i32) as usize;
     let width = (metrics.average_advance as i32 + offset.x as i32) as usize;
-    // Use one eight of the cell width, since this is used as a step size for block elements.
-    let stroke_size = cmp::max((width as f32 / 8.).round() as usize, 1) as f32;
+    let extra_thickness = calculate_stroke_size(width) as i32 - 1;
 
     let mut canvas = Canvas::new(width, height);
 
-    let y_center = (height - 1) as f32 / 2.;
+    let slope = 1;
+    let f_y0 = 1;
+    let g_y0 = height as i32 - f_y0 - 1;
+
     // Start with offset `1` and draw until the intersection of the f(x) = x + 1 and
-    // g(x) = H - x + 1 lines. The intersection happens when f(x) = g(x), which is at
-    // x = H/2 (`y_center`).
-    let from_y = 1;
-    let x_end = y_center.floor();
-    let y_end = (height - from_y - 1) as f32;
+    // g(x) = H - x - 1 lines. The intersection happens when f(x) = g(x), which is at
+    // x = H/2 - 1.
+    let intersection = (height as i32 + 1) / 2 - 1;
 
-    // Pick the start point outside of the canvas to even-out the start.
-    let from_x = 0.;
-    let to_x = x_end;
-    canvas.draw_line_grid(from_x, from_y as f32, to_x, y_center.floor());
-    canvas.draw_line_grid(from_x, y_end, to_x, y_center.ceil());
+    let mut f_x = LineEquation::new(slope, f_y0, 0, intersection);
+    let mut g_x = LineEquation::new(-slope, g_y0, 0, intersection);
 
-    // For regular arrows we handle thickness by drawing 2 angle arrows and then just filling
-    // the contents between them.
-    if (character == '\u{e0b1}' || character == '\u{e0b3}') && stroke_size > 1. {
-        // The default line is of stroke size 1, so the 0.5 is computed by subtracting 1 from
-        // stroke_size and then adding 0.5 to to put the target in the center of the cell.
-        let to_x = x_end - stroke_size;
-        canvas.draw_line_grid(from_x, from_y as f32 + stroke_size, to_x, y_center.floor());
-        canvas.draw_line_grid(from_x, y_end - stroke_size, to_x, y_center.ceil());
-    }
+    // Inner functions to make arrows thicker.
+    let mut f_x_inner =
+        LineEquation::new(slope, f_y0 + extra_thickness, 0, intersection - extra_thickness);
+    let mut g_x_inner =
+        LineEquation::new(-slope, g_y0 - extra_thickness, 0, intersection - extra_thickness);
 
-    let buffer = canvas.buffer_mut();
-    if character == '\u{e0b0}' || character == '\u{e0b2}' {
-        for row in from_y..height - from_y {
-            let row_offset = row * width;
-            for index in 1..width {
-                let index = row_offset + index;
-                if buffer[index - 1]._r > buffer[index]._r && buffer[index]._r == 0 {
-                    break;
-                }
+    while let (Some(p1), Some(p2)) = (f_x.next(), g_x.next()) {
+        if character == POWERLINE_TRIANGLE || character == POWERLINE_TRIANGLE_FLIPPED {
+            canvas.draw_rect(0., p1.1, p1.0 + 1., 1., COLOR_FILL);
+            canvas.draw_rect(0., p2.1, p2.0 + 1., 1., COLOR_FILL);
+        } else if character == POWERLINE_ARROW || character == POWERLINE_ARROW_FLIPPED {
+            let p3 = f_x_inner.next().unwrap_or(p2);
+            let p4 = g_x_inner.next().unwrap_or(p1);
 
-                buffer[index - 1] = COLOR_FILL;
-            }
-        }
-    } else if stroke_size > 1. {
-        // Find the bottom/top most points of extra line we draw, so we can properly set the
-        // `start`.
-
-        let mut y1 = 0;
-        for row in (0..height / 2).rev() {
-            if buffer[row * width]._r != 0 {
-                y1 = row;
+            // Once we reach the canvas end fill the area between f(x) and g(x) to make a proper
+            // cut.
+            if p1.0 as usize + 1 == width {
+                canvas.draw_rect(p1.0, p1.1, 1., p2.1 - p1.1 + 1., COLOR_FILL);
                 break;
-            }
-        }
-        let mut y2 = height / 2;
-        for row in height / 2..height {
-            if buffer[row * width]._r != 0 {
-                y2 = row;
-                break;
-            }
-        }
-
-        for row in from_y..height - from_y {
-            let row_offset = row * width;
-
-            // Find the point on the inner line.
-            let mut start = 0;
-            if row >= y1 && row <= y2 {
-                for base_index in 0..width - 1 {
-                    let index = row_offset + base_index;
-                    if buffer[index]._r != 0 {
-                        start = base_index + 1;
-                        break;
-                    }
-                }
-            }
-
-            // Find the point on the outer line.
-            let mut end = 0;
-            for base_index in (1..width).rev() {
-                let index = row_offset + base_index;
-                if buffer[index]._r != 0 {
-                    end = base_index - 1;
-                    break;
-                }
-            }
-
-            if (row == y1 || row == y2) && start == end {
-                start = 0;
-            }
-
-            // Fill the canvas between inner and outer points in the row.
-            for index in start..=end {
-                let index = row_offset + index;
-                buffer[index] = COLOR_FILL;
+            } else {
+                canvas.draw_rect(p1.0, p1.1, 1., p3.1 - p1.1 + 1., COLOR_FILL);
+                canvas.draw_rect(p4.0, p4.1, 1., p2.1 - p4.1 + 1., COLOR_FILL);
             }
         }
     }
 
-    // Some glyphs are just flipped versions of others, so just flip them.
-    if character == '\u{e0b2}' || character == '\u{e0b3}' {
+    if character == POWERLINE_TRIANGLE_FLIPPED || character == POWERLINE_ARROW_FLIPPED {
         canvas.flip_horizontal();
     }
 
@@ -831,33 +780,6 @@ impl Canvas {
         }
     }
 
-    /// WalkGrid line drawing from (`from_x`, `from_y`) to (`to_x`, `to_y`).
-    fn draw_line_grid(&mut self, from_x: f32, from_y: f32, to_x: f32, to_y: f32) {
-        let dx = (to_x - from_x).trunc();
-        let nx = dx.abs();
-
-        let dy = (to_y - from_y).trunc();
-        let ny = dy.abs();
-
-        let sign_x = dx.signum();
-        let sign_y = dy.signum();
-
-        let mut point = (from_x.trunc(), from_y.trunc());
-        let mut ix = 0.;
-        let mut iy = 0.;
-        while ix <= nx && iy <= ny {
-            self.put_pixel(point.0, point.1, COLOR_FILL);
-
-            if (0.5 + ix) / nx < (0.5 + iy) / ny {
-                point.0 += sign_x;
-                ix += 1.;
-            } else {
-                point.1 += sign_y;
-                iy += 1.;
-            }
-        }
-    }
-
     /// Draws a part of an ellipse centered in `(0., 0.)` with `self.x_center()` and `self.y_center`
     /// vertex and co-vertex respectively using a given `stroke` in the bottom-right quadrant of the
     /// `Canvas` coordinate system.
@@ -956,6 +878,39 @@ impl Canvas {
             let buf = self.buffer.as_ptr() as *mut u8;
             mem::forget(self.buffer);
             Vec::from_raw_parts(buf, len, capacity)
+        }
+    }
+}
+
+/// Size of the stroke to use.
+fn calculate_stroke_size(width: usize) -> usize {
+    // Use one eight of the cell width, since this is used as a step size for block elements.
+    cmp::max((width as f32 / 8.).round() as usize, 1)
+}
+
+/// Equation for `f(x) = slope * x + offset.
+struct LineEquation {
+    slope: i32,
+    offset: i32,
+    x: i32,
+    width: i32,
+}
+
+impl LineEquation {
+    fn new(slope: i32, offset: i32, from_x: i32, width: i32) -> Self {
+        Self { x: from_x - 1, width, slope, offset }
+    }
+}
+
+impl Iterator for LineEquation {
+    type Item = (f32, f32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.x += 1;
+        if self.x >= self.width {
+            None
+        } else {
+            Some((self.x as f32, (self.slope * self.x + self.offset) as f32))
         }
     }
 }


### PR DESCRIPTION
Iterate over points in line instead of drawing it right away
and then finding it in the buffer.

Fixes: 4a26667060 (Use builtin font to draw powerline symbols)