### PR TITLE
Send ESC with Alt for unicode input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Pressing `Alt` with unicode input will now add `ESC` like for ASCII input
 - No unused-key warnings will be emitted for OS-specific config keys
 - Use built-in font for sextant symbols from `U+1FB00` to `U+1FB3B`
 - Kitty encoding is not used anymore for uncommon keys unless the protocol enabled

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -126,7 +126,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                     self.ctx.modifiers().state().alt_key()
                 }
             },
-            _ => text.len() == 1 && alt_send_esc,
+            _ => alt_send_esc && text.chars().count() == 1,
         }
     }
 


### PR DESCRIPTION
Make `Alt` send `ESC` for unicode input the way it's done for ASCII. Previously it was disabled because of macOS, however on macOS we're using the `option_as_alt` setting, which solves the original issue.

The `Alt` prefixing is still disabled for the unicode strings, like when they come from the compose input.

Fixes #7852.