### PR TITLE
Fix text accessory view overlaps with text when changing IME on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Text accessory overlaps with text when changing input methods on macOS
 - `alacritty migrate` failing with nonexistent imports
 - `Alt` bindings requiring composed key rather than pre-composed one on macOS
 - `Alt + Control` bindings not working on Windows

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -113,6 +113,7 @@ pub struct Window {
     title: String,
 
     is_x11: bool,
+    is_appkit: bool,
     current_mouse_cursor: CursorIcon,
     mouse_visible: bool,
 }
@@ -190,6 +191,7 @@ impl Window {
         let scale_factor = window.scale_factor();
         log::info!("Window scale factor: {}", scale_factor);
         let is_x11 = matches!(window.raw_window_handle(), RawWindowHandle::Xlib(_));
+        let is_appkit = matches!(window.raw_window_handle(), RawWindowHandle::AppKit(_));
 
         Ok(Self {
             requested_redraw: false,
@@ -200,6 +202,7 @@ impl Window {
             scale_factor,
             window,
             is_x11,
+            is_appkit,
         })
     }
 
@@ -418,9 +421,9 @@ impl Window {
 
     /// Adjust the IME editor position according to the new location of the cursor.
     pub fn update_ime_position(&self, point: Point<usize>, size: &SizeInfo) {
-        // NOTE: X11 doesn't support cursor area, so we need to offset manually to not obscure
+        // NOTE: X11 and macOS doesn't support cursor area, so we need to offset manually to not obscure
         // the text.
-        let offset = if self.is_x11 { 1 } else { 0 };
+        let offset = if self.is_x11 || self.is_appkit { 1 } else { 0 };
         let nspot_x = f64::from(size.padding_x() + point.column.0 as f32 * size.cell_width());
         let nspot_y =
             f64::from(size.padding_y() + (point.line + offset) as f32 * size.cell_height());


### PR DESCRIPTION
When changing IME on macOS (or typing in a language that uses a word selection window), the text accessory view will overlap with the text. Add an offset of `cell_height` to prevent this from happening. Found the code to deal with this problem for X11, so I just added another check to offset for macOS.

Before:
![image](https://github.com/alacritty/alacritty/assets/20237141/3493c636-a055-4551-b43a-fda40d7a58ba)

After:
![image](https://github.com/alacritty/alacritty/assets/20237141/6dd62cd3-cd25-462a-96f3-c4475a94a624)
