### PR TITLE
Add motion repeat for vi-mode

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -495,7 +495,6 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         ArrowDown,                          +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Down;
         ArrowLeft,                          +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Left;
         ArrowRight,                         +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Right;
-        "0",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::First;
         "$",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Last;
         Home,                               +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::First;
         End,                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Last;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -206,13 +206,19 @@ impl Default for InlineSearchState {
     }
 }
 
+#[derive(Default)]
 pub struct MotionState {
+    /// Digit history.
+    ///
+    /// When a `ViMotion` is processed or a non-digit character is added,
+    /// `MotionState` discards its history of entered digits.
     history: String,
 }
 
+/// Vi motion state for repeating actions.
 impl MotionState {
     pub fn add_character(&mut self, ch: char) {
-        if ch.is_digit(10) {
+        if ch.is_ascii_digit() {
             self.history.push(ch);
         }
         else {
@@ -227,14 +233,6 @@ impl MotionState {
                 std::num::IntErrorKind::PosOverflow => u32::MAX,
                 _ => 1,
             }
-        }
-    }
-}
-
-impl Default for MotionState {
-    fn default() -> Self {
-        Self {
-            history: Default::default(),
         }
     }
 }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -226,11 +226,11 @@ impl MotionState {
         }
     }
     
-    pub fn eval_count(&self) -> u32 {
+    pub fn eval_count(&self) -> usize {
         match self.history.parse() {
             Ok(n) => n,
             Err(e) => match e.kind() {
-                std::num::IntErrorKind::PosOverflow => u32::MAX,
+                std::num::IntErrorKind::PosOverflow => usize::MAX,
                 _ => 1,
             }
         }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -220,19 +220,18 @@ impl MotionState {
     pub fn add_character(&mut self, ch: char) {
         if ch.is_ascii_digit() {
             self.history.push(ch);
-        }
-        else {
+        } else {
             self.history = Default::default();
         }
     }
-    
+
     pub fn eval_count(&self) -> usize {
         match self.history.parse() {
             Ok(n) => n,
             Err(e) => match e.kind() {
                 std::num::IntErrorKind::PosOverflow => usize::MAX,
                 _ => 1,
-            }
+            },
         }
     }
 }

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -75,6 +75,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         // Vi mode on its own doesn't have any input, the search input was done before.
         if mode.contains(TermMode::VI) {
+            for character in text.chars() {
+                self.ctx.motion_state().add_character(character);
+            }
             return;
         }
 

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -41,7 +41,7 @@ use crate::display::hint::HintMatch;
 use crate::display::window::Window;
 use crate::display::{Display, SizeInfo};
 use crate::event::{
-    ClickState, Event, EventType, InlineSearchState, MotionState, Mouse, TouchPurpose, TouchZoom
+    ClickState, Event, EventType, InlineSearchState, MotionState, Mouse, TouchPurpose, TouchZoom,
 };
 use crate::message_bar::{self, Message};
 use crate::scheduler::{Scheduler, TimerId, Topic};
@@ -1144,7 +1144,7 @@ mod tests {
         fn search_direction(&self) -> Direction {
             Direction::Right
         }
-        
+
         fn motion_state(&mut self) -> &mut MotionState {
             unimplemented!();
         }

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -179,7 +179,7 @@ impl<T: EventListener> Execute<T> for Action {
             },
             Action::ViMotion(motion) => {
                 ctx.on_typing_start();
-                ctx.terminal_mut().vi_motion(*motion);
+                ctx.terminal_mut().vi_motion(*motion, 1);
                 ctx.mark_dirty();
             },
             Action::Vi(ViAction::ToggleNormalSelection) => {
@@ -361,7 +361,7 @@ impl<T: EventListener> Execute<T> for Action {
                 // Move vi mode cursor.
                 let topmost_line = ctx.terminal().topmost_line();
                 ctx.terminal_mut().vi_mode_cursor.point.line = topmost_line;
-                ctx.terminal_mut().vi_motion(ViMotion::FirstOccupied);
+                ctx.terminal_mut().vi_motion(ViMotion::FirstOccupied, 1);
                 ctx.mark_dirty();
             },
             Action::ScrollToBottom => {
@@ -372,8 +372,7 @@ impl<T: EventListener> Execute<T> for Action {
                 term.vi_mode_cursor.point.line = term.bottommost_line();
 
                 // Move to beginning twice, to always jump across linewraps.
-                term.vi_motion(ViMotion::FirstOccupied);
-                term.vi_motion(ViMotion::FirstOccupied);
+                term.vi_motion(ViMotion::FirstOccupied, 2);
                 ctx.mark_dirty();
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -180,7 +180,7 @@ impl<T: EventListener> Execute<T> for Action {
             },
             Action::ViMotion(motion) => {
                 ctx.on_typing_start();
-                let count: u32 = ctx.motion_state().eval_count();
+                let count: usize = ctx.motion_state().eval_count();
                 *ctx.motion_state() = Default::default();
                 ctx.terminal_mut().vi_motion(*motion, count);
                 ctx.mark_dirty();

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -35,7 +35,8 @@ use crate::config::UiConfig;
 use crate::display::window::Window;
 use crate::display::Display;
 use crate::event::{
-    ActionContext, Event, EventProxy, InlineSearchState, MotionState, Mouse, SearchState, TouchPurpose
+    ActionContext, Event, EventProxy, InlineSearchState, MotionState, Mouse, SearchState,
+    TouchPurpose,
 };
 #[cfg(unix)]
 use crate::logging::LOG_TARGET_IPC_CONFIG;

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -35,7 +35,7 @@ use crate::config::UiConfig;
 use crate::display::window::Window;
 use crate::display::Display;
 use crate::event::{
-    ActionContext, Event, EventProxy, InlineSearchState, Mouse, SearchState, TouchPurpose,
+    ActionContext, Event, EventProxy, InlineSearchState, MotionState, Mouse, SearchState, TouchPurpose
 };
 #[cfg(unix)]
 use crate::logging::LOG_TARGET_IPC_CONFIG;
@@ -54,6 +54,7 @@ pub struct WindowContext {
     modifiers: Modifiers,
     inline_search_state: InlineSearchState,
     search_state: SearchState,
+    motion_state: MotionState,
     notifier: Notifier,
     mouse: Mouse,
     touch: TouchPurpose,
@@ -253,6 +254,7 @@ impl WindowContext {
             message_buffer: Default::default(),
             window_config: Default::default(),
             search_state: Default::default(),
+            motion_state: Default::default(),
             event_queue: Default::default(),
             modifiers: Default::default(),
             occluded: Default::default(),
@@ -430,6 +432,7 @@ impl WindowContext {
             message_buffer: &mut self.message_buffer,
             inline_search_state: &mut self.inline_search_state,
             search_state: &mut self.search_state,
+            motion_state: &mut self.motion_state,
             modifiers: &mut self.modifiers,
             notifier: &mut self.notifier,
             display: &mut self.display,

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -836,7 +836,7 @@ impl<T> Term<T> {
 
     /// Move vi mode cursor.
     #[inline]
-    pub fn vi_motion(&mut self, motion: ViMotion)
+    pub fn vi_motion(&mut self, motion: ViMotion, count: u32)
     where
         T: EventListener,
     {
@@ -846,7 +846,7 @@ impl<T> Term<T> {
         }
 
         // Move cursor.
-        self.vi_mode_cursor = self.vi_mode_cursor.motion(self, motion);
+        self.vi_mode_cursor = self.vi_mode_cursor.motion(self, motion, count);
         self.vi_mode_recompute_selection();
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -836,7 +836,7 @@ impl<T> Term<T> {
 
     /// Move vi mode cursor.
     #[inline]
-    pub fn vi_motion(&mut self, motion: ViMotion, count: u32)
+    pub fn vi_motion(&mut self, motion: ViMotion, count: usize)
     where
         T: EventListener,
     {

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -65,17 +65,20 @@ impl ViModeCursor {
         Self { point }
     }
 
+    /// Move vi mode cursor `count` times and apply it to `term`.
     #[must_use = "this returns the result of the operation, without modifying the original"]
     pub fn motion<T: EventListener>(mut self, term: &mut Term<T>, motion: ViMotion, count: u32) -> Self {
         for _ in 0..count {
+            let old_self: Self = self;
             self.motion_impl(term, motion);
+            if self == old_self { break; }
         }
         term.scroll_to_point(self.point);
         self
     }
 
     /// Move vi mode cursor.
-    fn motion_impl<T: EventListener>(&mut self, term: &mut Term<T>, motion: ViMotion) {
+    fn motion_impl<T: EventListener>(&mut self, term: &Term<T>, motion: ViMotion) {
         match motion {
             ViMotion::Up => {
                 if self.point.line > term.topmost_line() {

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -67,7 +67,7 @@ impl ViModeCursor {
 
     /// Move vi mode cursor `count` times and apply it to `term`.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn motion<T: EventListener>(mut self, term: &mut Term<T>, motion: ViMotion, count: u32) -> Self {
+    pub fn motion<T: EventListener>(mut self, term: &mut Term<T>, motion: ViMotion, count: usize) -> Self {
         for _ in 0..count {
             let new_point: Point = Self::motion_impl(self.point, term, motion);
             if self.point == new_point { break; }

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -83,7 +83,7 @@ impl ViModeCursor {
                 }
             },
             ViMotion::Down => {
-                if self.point.line + 1 < term.screen_lines() as i32 {
+                if self.point.line + 1 < term.screen_lines() {
                     self.point.line += 1;
                 }
             },
@@ -120,19 +120,25 @@ impl ViModeCursor {
             ViMotion::Last => self.point = last(term, self.point),
             ViMotion::FirstOccupied => self.point = first_occupied(term, self.point),
             ViMotion::High => {
-                let line = Line(-(term.grid().display_offset() as i32));
+                let display_offset = term.grid().display_offset() as i32;
+                
+                let line = Line(-display_offset);
                 let col = first_occupied_in_line(term, line).unwrap_or_default().column;
                 self.point = Point::new(line, col);
             },
             ViMotion::Middle => {
                 let display_offset = term.grid().display_offset() as i32;
-                let line = Line(-display_offset + term.screen_lines() as i32 / 2 - 1);
+                let screen_lines = term.screen_lines() as i32;
+                
+                let line = Line(-display_offset + (screen_lines / 2) - 1);
                 let col = first_occupied_in_line(term, line).unwrap_or_default().column;
                 self.point = Point::new(line, col);
             },
             ViMotion::Low => {
                 let display_offset = term.grid().display_offset() as i32;
-                let line = Line(-display_offset + term.screen_lines() as i32 - 1);
+                let screen_lines = term.screen_lines() as i32;
+                
+                let line = Line(-display_offset + screen_lines - 1);
                 let col = first_occupied_in_line(term, line).unwrap_or_default().column;
                 self.point = Point::new(line, col);
             },

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -67,10 +67,17 @@ impl ViModeCursor {
 
     /// Move vi mode cursor `count` times and apply it to `term`.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn motion<T: EventListener>(mut self, term: &mut Term<T>, motion: ViMotion, count: usize) -> Self {
+    pub fn motion<T: EventListener>(
+        mut self,
+        term: &mut Term<T>,
+        motion: ViMotion,
+        count: usize,
+    ) -> Self {
         for _ in 0..count {
             let new_point: Point = Self::motion_impl(self.point, term, motion);
-            if self.point == new_point { break; }
+            if self.point == new_point {
+                break;
+            }
             self.point = new_point;
         }
         term.scroll_to_point(self.point);
@@ -125,7 +132,7 @@ impl ViModeCursor {
             ViMotion::FirstOccupied => point = first_occupied(term, point),
             ViMotion::High => {
                 let display_offset = term.grid().display_offset() as i32;
-                
+
                 let line = Line(-display_offset);
                 let col = first_occupied_in_line(term, line).unwrap_or_default().column;
                 point = Point::new(line, col);
@@ -133,7 +140,7 @@ impl ViModeCursor {
             ViMotion::Middle => {
                 let display_offset = term.grid().display_offset() as i32;
                 let screen_lines = term.screen_lines() as i32;
-                
+
                 let line = Line(-display_offset + (screen_lines / 2) - 1);
                 let col = first_occupied_in_line(term, line).unwrap_or_default().column;
                 point = Point::new(line, col);
@@ -141,7 +148,7 @@ impl ViModeCursor {
             ViMotion::Low => {
                 let display_offset = term.grid().display_offset() as i32;
                 let screen_lines = term.screen_lines() as i32;
-                
+
                 let line = Line(-display_offset + screen_lines - 1);
                 let col = first_occupied_in_line(term, line).unwrap_or_default().column;
                 point = Point::new(line, col);


### PR DESCRIPTION
This pull request allows us to type `100j` to move 100 rows down, or `42l` to move 42 columns to the right. The `count` is applied for every `ViMotion` that changes the cursor's position.