### PR TITLE
Damage entire window on font size change

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -618,7 +618,8 @@ impl Display {
 
             info!("Cell size: {} x {}", cell_width, cell_height);
 
-            // NOTE: fonts can change glyph sizes keeping the same cell size.
+            // Mark entire terminal as damaged since glyph size could change without cell size
+            // changes.
             self.damage_tracker.frame().mark_fully_damaged();
         }
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -617,6 +617,9 @@ impl Display {
             cell_height = cell_dimensions.1;
 
             info!("Cell size: {} x {}", cell_width, cell_height);
+
+            // NOTE: fonts can change glyph sizes keeping the same cell size.
+            self.damage_tracker.frame().mark_fully_damaged();
         }
 
         let (mut width, mut height) = (self.size_info.width(), self.size_info.height());


### PR DESCRIPTION
Font size could change without changing the cell dimensions, like becoming slightly higher/wider.

Fixes: 40160c5d (Damage only terminal inside `alacritty_terminal`)