### PR TITLE
Fix kitty encoding used for char input without text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Config keys are available under proper names
 - Build failure when compiling with x11 feature on NetBSD
 - Hint `Select` action selecting the entire line for URL escapes
+- Kitty encoding used for regular keys when they don't carry text
 
 ### Changed
 

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -347,7 +347,7 @@ impl SequenceBuilder {
         associated_text: Option<&str>,
     ) -> Option<SequenceBase> {
         let character = match key.logical_key.as_ref() {
-            Key::Character(character) => character,
+            Key::Character(character) if self.kitty_seq => character,
             _ => return None,
         };
 


### PR DESCRIPTION
On Windows some key combinations for regular text input, like Ctrl+1 don't have any text attached, so they were generating the kitty escape sequence even when they shouldn't.