### PR TITLE
Clamp end point before getting selection range

### DIFF
--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -285,6 +285,7 @@ impl Selection {
             return None;
         }
         start.point = start.point.grid_clamp(term, Boundary::Grid);
+        end.point = end.point.grid_clamp(term, Boundary::Grid);
 
         match self.ty {
             SelectionType::Simple => self.range_simple(start, end, columns),


### PR DESCRIPTION
 An out of range end column, for example, can cause out of range access later.