### PR TITLE
Add inode/directory compatible desktop entry

### DIFF
--- a/extra/linux/Alacritty-open.desktop
+++ b/extra/linux/Alacritty-open.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Exec=alacritty --working-directory %U
+TryExec=alacritty
+Icon=Alacritty
+Terminal=false
+Categories=System;TerminalEmulator;
+Name=Alacritty
+GenericName=Terminal
+Comment=Open URLs with Alacritty
+StartupWMClass=Alacritty
+Actions=New;
+MimeType=inode/directory;text/*;x-scheme-handler/alacritty;x-scheme-handler/ssh;

--- a/extra/linux/Alacritty-open.desktop
+++ b/extra/linux/Alacritty-open.desktop
@@ -10,4 +10,4 @@ GenericName=Terminal
 Comment=Open URLs with Alacritty
 StartupWMClass=Alacritty
 Actions=New;
-MimeType=inode/directory;text/*;x-scheme-handler/alacritty;x-scheme-handler/ssh;
+MimeType=inode/directory;text/*;x-scheme-handler/alacritty;


### PR DESCRIPTION
Some terminals support being set as the default file manager so that UI elements such as `Browse Files` can open the terminal but `cd`'d into that directory. 

Kitty accomplishes this by having a separate desktop entry that supports being a file manager and a ssh client. 
Alacritty's CLI doesn't really have a flag to allow it to be both a SSH client and a file manager under the same flag, however the desktop entry file provided here supports at least the file manager part. 
```sh
$ xdg-mime query default inode/directory
Alacritty-open.desktop
```

Long term, maybe alacritty should introduce a `--uri` flag to it's CLI which parses the URI to be either a path, or a compatible protocol such as `ssh://` to then act accordingly? That way we could have one generalized desktop entry that supports numerous mimetypes. 