### PR TITLE
Fix env variable overrides through CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.14.0-dev
 
+### Fixed
+
+- CLI env variables clearing configuration file variables
+
 ## 0.13.1
 
 ### Added

--- a/alacritty_config/src/lib.rs
+++ b/alacritty_config/src/lib.rs
@@ -61,7 +61,15 @@ impl<'de, T: SerdeReplace + Deserialize<'de>> SerdeReplace for Option<T> {
 
 impl<'de, T: Deserialize<'de>> SerdeReplace for HashMap<String, T> {
     fn replace(&mut self, value: Value) -> Result<(), Box<dyn Error>> {
-        replace_simple(self, value)
+        // Deserialize replacement as HashMap.
+        let hashmap: HashMap<String, T> = Self::deserialize(value)?;
+
+        // Merge the two HashMaps, replacing existing values.
+        for (key, value) in hashmap {
+            self.insert(key, value);
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This fixes an issue where all CLI environment variables would replace existing configuration file variables instead of merging the two maps together.

Closes #7618.