### PR TITLE
Update homepage and repository fields in Cargo.toml

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"
 readme = "README.md"
-homepage = "https://github.com/alacritty/alacritty"
+homepage = "https://alacritty.org"
+repository = "https://github.com/alacritty/alacritty"
 edition = "2021"
 rust-version = "1.70.0"
 

--- a/alacritty_config/Cargo.toml
+++ b/alacritty_config/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.2.1-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT OR Apache-2.0"
 description = "Alacritty configuration abstractions"
-homepage = "https://github.com/alacritty/alacritty"
+homepage = "https://alacritty.org"
+repository = "https://github.com/alacritty/alacritty"
 edition = "2021"
 rust-version = "1.70.0"
 

--- a/alacritty_config_derive/Cargo.toml
+++ b/alacritty_config_derive/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.2.3-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT OR Apache-2.0"
 description = "Failure resistant deserialization derive"
-homepage = "https://github.com/alacritty/alacritty"
+homepage = "https://alacritty.org"
+repository = "https://github.com/alacritty/alacritty"
 edition = "2021"
 rust-version = "1.70.0"
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"
 readme = "../README.md"
-homepage = "https://github.com/alacritty/alacritty"
+homepage = "https://alacritty.org"
+repository = "https://github.com/alacritty/alacritty"
 edition = "2021"
 rust-version = "1.70.0"
 


### PR DESCRIPTION
Update [homepage](https://doc.rust-lang.org/cargo/reference/manifest.html#the-homepage-field) to correctly point to the website, and instead set [repository](https://rust-digger.code-maven.com/about-repository) to point to the GitHub repo.

This makes both the website and repository to show correctly on Crates.io. 🙂 

This PR was **inspired** by the [Rust Digger](https://rust-digger.code-maven.com/about) crawler project, and I saw Alacritty under the "[Has homepage, but no repository](https://rust-digger.code-maven.com/has-homepage-but-no-repo)" list while browsing, but I have no connection with that project.