### PR TITLE
Attempt to let the cursor show up in the preedit area.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-.idea

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -47,15 +47,29 @@ impl<'a> RenderableContent<'a> {
         let focused_match = search_state.focused_match();
         let terminal_content = term.renderable_content();
 
+        let mut has_preedit_cursor_pos = false;
+
+        match display.ime.preedit() {
+            None => {}
+            Some(the_preedit) => {
+                match the_preedit.cursor_byte_offset {
+                    None => {}
+                    Some(_) => has_preedit_cursor_pos = true
+                }
+            }
+        }
+
         // Find terminal cursor shape.
         let cursor_shape = if terminal_content.cursor.shape == CursorShape::Hidden
             || display.cursor_hidden
             || search_state.regex().is_some()
-            || display.ime.preedit().is_some()
+            || (display.ime.preedit().is_some() && !has_preedit_cursor_pos)
         {
             CursorShape::Hidden
         } else if !term.is_focused && config.cursor.unfocused_hollow {
             CursorShape::HollowBlock
+        } else if has_preedit_cursor_pos {
+            CursorShape::Beam
         } else {
             terminal_content.cursor.shape
         };


### PR DESCRIPTION
This solves https://github.com/alacritty/alacritty/issues/7849

However, there are other following issues that need to be solved (which is not included in this PR):
https://github.com/alacritty/alacritty/issues/7881
https://github.com/alacritty/alacritty/issues/7882

Also, the `display.ime.preedit()` has insane values. See my first reply in the issue 7881 for more information. Once 7881 gets fixed, I believe that the modifications in this PR needs extra fixes.

P.S.: This PR also updates the gitIgnore to exclude metadata files generated by JetBrain RustRover (an IDE for Rust).
