### PR TITLE
Mouse bindings with numbers don't work in 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Blurry window when using `window.dimensions` on some Wayland compositors
 - IME input lagging behind on X11
 - xdotool modifiers input not working correctly on X11
+- Parsing numbers fails for mouse bindings
 
 ## 0.13.0
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -860,6 +860,16 @@ impl<'a> Deserialize<'a> for MouseButtonWrapper {
                 f.write_str("Left, Right, Middle, Back, Forward, or a number from 0 to 65536")
             }
 
+            fn visit_i64<E>(self, value: i64) -> Result<MouseButtonWrapper, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    0..=65536 => Ok(MouseButtonWrapper(MouseButton::Other(value as u16))),
+                    _ => Err(E::invalid_value(Unexpected::Signed(value), &self)),
+                }
+            }
+
             fn visit_u64<E>(self, value: u64) -> Result<MouseButtonWrapper, E>
             where
                 E: de::Error,


### PR DESCRIPTION
not having a visitor for this would mean numbers for mouse buttons wouldn't work

/fixes #7527