### PR TITLE
cfg-guard tests which rely on the serde feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Stable
         run: cargo test
+      - name: Stable (no default features)
+        run: cargo test -p alacritty_terminal --no-default-features
       - name: Oldstable
         run: |
           rustup default 1.70.0

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2710,6 +2710,7 @@ mod tests {
     /// This test is in the term module as opposed to the grid since we want to
     /// test this property with a T=Cell.
     #[test]
+    #[cfg(feature = "serde")]
     fn grid_serde() {
         let grid: Grid<Cell> = Grid::new(24, 80, 0);
         let serialized = serde_json::to_string(&grid).expect("ser");

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use serde::Deserialize;
 use serde_json as json;
 


### PR DESCRIPTION
Encountered this test failure when updating Debian's alacritty packaging.

<details><summary>test failure when using "--no-default-features"</summary>

```
   Compiling alacritty_terminal v0.20.0 (/Users/runner/work/alacritty/alacritty/alacritty_terminal)
error[E0277]: the trait bound `grid::Grid<term::cell::Cell>: serde::ser::Serialize` is not satisfied
    --> alacritty_terminal/src/term/mod.rs:2715:48
     |
2715 |         let serialized = serde_json::to_string(&grid).expect("ser");
     |                          --------------------- ^^^^^ the trait `serde::ser::Serialize` is not implemented for `grid::Grid<term::cell::Cell>`
     |                          |
     |                          required by a bound introduced by this call
     |
     = help: the following other types implement trait `serde::ser::Serialize`:
               bool
               char
               isize
               i8
               i16
               i32
               i64
               i128
             and 133 others
note: required by a bound in `serde_json::to_string`
    --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/src/ser.rs:2209:17
     |
2207 | pub fn to_string<T>(value: &T) -> Result<String>
     |        --------- required by a bound in this function
2208 | where
2209 |     T: ?Sized + Serialize,
     |                 ^^^^^^^^^ required by this bound in `to_string`

error[E0277]: the trait bound `grid::Grid<term::cell::Cell>: serde::de::Deserialize<'_>` is not satisfied
    --> alacritty_terminal/src/term/mod.rs:2716:28
     |
2716 |         let deserialized = serde_json::from_str::<Grid<Cell>>(&serialized).expect("de");
     |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde::de::Deserialize<'_>` is not implemented for `grid::Grid<term::cell::Cell>`
     |
     = help: the following other types implement trait `serde::de::Deserialize<'de>`:
               bool
               char
               isize
               i8
               i16
               i32
               i64
               i128
             and 133 others
note: required by a bound in `serde_json::from_str`
    --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/src/de.rs:2675:8
     |
2673 | pub fn from_str<'a, T>(s: &'a str) -> Result<T>
     |        -------- required by a bound in this function
2674 | where
2675 |     T: de::Deserialize<'a>,
     |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `from_str`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `alacritty_terminal` (lib test) due to 2 previous errors
```
<details>

Add CI for --no-default-features to catch this in the future.
