### PR TITLE
Fix window positioning issue on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Build failure when compiling with x11 feature on NetBSD
 - Hint `Select` action selecting the entire line for URL escapes
 - Kitty encoding used for regular keys when they don't carry text
+- Configuration window position dependency on macOS window size
+- Limitation on the width of configuration windows on macOS
 
 ### Changed
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -411,10 +411,12 @@ impl Display {
         let metrics = glyph_cache.font_metrics();
         let (cell_width, cell_height) = compute_cell_size(config, &metrics);
 
-        // Resize the window to account for the user configured size.
         // In macOS, for keeping the window position after resizing
         // at the top left window corner, it must be visible.
+        #[cfg(target_os = "macos")]
         window.set_visible(true);
+
+        // Resize the window to account for the user configured size.
         if let Some(dimensions) = config.window.dimensions() {
             let size = window_size(config, dimensions, cell_width, cell_height, scale_factor);
             window.request_inner_size(size);
@@ -481,6 +483,9 @@ impl Display {
         if config.window.resize_increments {
             window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
         }
+
+        #[cfg(not(target_os = "macos"))]
+        window.set_visible(true);
 
         #[allow(clippy::single_match)]
         #[cfg(not(windows))]

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -16,6 +16,8 @@ use log::{debug, info};
 use parking_lot::MutexGuard;
 use raw_window_handle::RawWindowHandle;
 use serde::{Deserialize, Serialize};
+#[cfg(target_os = "macos")]
+use winit::dpi::PhysicalPosition;
 use winit::dpi::PhysicalSize;
 use winit::keyboard::ModifiersState;
 use winit::window::CursorIcon;
@@ -420,6 +422,12 @@ impl Display {
         if let Some(dimensions) = config.window.dimensions() {
             let size = window_size(config, dimensions, cell_width, cell_height, scale_factor);
             window.request_inner_size(size);
+        }
+
+        // Set the window position to account for the user configured position.
+        #[cfg(target_os = "macos")]
+        if let Some(position) = config.window.position {
+            window.set_outer_position(PhysicalPosition::new(position.x as u32, position.y as u32));
         }
 
         // Create the GL surface to draw into.

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -412,6 +412,9 @@ impl Display {
         let (cell_width, cell_height) = compute_cell_size(config, &metrics);
 
         // Resize the window to account for the user configured size.
+        // In macOS, for keeping the window position after resizing
+        // at the top left window corner, it must be visible.
+        window.set_visible(true);
         if let Some(dimensions) = config.window.dimensions() {
             let size = window_size(config, dimensions, cell_width, cell_height, scale_factor);
             window.request_inner_size(size);
@@ -478,8 +481,6 @@ impl Display {
         if config.window.resize_increments {
             window.set_resize_increments(PhysicalSize::new(cell_width, cell_height));
         }
-
-        window.set_visible(true);
 
         #[allow(clippy::single_match)]
         #[cfg(not(windows))]

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -214,6 +214,12 @@ impl Window {
     }
 
     #[inline]
+    #[cfg(target_os = "macos")]
+    pub fn set_outer_position(&self, position: PhysicalPosition<u32>) {
+        self.window.set_outer_position(position);
+    }
+
+    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         self.window.inner_size()
     }


### PR DESCRIPTION
PR addresses an issue related to window positioning on macOS. The problem arises when setting the window to visible after resizing, which leads to inconsistent window positioning behavior after resizing. Specifically, the configuration window's position becomes dependent on the window size, causing it to appear at the bottom left corner of the window instead of the expected top left corner.

To fix this issue, I adjusted the order of operations to set the window visible before resizing.

This PR is linked to the corresponding GitHub issue: [Link to GitHub issue](https://github.com/alacritty/alacritty/issues/7774)
