### PR TITLE
Occupied entries are correctly updated when using IndexMut<RangeToInc…

### DIFF
--- a/alacritty_terminal/src/grid/row.rs
+++ b/alacritty_terminal/src/grid/row.rs
@@ -291,7 +291,7 @@ impl<T> Index<RangeToInclusive<Column>> for Row<T> {
 impl<T> IndexMut<RangeToInclusive<Column>> for Row<T> {
     #[inline]
     fn index_mut(&mut self, index: RangeToInclusive<Column>) -> &mut [T] {
-        self.occ = max(self.occ, *index.end);
+        self.occ = max(self.occ, *index.end + 1);
         &mut self.inner[..=(index.end.0)]
     }
 }


### PR DESCRIPTION
[Here](https://github.com/alacritty/alacritty/blob/master/alacritty_terminal/src/grid/row.rs#L209), the number of occupied columns is updated correctly, but, on `IndexMut<RangeToInclusive<Column>>` trait impl, the occupied uses `*index.end` instead of `*index.end + 1`