### PR TITLE
Fix build failure on NetBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Freeze when moving window between monitors on Xfwm
 - Mouse cursor not changing on Wayland when cursor theme uses legacy cursor icon names
 - Config keys are available under proper names
+- Build failure when compiling with x11 feature on NetBSD
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "x11-clipboard"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613c2be3e772af2bbb57c5a94413675f5ec668bac00a71ada2ced28c420ef087"
+checksum = "b98785a09322d7446e28a13203d2cae1059a0dd3dfb32cb06d0a225f023d8286"
 dependencies = [
  "libc",
  "x11rb",


### PR DESCRIPTION
x11-clipboard was unconditionally using eventfd which is not present on NetBSD.

Links: https://github.com/quininer/x11-clipboard/issues/48

cc @0323pin