### PR TITLE
Replace Github runner with FlyCI MacOS runer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, flyci-macos-large-latest-m2]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR replaces `macos-latest` runner with `flyci-macos-large-latest-m2`.