### PR TITLE
Don't emit text for NamedKey without text repr

### DIFF
--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -110,13 +110,13 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return true;
         }
 
-        let disambiguate = if mode.contains(TermMode::DISAMBIGUATE_ESC_CODES) {
+        let mut disambiguate = false;
+        if mode.contains(TermMode::DISAMBIGUATE_ESC_CODES) {
             let on_numpad = key.location == KeyLocation::Numpad;
             let is_escape = key.logical_key == Key::Named(NamedKey::Escape);
-            is_escape || (!mods.is_empty() && mods != ModifiersState::SHIFT) || on_numpad
-        } else {
-            false
-        };
+            disambiguate =
+                is_escape || (!mods.is_empty() && mods != ModifiersState::SHIFT) || on_numpad;
+        }
 
         match key.logical_key {
             _ if disambiguate => true,

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -107,15 +107,22 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         mods: ModifiersState,
     ) -> bool {
         if mode.contains(TermMode::REPORT_ALL_KEYS_AS_ESC) {
-            true
-        } else if mode.contains(TermMode::DISAMBIGUATE_ESC_CODES) {
+            return true;
+        }
+
+        let disambiguate = if mode.contains(TermMode::DISAMBIGUATE_ESC_CODES) {
             let on_numpad = key.location == KeyLocation::Numpad;
             let is_escape = key.logical_key == Key::Named(NamedKey::Escape);
             is_escape || (!mods.is_empty() && mods != ModifiersState::SHIFT) || on_numpad
         } else {
-            // `Delete` key always has text attached to it, but it's a named key, thus needs to be
-            // excluded here as well.
-            text.is_empty() || key.logical_key == Key::Named(NamedKey::Delete)
+            false
+        };
+
+        match key.logical_key {
+            _ if disambiguate => true,
+            // Exclude all the named keys unless they have textual representation.
+            Key::Named(named) => named.to_text().is_none(),
+            _ => text.is_empty(),
         }
     }
 

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -110,13 +110,10 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return true;
         }
 
-        let mut disambiguate = false;
-        if mode.contains(TermMode::DISAMBIGUATE_ESC_CODES) {
-            let on_numpad = key.location == KeyLocation::Numpad;
-            let is_escape = key.logical_key == Key::Named(NamedKey::Escape);
-            disambiguate =
-                is_escape || (!mods.is_empty() && mods != ModifiersState::SHIFT) || on_numpad;
-        }
+        let disambiguate = mode.contains(TermMode::DISAMBIGUATE_ESC_CODES)
+            && (key.logical_key == Key::Named(NamedKey::Escape)
+                || (!mods.is_empty() && mods != ModifiersState::SHIFT)
+                || key.location == KeyLocation::Numpad);
 
         match key.logical_key {
             _ if disambiguate => true,


### PR DESCRIPTION
When the key doesn't have textual representation we shouldn't emit the text for them, since they are processed via bindings.

Fixes #7423.