### PR TITLE
Don't report associated text only for C0/C1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - CLI env variables clearing configuration file variables
 - Vi inline search/semantic selection expanding across newlines
+- C0 and C1 codes being emitted in associated text when using kitty keyboard
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - No unused-key warnings will be emitted for OS-specific config keys
+- Use built-in font for sextant symbols from `U+1FB00` to `U+1FB3B`
 
 ## 0.13.1
 
@@ -26,7 +27,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - `alacritty migrate` will ignore null values in yaml instead of erroring out
-- Use built-in font for sextant symbols from `U+1FB00` to `U+1FB3B`
 
 ### Fixed
 


### PR DESCRIPTION
This has a side effect that we'll have text reported for Alt+Shift+T and similar, but only C0/C1 should be excluded and Alt+Shift+T is emitting neither, thus regular `T` will be reported.

Fixes #7657.

--

@rockorager