### PR TITLE
Bump alacritty_terminal to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.20.1-dev"
+version = "0.22.1-dev"
 dependencies = [
  "base64",
  "bitflags 2.4.1",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.70.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.20.1-dev"
+version = "0.22.1-dev"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.20.1-dev"
+version = "0.22.1-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"


### PR DESCRIPTION
This is only an update to the development version and does not represent a stable release.