### PR TITLE
Fix trigger of normal bindings in mouse mode

### DIFF
--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -1000,7 +1000,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let mut check_fallback = mouse_mode && mods.contains(ModifiersState::SHIFT);
 
         for binding in &mouse_bindings {
-            if binding.is_triggered_by(mode, mods, &button) {
+            // Don't trigger normal bindings in mouse mode unless Shift is pressed.
+            if binding.is_triggered_by(mode, mods, &button) && (check_fallback || !mouse_mode) {
                 binding.action.execute(&mut self.ctx);
                 check_fallback = false;
             }


### PR DESCRIPTION
We should ensure that the `Shift` is actually pressed when trying to prefer regular bindings instead of the ones if we had Shift applied.

Fixes: 500b696ca8ed (Prefer exact matches for bindings in mouse mode)
Fixes #7415.