### PR TITLE
cargo update smithay-client-toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Modifiers occasionally getting desynced on X11
 - Autokey no longer working with alacritty on X11
 - Freeze when moving window between monitors on Xfwm
+- Mouse cursor not changing on Wayland when cursor theme uses legacy cursor icon names
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,9 +1642,9 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
+checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
  "bitflags 2.4.1",
  "calloop",


### PR DESCRIPTION
alacritty will now benefit from https://github.com/Smithay/client-toolkit/pull/427.

Should we run a general `cargo update` instead?