### PR TITLE
Added env parsing to import paths

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -301,6 +301,13 @@ pub fn imports(
 
     for import in imports {
         let mut path = match import {
+            Value::String(path) if path.contains("${") => {
+                let mut parsed_path = path.clone();
+                for (key, value) in std::env::vars() {
+                    parsed_path = parsed_path.replace(&format!("${{{}}}", key), &value);
+                }
+                PathBuf::from(parsed_path)
+            },
             Value::String(path) => PathBuf::from(path),
             _ => {
                 import_paths.push(Err("Invalid import element type: expected path string".into()));


### PR DESCRIPTION
This adds support for env values being parsed in the import paths via config.

```sh
export MY_THEME=tokyo-night
```

```toml
import = [
    "~/.config/alacritty/${MY_THEME}.toml",
    "~/.config/alacritty/common.toml",
]
```