### PR TITLE
Fix `debug.renderer="gles2pure"` documentation

### DIFF
--- a/alacritty/src/config/debug.rs
+++ b/alacritty/src/config/debug.rs
@@ -48,14 +48,11 @@ impl Default for Debug {
 #[derive(ConfigDeserialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RendererPreference {
     /// OpenGL 3.3 renderer.
-    #[config(rename = "glsl3")]
     Glsl3,
 
     /// GLES 2 renderer, with optional extensions like dual source blending.
-    #[config(rename = "gles2")]
     Gles2,
 
     /// Pure GLES 2 renderer.
-    #[config(rename = "gles2_pure")]
     Gles2Pure,
 }

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -996,7 +996,7 @@ relied upon.
 	Example:
 		_ALACRITTY_EXTRA_LOG_TARGETS="winit;vte" alacritty -vvv_
 
-*renderer* = _"glsl3"_ | _"gles2"_ | _"gles2_pure"_ | _"None"_
+*renderer* = _"glsl3"_ | _"gles2"_ | _"gles2pure"_ | _"None"_
 
 	Force use of a specific renderer, _"None"_ will use the highest available
 	one.


### PR DESCRIPTION
Patch 5685ce8bf changed the allowed values of the `debug.renderer` enum, prohibiting the usage of `_` in the `Gles2Pure` variant. This patch updates the documentation to correct for that.