### PR TITLE
Added function and explanation-comments, for how drawing of 'block' shape cursor is done

### DIFF
--- a/alacritty/src/display/cursor.rs
+++ b/alacritty/src/display/cursor.rs
@@ -32,6 +32,7 @@ impl IntoRects for RenderableCursor {
             CursorShape::Beam => beam(x, y, height, thickness, self.color()),
             CursorShape::Underline => underline(x, y, width, height, thickness, self.color()),
             CursorShape::HollowBlock => hollow(x, y, width, height, thickness, self.color()),
+            CursorShape::Block => block(),
             _ => CursorRects::default(),
         }
     }
@@ -89,4 +90,10 @@ fn hollow(x: f32, y: f32, width: f32, height: f32, thickness: f32, color: Rgb) -
         rects: [Some(top_line), Some(bottom_line), Some(left_line), Some(right_line)],
         index: 0,
     }
+}
+
+/// for CursorShape::Block, drawing is done by changing 'bg' of cell,
+/// not drawing rect (see content.rs), so return default/empty value.
+fn block() -> CursorRects {
+    CursorRects::default()
 }

--- a/alacritty/src/display/cursor.rs
+++ b/alacritty/src/display/cursor.rs
@@ -92,7 +92,7 @@ fn hollow(x: f32, y: f32, width: f32, height: f32, thickness: f32, color: Rgb) -
     }
 }
 
-/// for CursorShape::Block, drawing is done by changing 'bg' of cell,
+/// For CursorShape::Block, drawing is done by changing 'bg' of cell,
 /// not drawing rect (see content.rs), so return default/empty value.
 fn block() -> CursorRects {
     CursorRects::default()


### PR DESCRIPTION
The drawing of 'block' shape cursor is different from other cursors,
and not clear at first, because implemented in different way, and in other file.
I've add a function that wraps original code, with explanation.
All logic is kept not changed, also kept default handler in `match self.shape()`, to avoid any changes due to un-mentioned values of `CursorShape`.

See also
[https://github.com/alacritty/alacritty/issues/7833](https://github.com/alacritty/alacritty/issues/7833)