### PR TITLE
Update wxs to fix Open Alacritty Here in Windows

### DIFF
--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -41,7 +41,7 @@
       <!-- Add context menu -->
       <Component Id="ContextMenu" Guid="449f9121-f7b9-41fe-82da-52349ea8ff91" Directory="TARGETDIR">
          <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here\command">
-            <RegistryValue Type="string" Value="[AlacrittyProgramFiles]alacritty.exe &quot;--working-directory&quot; &quot;%v.&quot;" KeyPath="yes" />
+            <RegistryValue Type="string" Value='[AlacrittyProgramFiles]alacritty.exe --working-directory "%v"' KeyPath="yes" />
          </RegistryKey>
          <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here">
             <RegistryValue Type="string" Name="Icon" Value="[AlacrittyProgramFiles]alacritty.exe" />

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -41,7 +41,7 @@
       <!-- Add context menu -->
       <Component Id="ContextMenu" Guid="449f9121-f7b9-41fe-82da-52349ea8ff91" Directory="TARGETDIR">
          <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here\command">
-            <RegistryValue Type="string" Value="[AlacrittyProgramFiles]alacritty.exe" KeyPath="yes" />
+            <RegistryValue Type="string" Value="[AlacrittyProgramFiles]alacritty.exe &quot;--working-directory&quot; &quot;%v.&quot;" KeyPath="yes" />
          </RegistryKey>
          <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here">
             <RegistryValue Type="string" Name="Icon" Value="[AlacrittyProgramFiles]alacritty.exe" />


### PR DESCRIPTION
The previous msi installer generated incorrect registry values. This causes the working path of alacritty started by "Open Alacritty Here" in the right-click menu is not in the current path.

This patch corrects the registry generated values.

The above modifications have been tested on Windows 11 Pro (23H2).