### PR TITLE
Allow setting terminal env vars via pty options

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -196,7 +196,6 @@ impl From<TerminalOptions> for PtyOptions {
             working_directory: options.working_directory.take(),
             shell: options.command().map(Into::into),
             hold: options.hold,
-            #[cfg(not(windows))]
             env: HashMap::new(),
         }
     }

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -1,4 +1,5 @@
 use std::cmp::max;
+use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -195,6 +196,8 @@ impl From<TerminalOptions> for PtyOptions {
             working_directory: options.working_directory.take(),
             shell: options.command().map(Into::into),
             hold: options.hold,
+            #[cfg(not(windows))]
+            env: HashMap::new(),
         }
     }
 }

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -167,7 +167,13 @@ impl UiConfig {
     /// Derive [`PtyOptions`] from the config.
     pub fn pty_config(&self) -> PtyOptions {
         let shell = self.shell.clone().map(Into::into);
-        PtyOptions { shell, working_directory: self.working_directory.clone(), hold: false }
+        PtyOptions {
+            shell,
+            working_directory: self.working_directory.clone(),
+            hold: false,
+            #[cfg(not(windows))]
+            env: self.env.clone(),
+        }
     }
 
     /// Generate key bindings for all keyboard hints.

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -172,7 +172,7 @@ impl UiConfig {
             working_directory: self.working_directory.clone(),
             hold: false,
             #[cfg(not(windows))]
-            env: self.env.clone(),
+            env: HashMap::new(),
         }
     }
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -171,7 +171,6 @@ impl UiConfig {
             shell,
             working_directory: self.working_directory.clone(),
             hold: false,
-            #[cfg(not(windows))]
             env: HashMap::new(),
         }
     }

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -1,5 +1,6 @@
 //! TTY related functionality.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{env, io};
@@ -29,6 +30,10 @@ pub struct Options {
 
     /// Remain open after child process exits.
     pub hold: bool,
+
+    /// Extra environment variables.
+    #[cfg(not(windows))]
+    pub env: HashMap<String, String>,
 }
 
 /// Shell options.

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -32,7 +32,6 @@ pub struct Options {
     pub hold: bool,
 
     /// Extra environment variables.
-    #[cfg(not(windows))]
     pub env: HashMap<String, String>,
 }
 

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -228,9 +228,11 @@ pub fn new(config: &Options, window_size: WindowSize, window_id: u64) -> Result<
     builder.env("ALACRITTY_WINDOW_ID", &window_id);
     builder.env("USER", user.user);
     builder.env("HOME", user.home);
-
     // Set Window ID for clients relying on X11 hacks.
     builder.env("WINDOWID", window_id);
