### PR TITLE
Expose more process info

### DIFF
--- a/alacritty_terminal/src/tty/windows/child.rs
+++ b/alacritty_terminal/src/tty/windows/child.rs
@@ -93,8 +93,10 @@ impl ChildExitWatcher {
 
     /// Retrieve the process handle of the underlying child process.
     /// This function does **not** pass ownership of the raw handle to you,
-    /// and the handle is only guaranteed to be valid while the hosted application has not yet been destroyed.
-    /// If you terminate the process using this handle, the terminal will get a timeout error, and the child watcher will emit an `Exited` event.
+    /// and the handle is only guaranteed to be valid while the hosted application
+    /// has not yet been destroyed.
+    /// If you terminate the process using this handle, the terminal will get a
+    /// timeout error, and the child watcher will emit an `Exited` event.
     pub fn raw_handle(&self) -> HANDLE {
         self.child_handle
     }

--- a/alacritty_terminal/src/tty/windows/child.rs
+++ b/alacritty_terminal/src/tty/windows/child.rs
@@ -93,9 +93,11 @@ impl ChildExitWatcher {
     }
 
     /// Retrieve the process handle of the underlying child process.
+    ///
     /// This function does **not** pass ownership of the raw handle to you,
     /// and the handle is only guaranteed to be valid while the hosted application
     /// has not yet been destroyed.
+    ///
     /// If you terminate the process using this handle, the terminal will get a
     /// timeout error, and the child watcher will emit an `Exited` event.
     pub fn raw_handle(&self) -> HANDLE {

--- a/alacritty_terminal/src/tty/windows/child.rs
+++ b/alacritty_terminal/src/tty/windows/child.rs
@@ -91,10 +91,15 @@ impl ChildExitWatcher {
         *self.interest.lock().unwrap() = None;
     }
 
-    pub fn fd(&self) -> isize {
+    /// Retrieve the process handle of the underlying child process.
+    /// This function does **not** pass ownership of the raw handle to you,
+    /// and the handle is only guaranteed to be valid while the hosted application has not yet been destroyed.
+    /// If you terminate the process using this handle, the terminal will get a timeout error, and the child watcher will emit an `Exited` event.
+    pub fn raw_handle(&self) -> HANDLE {
         self.child_handle
     }
 
+    /// Retrieve the Process ID associated to the underlying child process.
     pub fn pid(&self) -> u32 {
         self.pid
     }

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -47,6 +47,14 @@ impl Pty {
     ) -> Self {
         Self { backend: backend.into(), conout: conout.into(), conin: conin.into(), child_watcher }
     }
+
+    pub fn fd(&self) -> isize {
+        self.child_watcher.fd()
+    }
+
+    pub fn pid(&self) -> u32 {
+        self.child_watcher.pid()
+    }
 }
 
 fn with_key(mut event: Event, key: usize) -> Event {

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -48,12 +48,8 @@ impl Pty {
         Self { backend: backend.into(), conout: conout.into(), conin: conin.into(), child_watcher }
     }
 
-    pub fn fd(&self) -> isize {
-        self.child_watcher.fd()
-    }
-
-    pub fn pid(&self) -> u32 {
-        self.child_watcher.pid()
+    pub fn child_watcher(&self) -> &ChildExitWatcher {
+        &self.child_watcher
     }
 }
 


### PR DESCRIPTION
This PR introduces two functions that are equivalent to their Unix counterparts:
```rust
// unix
let pty = alacritty_terminal::tty::new();
let fd = pty.file().as_raw_fd();
let pid = pty.child().id();
// Windows
let fd = pty.fd();
let pid = pty.pid()
```