### PR TITLE
Derive `Clone` for `EventLoopSender`

### DIFF
--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -349,6 +349,7 @@ impl event::OnResize for Notifier {
     }
 }
 
+#[derive(Clone)]
 pub struct EventLoopSender {
     sender: Sender<Msg>,
     poller: Arc<polling::Poller>,


### PR DESCRIPTION
`.spawn()` consumes `EventLoop` making it impossible to acquire more senders by calling `.channel()` after the fact. It is possible to produce all the senders you would need in advance by calling `.channel()` multiple times before calling `.spawn()` but this is very unidiomatic and would both pollute the namespace and hinder readability. I am proposing this change under the assumption that it is generally always expected that Sender (new)types implement `Clone`.