### PR TITLE
Fix ime position

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -413,7 +413,7 @@ impl Window {
     /// Adjust the IME editor position according to the new location of the cursor.
     pub fn update_ime_position(&self, point: Point<usize>, size: &SizeInfo) {
         let nspot_x = f64::from(size.padding_x() + point.column.0 as f32 * size.cell_width());
-        let nspot_y = f64::from(size.padding_y() + (point.line + 1) as f32 * size.cell_height());
+        let nspot_y = f64::from(size.padding_y() + point.line as f32 * size.cell_height());
 
         // Exclude the rest of the line since we edit from left to right.
         let width = size.width as f64 - nspot_x;


### PR DESCRIPTION
In the past, only the bottom left corner point was passed to ime, so the position was `point.line + 1` to account for current line. However, a rectangle is now passed, and the coordinate passed should be the top left corner of the rectangle. The current line height should not be added in this case.