### PR TITLE
Fix logic for reflowing cursor when growing columns, after shrinking columns

### DIFF
--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -167,6 +167,13 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
             let cursor_buffer_line = self.lines - self.cursor.point.line.0 as usize - 1;
 
             if i == cursor_buffer_line && reflow {
+                if row.is_clear() {
+                    // Rotate cursor down, if the line can be completely moved up (into history).
+                    // This allows us to correctly complete the subtraction of num_wrapped below (and avoid
+                    // hitting the Cursor boundary at (0, 0) incorrectly).
+                    self.cursor.point.line += 1;
+                }
+
                 // Resize cursor's line and reflow the cursor if necessary.
                 let mut target = self.cursor.point.sub(self, Boundary::Cursor, num_wrapped);
 
@@ -182,6 +189,8 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
                 let line_delta = self.cursor.point.line - target.line;
 
                 if line_delta != 0 && row.is_clear() {
+                    // We move the cursor up a line, if the current row is being entirely reflowed and removed.
+                    self.cursor.point.line -= line_delta;
                     continue;
                 }
 

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -169,8 +169,9 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
             if i == cursor_buffer_line && reflow {
                 if row.is_clear() {
                     // Rotate cursor down, if the line can be completely moved up (into history).
-                    // This allows us to correctly complete the subtraction of num_wrapped below (and avoid
-                    // hitting the Cursor boundary at (0, 0) incorrectly).
+                    // This allows us to correctly complete the subtraction of num_wrapped below
+                    // (and avoid hitting the Cursor boundary at (0, 0)
+                    // incorrectly).
                     self.cursor.point.line += 1;
                 }
 
@@ -189,7 +190,8 @@ impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
                 let line_delta = self.cursor.point.line - target.line;
 
                 if line_delta != 0 && row.is_clear() {
-                    // We move the cursor up a line, if the current row is being entirely reflowed and removed.
+                    // We move the cursor up a line, if the current row is being entirely reflowed
+                    // and removed.
                     self.cursor.point.line -= line_delta;
                     continue;
                 }

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -214,7 +214,6 @@ fn shrink_reflow_twice() {
     assert_eq!(grid[Line(0)][Column(1)], Cell::default());
 }
 
-
 /// Tests shrinking the Grid and then growing it back to its original size, to confirm we
 /// adjust the cursor appropriately.
 #[test]
@@ -246,7 +245,7 @@ fn shrink_grow_reflow_cursor_position() {
     // Scrollback history should have 1 row.
     assert_eq!(grid.history_size(), 1);
 
-    // Resize the Grid back to its original size of 3 rows and 8 columns. Results in a 
+    // Resize the Grid back to its original size of 3 rows and 8 columns. Results in a
     // grow_columns call.
     grid.resize(true, 3, 8);
 

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-use crate::term::cell::Cell;
+use crate::{index, term::cell::Cell};
 
 impl GridCell for usize {
     fn is_empty(&self) -> bool {
@@ -212,6 +212,50 @@ fn shrink_reflow_twice() {
     assert_eq!(grid[Line(0)].len(), 2);
     assert_eq!(grid[Line(0)][Column(0)], cell('5'));
     assert_eq!(grid[Line(0)][Column(1)], Cell::default());
+}
+
+
+/// Tests shrinking the Grid and then growing it back to its original size, to confirm we
+/// adjust the cursor appropriately.
+#[test]
+fn shrink_grow_reflow_cursor_position() {
+    // Create a Grid with 3 rows and 8 columns.
+    let mut grid = Grid::<Cell>::new(3, 8, 2);
+    grid[Line(0)][Column(0)] = cell('1');
+    grid[Line(0)][Column(1)] = cell('2');
+    grid[Line(0)][Column(2)] = cell('3');
+    grid[Line(0)][Column(3)] = cell('4');
+    grid[Line(0)][Column(4)] = cell('5');
+
+    // Set the cursor position to (0, 5). Note that NO rows are in scrollback currently.
+    grid.cursor.point.line = index::Line(0);
+    grid.cursor.point.column = index::Column(5);
+
+    // Confirm the cursor position and scrollback size is correct.
+    assert_eq!(grid.cursor.point.line, index::Line(0));
+    assert_eq!(grid.cursor.point.column, index::Column(5));
+    assert_eq!(grid.history_size(), 0);
+
+    // Resize the Grid to have 3 columns, instead of 8 columns. Results in a shrink_columns call.
+    grid.resize(true, 3, 3);
+
+    // Note that 1 row is now in scrollback history. Hence, the cursor should be at (0, 2), since
+    // it's in the "visible" coordinate system.
+    assert_eq!(grid.cursor.point.line, index::Line(0));
+    assert_eq!(grid.cursor.point.column, index::Column(2));
+    // Scrollback history should have 1 row.
+    assert_eq!(grid.history_size(), 1);
+
+    // Resize the Grid back to its original size of 3 rows and 8 columns. Results in a 
+    // grow_columns call.
+    grid.resize(true, 3, 8);
+
+    // We expect the cursor to be back at (0, 5), as we grew the Grid back to its original size.
+    assert_eq!(grid.cursor.point.line, index::Line(0));
+    assert_eq!(grid.cursor.point.column, index::Column(5));
+    // We expect the scrollback history to be empty since we grew the Grid back to its original size
+    // and removed the row that was in scrollback history (it's "visible" once again).
+    assert_eq!(grid.history_size(), 0);
 }
 
 #[test]

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -2,7 +2,8 @@
 
 use super::*;
 
-use crate::{index, term::cell::Cell};
+use crate::index;
+use crate::term::cell::Cell;
 
 impl GridCell for usize {
     fn is_empty(&self) -> bool {


### PR DESCRIPTION
- Noticed that **if you do a sequence of `shrink_columns()` and then `grow_columns()` the `Grid`'s cursor is _not_ being reflowed back to its original position.**
- Upon digging into this, found out that this was due to `let mut target = self.cursor.point.sub(self, Boundary::Cursor, num_wrapped);` only being able to subtract until it saturates at the `Boundary`. Specifically, in this case, the cursor was hitting the boundary of `(0, 0)` and was not getting reflowed correctly.
- I believe the fix is to rotate the cursor downwards if the current `row` is being entirely reflowed (nothing leftover i.e. `is_clear`). Then, we can appropriately subtract `num_wrapped`, which gets us to the right `target`, that we can apply with `line_delta`.
- Added a unit test to verify this behavior and illustrate an example of this case. Specific details:
  - We set up a `Grid` with 3 rows and 8 columns, which 5 characters on the first line. We position the `Cursor` at `(0, 5)`.
  - When we shrink the grid to 3 columns, we expect 1 row to go into scrollback history. Hence, the new `Cursor` will be at  `(0, 2)` (the first line has the first 3 cells and rest are reflowed onto the second line). 
  - Then, when we grow the grid back out to 8 columns, I believe that we expect the row to come OUT of scrollback history and for the `Cursor` to be reflowed back to `(0, 5)`.
  - Prior to my change, I was seeing the cursor reflowed to `(0, 0)` due to the saturation with subtraction at the `Boundary` and 1 row staying in scrollback history.
- **Please let me know if I misunderstood any piece of this reflowing logic or how the visible lines vs scrollback history works!** I was pretty surprised to discover this in Alacritty - so I may very well have missed something conceptually here in terms of the cases possible or intended behavior! 😄 
- Verified all existing tests pass via `cargo test`. Verified new test passes.
- Verified Alacritty resizing still works locally via `cargo run`.
- @chrisduerr for review/discussion perhaps? Noticed you'd worked on this code originally it seemed. Thanks!