### PR TITLE
Update README.md for config file location in windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ following locations:
 
 On Windows, the config file should be located at:
 
-`%APPDATA%\alacritty\alacritty.toml`
+1. `%APPDATA%\Roaming\alacritty\alacritty.toml`
+2. `%APPDATA%\alacritty\alacritty.toml`
 
 ## Contributing
 


### PR DESCRIPTION
Added config file location for Windows installation when it shows .yml deprecated error after the first start of Alacritty.