### PR TITLE
Fix macOS creating tab in startup_mode = Fullscreen

### DIFF
--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -144,7 +144,7 @@ impl WindowContext {
 
         #[cfg(target_os = "macos")]
         let config = if tabbed && config.window.startup_mode == StartupMode::Fullscreen {
-            let mut config = config.clone().as_ref().clone();
+            let mut config = config.as_ref().clone();
             config.window.startup_mode = StartupMode::Windowed;
             Rc::new(config)
         } else {

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -31,6 +31,7 @@ use alacritty_terminal::tty;
 
 use crate::cli::{ParsedOptions, WindowOptions};
 use crate::clipboard::Clipboard;
+#[cfg(target_os = "macos")]
 use crate::config::window::StartupMode;
 use crate::config::UiConfig;
 use crate::display::window::Window;

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -142,6 +142,7 @@ impl WindowContext {
         #[cfg(not(target_os = "macos"))]
         let tabbed = false;
 
+        #[cfg(target_os = "macos")]
         let config = if tabbed && config.window.startup_mode == StartupMode::Fullscreen {
             let mut config = config.clone().as_ref().clone();
             config.window.startup_mode = StartupMode::Windowed;


### PR DESCRIPTION
When startup_mode was set to Fullscreen, creating a new tab would cause the tab to be set as Fullscreen too
Tab being Fullscreen cause a new window to be created instead of doing a tab