+    for (key, value) in &config.env {
+        builder.env(key, value);
+    }
 
     unsafe {
         builder.pre_exec(move || {

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -1,4 +1,4 @@
-use log::info;
+use log::{info, warn};
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::io::Error;
@@ -256,12 +256,17 @@ fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> 
     let mut converted_block = Vec::new();
     let mut all_env_keys = HashSet::new();
     for (custom_key, custom_value) in custom_env {
-        let custom_key = OsStr::new(custom_key);
-        if all_env_keys.insert(custom_key.to_ascii_uppercase()) {
+        let custom_key_os = OsStr::new(custom_key);
+        if all_env_keys.insert(custom_key_os.to_ascii_uppercase()) {
             add_windows_env_key_value_to_block(
                 &mut converted_block,
-                custom_key,
+                custom_key_os,
                 OsStr::new(&custom_value),
+            );
+        } else {
+            warn!(
+                "Omitting environment variable pair with duplicate key: \
+                 '{custom_key}={custom_value}'"
             );
         }
     }

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -241,8 +241,9 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
     Some(Pty::new(conpty, conout, conin, child_watcher))
 }
 
-// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
-// https://learn.microsoft.com/sk-SK/previous-versions/troubleshoot/windows/win32/createprocess-cannot-eliminate-duplicate-variables#environment-variables
+// Windows environment variables are case-insensitive, and
+// https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/createprocess-cannot-eliminate-duplicate-variables#environment-variables
+// mentions that the caller is responsible for deduplicating environment variables, so do that here while converting.
 fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> {
     // Windows inherits parent's env when no `lpEnvironment` parameter is specified.
     if custom_env.is_empty() {
@@ -277,7 +278,9 @@ fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> 
     Some(converted_block)
 }
 
-// According to the `lpEnvironment` parameter description in the link above:
+// According to the `lpEnvironment` parameter description:
+// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
+//
 // > An environment block consists of a null-terminated block of null-terminated strings. Each
 // string is in the following form:
 // >

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -241,7 +241,8 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
     Some(Pty::new(conpty, conout, conin, child_watcher))
 }
 
-// Windows environment variables are case-insensitive, and the caller is responsible for deduplicating environment variables, so do that here while converting.
+// Windows environment variables are case-insensitive, and the caller is responsible for
+// deduplicating environment variables, so do that here while converting.
 //
 // https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/createprocess-cannot-eliminate-duplicate-variables#environment-variables
 fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> {

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -241,9 +241,9 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
     Some(Pty::new(conpty, conout, conin, child_watcher))
 }
 
-// Windows environment variables are case-insensitive, and
+// Windows environment variables are case-insensitive, and the caller is responsible for deduplicating environment variables, so do that here while converting.
+//
 // https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/createprocess-cannot-eliminate-duplicate-variables#environment-variables
-// mentions that the caller is responsible for deduplicating environment variables, so do that here while converting.
 fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> {
     // Windows inherits parent's env when no `lpEnvironment` parameter is specified.
     if custom_env.is_empty() {
@@ -263,7 +263,7 @@ fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> 
         }
     }
 
-    // Pull the current a process environment after to not overwrite user provided one.
+    // Pull the current process environment after, to avoid overwriting the user provided one.
     for (inherited_key, inherited_value) in std::env::vars_os() {
         if all_env_keys.insert(inherited_key.to_ascii_uppercase()) {
             add_windows_env_key_value_to_block(

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -256,7 +256,7 @@ fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> 
         if all_env_keys.insert(custom_key.to_ascii_uppercase()) {
             add_windows_env_key_value_to_block(
                 &mut converted_block,
-                &custom_key,
+                custom_key,
                 OsStr::new(&custom_value),
             );
         }
@@ -278,10 +278,11 @@ fn convert_custom_env(custom_env: &HashMap<String, String>) -> Option<Vec<u16>> 
 }
 
 // According to the `lpEnvironment` parameter description in the link above:
-// > An environment block consists of a null-terminated block of null-terminated strings. Each string is in the following form:
+// > An environment block consists of a null-terminated block of null-terminated strings. Each
+// string is in the following form:
 // >
 // > name=value\0
-fn add_windows_env_key_value_to_block(block: &mut Vec<u16>, key: &OsStr, alue: &OsStr) {
+fn add_windows_env_key_value_to_block(block: &mut Vec<u16>, key: &OsStr, value: &OsStr) {
     block.extend(key.encode_wide());
     block.push('=' as u16);
     block.extend(value.encode_wide());

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -6,7 +6,7 @@ use std::os::windows::ffi::OsStrExt;
 use std::os::windows::io::IntoRawHandle;
 use std::{mem, ptr};
 
-use windows_sys::core::{IInspectable, HRESULT, PWSTR};
+use windows_sys::core::{HRESULT, PWSTR};
 use windows_sys::Win32::Foundation::{HANDLE, S_OK};
 use windows_sys::Win32::System::Console::{
     ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole, COORD, HPCON,
@@ -208,7 +208,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
     let custom_env_block_pointer = match &custom_env_block {
         Some(custom_env_block) => {
             creation_flags |= CREATE_UNICODE_ENVIRONMENT;
-            custom_env_block.as_ptr() as IInspectable
+            custom_env_block.as_ptr() as *mut std::ffi::c_void
         },
         None => ptr::null_mut(),
     };

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -201,6 +201,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
         }
     }
 
+    // Prepare child process creation arguments.
     let cmdline = win32_string(&cmdline(config));
     let cwd = config.working_directory.as_ref().map(win32_string);
     let mut creation_flags = EXTENDED_STARTUPINFO_PRESENT;
@@ -212,6 +213,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
         },
         None => ptr::null_mut(),
     };
+
     let mut proc_info: PROCESS_INFORMATION = unsafe { mem::zeroed() };
     unsafe {
         success = CreateProcessW(


### PR DESCRIPTION
Closes https://github.com/alacritty/alacritty/issues/7778 by adding another field to `alacritty_terminal::tty::Options` and using those in `unix.rs` during the shell command building.

Some questions came up along the way:

* Are `tty::setup_env` vars supposed to be process-specific too in the unix case?
https://github.com/alacritty/alacritty/blob/8218c203032e6f42a20f31112c5e72abf6c3af83/alacritty_terminal/src/tty/mod.rs#L92 

Seems like not, but wanted to double check.

* There are no explicit *.md doc files related to alacritty_terminal, but should I mention this breaking change into root CHANGELOG.md? Something else?

* re: https://github.com/alacritty/alacritty/issues/7778#issuecomment-1966045017 change
Was the idea to check that new `env` for the id? I'm glad to omit that bit out of the PR unless it's not something simple to do along the way.