### PR TITLE
Passthrough potential errors for `EventLoopSender`

### DIFF
--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -560,6 +560,6 @@ impl WindowContext {
 impl Drop for WindowContext {
     fn drop(&mut self) {
         // Shutdown the terminal's PTY.
-        self.notifier.0.send(Msg::Shutdown);
+        let _ = self.notifier.0.send(Msg::Shutdown);
     }
 }

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::fmt::{self, Formatter, Display};
+use std::fmt::{self, Display, Formatter};
 use std::fs::File;
 use std::io::{self, ErrorKind, Read, Write};
 use std::marker::Send;

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -352,15 +352,18 @@ impl event::OnResize for Notifier {
 
 #[derive(Debug)]
 pub enum EventLoopSendError {
+    /// Error polling the event loop.
     Io(io::Error),
+
+    /// Error sending a message to the event loop.
     Send(mpsc::SendError<Msg>),
 }
 
 impl Display for EventLoopSendError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            EventLoopSendError::Io(x) => x.fmt(f),
-            EventLoopSendError::Send(x) => x.fmt(f),
+            EventLoopSendError::Io(err) => err.fmt(f),
+            EventLoopSendError::Send(err) => err.fmt(f),
         }
     }
 }
@@ -368,8 +371,8 @@ impl Display for EventLoopSendError {
 impl std::error::Error for EventLoopSendError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            EventLoopSendError::Io(x) => Some(x),
-            EventLoopSendError::Send(x) => Some(x),
+            EventLoopSendError::Io(err) => err.source(),
+            EventLoopSendError::Send(err) => err.source(),
         }
     }
 }


### PR DESCRIPTION
For this change I'm not sure if the error enum should be made `#[non_exhaustive]` or not, I'm simply not familiar enough with the codebase or your plans for the future to make that determination myself. I think it's fine that you chose to ignore these errors internally but it felt like bad practice to not pass through potential errors on a `pub` method.