### PR TITLE
Update IME position more frequently

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -900,8 +900,8 @@ impl Display {
         };
 
         // Handle IME.
-        if self.ime.is_enabled() {
-            if let Some(point) = ime_position {
+        if let Some(point) = ime_position {
+            if self.ime.is_enabled() {
                 let (fg, bg) = if search_state.regex().is_some() {
                     (config.colors.footer_bar_foreground(), config.colors.footer_bar_background())
                 } else {
@@ -909,6 +909,8 @@ impl Display {
                 };
 
                 self.draw_ime_preview(point, fg, bg, &mut rects, config);
+            } else {
+                self.window.update_ime_position(point, &self.size_info);
             }
         }
 


### PR DESCRIPTION
Currently the IME position is only updated when the IME is enabled. So the initial position of the IME will be wrong if the IME is not enabled. Changed to update position even if the IME is off.

Steps to reproduce the bug:
- Change typing language to English (turn off IME)
- Open Alacritty
- Start typing using IME, the initial position will be wrong

Or:
- Open Alacritty
- Type in English for a few characters
- Switch to another language which uses IME, the position will be wrong

The bug might only reproducible for some languages' IME depending on whether the IME immediately pup up the candidate window or not.