### PR TITLE
Fix DECRPM reporting

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1922,7 +1922,7 @@ impl<T: EventListener> Handler for Term<T> {
         };
 
         self.event_proxy.send_event(Event::PtyWrite(format!(
-            "\x1b[?{};{}$p",
+            "\x1b[?{};{}$y",
             mode.raw(),
             state as u8,
         )));
@@ -1979,7 +1979,7 @@ impl<T: EventListener> Handler for Term<T> {
         };
 
         self.event_proxy.send_event(Event::PtyWrite(format!(
-            "\x1b[{};{}$p",
+            "\x1b[{};{}$y",
             mode.raw(),
             state as u8,
         )));


### PR DESCRIPTION
The DECRQM uses `p` to query, but the reply uses `y`.

Fixes #7397.