### PR TITLE
Make AA stronger for undercurl

### DIFF
--- a/alacritty/res/rect.f.glsl
+++ b/alacritty/res/rect.f.glsl
@@ -45,7 +45,7 @@ color_t draw_undercurl(float_t x, float_t y) {
   // cosine curve.
   float_t alpha = 1.;
   if (y > undercurlTop || y < undercurlBottom) {
-    // NOTE: doing proper SDF is complicated for this shader, so just make AA
+    // Doing proper SDF is complicated for this shader, so just make AA
     // stronger by 1/x^2, which renders preserving underline thickness and
     // being bold enough.
     float_t dst = min(abs(undercurlTop - y), abs(undercurlBottom - y));

--- a/alacritty/res/rect.f.glsl
+++ b/alacritty/res/rect.f.glsl
@@ -45,7 +45,11 @@ color_t draw_undercurl(float_t x, float_t y) {
   // cosine curve.
   float_t alpha = 1.;
   if (y > undercurlTop || y < undercurlBottom) {
-    alpha = 1. - min(abs(undercurlTop - y), abs(undercurlBottom - y));
+    // NOTE: doing proper SDF is complicated for this shader, so just make AA
+    // stronger by 1/x^2, which renders preserving underline thickness and
+    // being bold enough.
+    float_t dst = min(abs(undercurlTop - y), abs(undercurlBottom - y));
+    alpha -= dst * dst;
   }
 
   // The result is an alpha mask on a rect, which leaves only curve opaque.


### PR DESCRIPTION
This improves undercurl rendering preserving its original thickness. This also makes it look not out-of place when places next to other lines.

--

Before

![image](https://github.com/alacritty/alacritty/assets/27620401/7898007a-eb08-499e-9962-b54af321533d)

After

![image](https://github.com/alacritty/alacritty/assets/27620401/11467e0c-c1c1-429d-aa49-d799773fbaf2)
