### PR TITLE
Fix inline search expanding across newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.14.0-dev
 
+### Fixed
+
+- Vi inline search/semantic selection expanding across newlines
+
 ## 0.13.1
 
 ### Added


### PR DESCRIPTION
Closes #7587.

---

Very possible this just causes another bug, but I've covered this issue with a new test case at least and haven't found more issues.

The original issue only mentions semantic selection, but vi's inline search is also affected.