### PR TITLE
Fix hint `Select` action for hyperlink escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Mouse cursor not changing on Wayland when cursor theme uses legacy cursor icon names
 - Config keys are available under proper names
 - Build failure when compiling with x11 feature on NetBSD
+- Hint `Select` action selecting the entire line for URL escapes
 
 ### Changed
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use alacritty_config::SerdeReplace;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueHint};
-use log::{self, error, LevelFilter};
+use log::{error, LevelFilter};
 use serde::{Deserialize, Serialize};
 use toml::Value;
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -10,7 +10,7 @@ use alacritty_terminal::term::Config as TermConfig;
 use alacritty_terminal::tty::{Options as PtyOptions, Shell};
 use log::{error, warn};
 use serde::de::{Error as SerdeError, MapAccess, Visitor};
-use serde::{self, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer};
 use unicode_width::UnicodeWidthChar;
 use winit::keyboard::{Key, ModifiersState};
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -20,7 +20,7 @@ use winit::dpi::PhysicalSize;
 use winit::keyboard::ModifiersState;
 use winit::window::CursorIcon;
 
-use crossfont::{self, Rasterize, Rasterizer, Size as FontSize};
+use crossfont::{Rasterize, Rasterizer, Size as FontSize};
 use unicode_width::UnicodeWidthChar;
 
 use alacritty_terminal::event::{EventListener, OnResize, WindowSize};

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -1050,12 +1050,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let point = self.ctx.mouse().point(&self.ctx.size_info(), display_offset);
         let hyperlink = self.ctx.terminal().grid()[point].hyperlink();
 
-        // Function to check if mouse is on top of a hint.
-        let hint_highlighted = |hint: &HintMatch| hint.should_highlight(point, hyperlink.as_ref());
-
         if let Some(mouse_state) = self.message_bar_cursor_state() {
             mouse_state
-        } else if self.ctx.display().highlighted_hint.as_ref().map_or(false, hint_highlighted) {
+        } else if hyperlink.is_some() {
             CursorIcon::Pointer
         } else if !self.ctx.modifiers().state().shift_key() && self.ctx.mouse_mode() {
             CursorIcon::Default

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -1050,9 +1050,12 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let point = self.ctx.mouse().point(&self.ctx.size_info(), display_offset);
         let hyperlink = self.ctx.terminal().grid()[point].hyperlink();
 
+        // Function to check if mouse is on top of a hint.
+        let hint_highlighted = |hint: &HintMatch| hint.should_highlight(point, hyperlink.as_ref());
+
         if let Some(mouse_state) = self.message_bar_cursor_state() {
             mouse_state
-        } else if hyperlink.is_some() {
+        } else if self.ctx.display().highlighted_hint.as_ref().map_or(false, hint_highlighted) {
             CursorIcon::Pointer
         } else if !self.ctx.modifiers().state().shift_key() && self.ctx.mouse_mode() {
             CursorIcon::Default

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 use std::{env, process};
 
-use log::{self, Level, LevelFilter};
+use log::{Level, LevelFilter};
 use winit::event_loop::EventLoopProxy;
 
 use crate::cli::Options;

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -5,7 +5,6 @@ use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
 use std::fs::File;
 use std::io::{self, ErrorKind, Read, Write};
-use std::marker::Send;
 use std::num::NonZeroUsize;
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::sync::Arc;

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -1,4 +1,4 @@
-use std::cmp::{max, PartialEq};
+use std::cmp::max;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::ops::{Index, IndexMut};

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2389,10 +2389,8 @@ pub mod test {
 
     #[cfg(feature = "serde")]
     use serde::{Deserialize, Serialize};
-    use unicode_width::UnicodeWidthChar;
 
     use crate::event::VoidListener;
-    use crate::index::Column;
 
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct TermSize {

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -11,7 +11,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::{env, ptr};
 
-use libc::{self, c_int, TIOCSCTTY};
+use libc::{c_int, TIOCSCTTY};
 use log::error;
 use polling::{Event, PollMode, Poller};
 use rustix_openpty::openpty;


### PR DESCRIPTION
This fixes an issue where the `Select` action for hyperlink escape text
would select the entire line, instead of selecting only the hyperlink
itself.

It also changes the way hyperlinks with the same ID are highlighted,
removing the restriction of being on consecutive lines and instead
highlighting all visible cells that correspond to the matching
hyperlink.

Closes #7766.

---

Had this patch around for a while but never sent it. It definitely changes the behavior a bit but imo the code is both simpler and works better.