### PR TITLE
Use dynamic MSRV for oldstable CI

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -24,8 +24,9 @@ tasks:
       cargo test
   - oldstable: |
       cd alacritty
-      rustup toolchain install --profile minimal 1.70.0
-      rustup default 1.70.0
+      oldstable=$(cat alacritty/Cargo.toml | grep "rust-version" | sed 's/.*"\(.*\)".*/\1/')
+      rustup toolchain install --profile minimal $oldstable
+      rustup default $oldstable
       cargo test
   - clippy: |
       cd alacritty

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -34,8 +34,9 @@ tasks:
       cargo test
   - oldstable: |
       cd alacritty
-      rustup toolchain install --profile minimal 1.70.0
-      rustup default 1.70.0
+      oldstable=$(cat alacritty/Cargo.toml | grep "rust-version" | sed 's/.*"\(.*\)".*/\1/')
+      rustup toolchain install --profile minimal $oldstable
+      rustup default $oldstable
       cargo test
   - clippy: |
       cd alacritty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: cargo test -p alacritty_terminal --no-default-features
       - name: Oldstable
         run: |
-          rustup default 1.70.0
+          rustup default $(cat alacritty/Cargo.toml | grep "rust-version" | sed 's/.*"\(.*\)".*/\1/')
           cargo test
       - name: Clippy
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.14.0-dev
 
+### Packaging
+
+- Minimum Rust version has been bumped to 1.72.0
+
 ### Added
 
 - Default `Home`/`End` bindings in Vi mode mapped to `First`/`Last` respectively

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,9 @@ and
 [easy](https://github.com/alacritty/alacritty/issues?q=is%3Aopen+is%3Aissue+label%3A%22D+-+easy%22)
 issues.
 
-Please note that the minimum supported version of Alacritty is Rust 1.70.0. All patches are expected
-to work with the minimum supported version.
+You can find the minimum supported Rust version in Alacritty's manifest file
+(`cat alacritty/Cargo.toml | grep "rust-version"`). Alacritty **must** always
+build with the MSRV and bumping it should be avoided if possible.
 
 Since `alacritty_terminal`'s version always tracks the next release, make sure that the version is
 bumped according to semver when necessary.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -7,7 +7,7 @@ description = "A fast, cross-platform, OpenGL terminal emulator"
 readme = "README.md"
 homepage = "https://github.com/alacritty/alacritty"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.72.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -917,6 +917,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.config
     }
 
+    #[cfg(target_os = "macos")]
     fn event_loop(&self) -> &EventLoopWindowTarget<Event> {
         self.event_loop
     }

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -19,6 +19,7 @@ use winit::dpi::PhysicalPosition;
 use winit::event::{
     ElementState, Modifiers, MouseButton, MouseScrollDelta, Touch as TouchEvent, TouchPhase,
 };
+#[cfg(target_os = "macos")]
 use winit::event_loop::EventLoopWindowTarget;
 use winit::keyboard::ModifiersState;
 #[cfg(target_os = "macos")]
@@ -103,6 +104,7 @@ pub trait ActionContext<T: EventListener> {
     fn pop_message(&mut self) {}
     fn message(&self) -> Option<&Message>;
     fn config(&self) -> &UiConfig;
+    #[cfg(target_os = "macos")]
     fn event_loop(&self) -> &EventLoopWindowTarget<Event>;
     fn mouse_mode(&self) -> bool;
     fn clipboard_mut(&mut self) -> &mut Clipboard;
@@ -1216,6 +1218,7 @@ mod tests {
             self.clipboard
         }
 
+        #[cfg(target_os = "macos")]
         fn event_loop(&self) -> &EventLoopWindowTarget<Event> {
             unimplemented!();
         }


### PR DESCRIPTION
Instead of manually specifying the oldstable version in all our CI
scripts, it is now pulled from the `Cargo.toml` which simplifies the
update process.

The contributing guide has also been updated to not include the explicit
version and its wording has been loosened a bit to correctly represent
current maintenance practices.