### PR TITLE
ALT + arrows default key binding

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -452,6 +452,8 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         End,       ModifiersState::SHIFT, ~BindingMode::ALT_SCREEN; Action::ScrollToBottom;
         PageUp,    ModifiersState::SHIFT, ~BindingMode::ALT_SCREEN; Action::ScrollPageUp;
         PageDown,  ModifiersState::SHIFT, ~BindingMode::ALT_SCREEN; Action::ScrollPageDown;
+        ArrowRight, ModifiersState::ALT; Action::Esc("\x1bF".into());
+        ArrowLeft,  ModifiersState::ALT; Action::Esc("\x1bB".into());
         // App cursor mode.
         Home,       +BindingMode::APP_CURSOR, ~BindingMode::VI, ~BindingMode::SEARCH; Action::Esc("\x1bOH".into());
         End,        +BindingMode::APP_CURSOR, ~BindingMode::VI, ~BindingMode::SEARCH; Action::Esc("\x1bOF".into());


### PR DESCRIPTION
ALT/Option + arrows is the default behavior of MacOS Terminal, kitty, and VSCode terminal: jump by word-by-word instead of moving char-by-char, which is extremely handy when editing a (long) command.

With YAML config it was possible as [described here](https://stackoverflow.com/questions/58516583/move-cursor-word-by-word-in-alacritty) :

```
key_bindings:
  ...
  - { key: Right, mods: Alt, chars: "\x1BF" }
  - { key: Left,  mods: Alt, chars: "\x1BB" }
```

However, with the TOML configuration of Alactritty it is not possible to get this behavior, thus I propose to add it as default key bindings.

PS: this is my first PR to alacritty and the first in Rust, so I'm open to any suggestions to fix/update/make it better.