### PR TITLE
Use pre-composed key for `Alt` bindings on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `alacritty migrate` failing with nonexistent imports
+- `Alt` bindings requiring composed key rather than pre-composed one on macOS
 
 ## 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `alacritty migrate` failing with nonexistent imports
 - `Alt` bindings requiring composed key rather than pre-composed one on macOS
+- `Alt + Control` bindings not working on Windows
 
 ## 0.13.0
 

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -174,7 +174,14 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             let logical_key = if let Key::Character(ch) = key.logical_key.as_ref() {
                 // Match `Alt` bindings without `Alt` being applied, otherwise they use the
                 // composed chars, which are not intuitive to bind.
-                if cfg!(target_os = "macos") && mods.alt_key() {
+                //
+                // On Windows, the `Ctrl + Alt` mangles `logical_key` to unidentified values, thus
+                // preventing them from being used in bindings
+                //
+                // For more see https://github.com/rust-windowing/winit/issues/2945.
+                if (cfg!(target_os = "macos") || (cfg!(windows) && mods.control_key()))
+                    && mods.alt_key()
+                {
                     key.key_without_modifiers()
                 } else {
                     Key::Character(ch.to_lowercase().into())

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -172,7 +172,13 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             // the time. However what we want is to manually lowercase the character to account
             // for both small and capital letters on regular characters at the same time.
             let logical_key = if let Key::Character(ch) = key.logical_key.as_ref() {
-                Key::Character(ch.to_lowercase().into())
+                // Match `Alt` bindings without `Alt` being applied, otherwise they use the
+                // composed chars, which are not intuitive to bind.
+                if cfg!(target_os = "macos") && mods.alt_key() {
+                    key.key_without_modifiers()
+                } else {
+                    Key::Character(ch.to_lowercase().into())
+                }
             } else {
                 key.logical_key.clone()
             };


### PR DESCRIPTION
Fixes #7475.