### PR TITLE
Fix window being focused by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+Notable changes to `alacritty_terminal` crate should be documented in its
+[CHANGELOG](./alacritty_terminal/CHANGELOG.md).
+
 ## 0.14.0-dev
+
+### Fixed
+
+- New window sometimes being treated as focused when it's not on Wayland
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-Notable changes to `alacritty_terminal` crate should be documented in its
+Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
 ## 0.14.0-dev
 
 ### Fixed
 
-- New window sometimes being treated as focused when it's not on Wayland
+- New window being treated as focused when it's not on Wayland
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,10 @@ If any change has been made to the `config.rs` file, it should also be documente
 
 Changes compared to the latest Alacritty release which have a direct effect on the user (opposed to
 things like code refactorings or documentation/tests) additionally need to be documented in the
-`CHANGELOG.md`. The existing entries should be used as a style guideline. The change log should be
-used to document changes from a user-perspective, instead of explaining the technical background
-(like commit messages). More information about Alacritty's change log format can be found
+`CHANGELOG.md`. When notable change is made to `alacritty_terminal` it should be documnted in its
+`CHANGELOG.md` as well. The existing entries should be used as a style guideline. The change log
+should be used to document changes from a user-perspective, instead of explaining the technical
+background (like commit messages). More information about Alacritty's change log format can be found
 [here](https://keepachangelog.com).
 
 ### Style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,11 +91,11 @@ If any change has been made to the `config.rs` file, it should also be documente
 
 Changes compared to the latest Alacritty release which have a direct effect on the user (opposed to
 things like code refactorings or documentation/tests) additionally need to be documented in the
-`CHANGELOG.md`. When notable change is made to `alacritty_terminal` it should be documnted in its
-`CHANGELOG.md` as well. The existing entries should be used as a style guideline. The change log
-should be used to document changes from a user-perspective, instead of explaining the technical
-background (like commit messages). More information about Alacritty's change log format can be found
-[here](https://keepachangelog.com).
+`CHANGELOG.md`. When a notable change is made to `alacritty_terminal`, it should be documented in
+`alacritty_terminal/CHANGELOG.md` as well. The existing entries should be used as a style guideline.
+The change log should be used to document changes from a user-perspective, instead of explaining the
+technical background (like commit messages) More information about Alacritty's change log format can
+be found [here](https://keepachangelog.com).
 
 ### Style
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.22.1-dev"
+version = "0.23.0-dev"
 dependencies = [
  "base64",
  "bitflags 2.4.2",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.70.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.22.1-dev"
+version = "0.23.0-dev"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -10,4 +10,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- `Term<T>` is not focused by default anymore
+- `Term` is not focused by default anymore

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to alacritty_terminal are documented in this file. The
+sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
+`Removed`.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## 0.23.0-dev
+
+### Changed
+
+- `Term<T>` is not focused by default anymore

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to alacritty_terminal are documented in this file. The
 sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 `Removed`.
 
+**Breaking changes are written in bold style.**
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.23.0-dev
 
 ### Changed
 
-- `Term` is not focused by default anymore
+- **`Term` is not focused by default anymore**

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.22.1-dev"
+version = "0.23.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -407,13 +407,13 @@ impl<T> Term<T> {
         }
     }
 
-    pub fn new<D: Dimensions>(options: Config, dimensions: &D, event_proxy: T) -> Term<T> {
+    pub fn new<D: Dimensions>(config: Config, dimensions: &D, event_proxy: T) -> Term<T> {
         let num_cols = dimensions.columns();
         let num_lines = dimensions.screen_lines();
 
-        let history_size = options.scrolling_history;
+        let history_size = config.scrolling_history;
         let grid = Grid::new(num_lines, num_cols, history_size);
-        let alt = Grid::new(num_lines, num_cols, 0);
+        let inactive_grid = Grid::new(num_lines, num_cols, 0);
 
         let tabs = TabStops::new(grid.columns());
 
@@ -423,24 +423,24 @@ impl<T> Term<T> {
         let damage = TermDamageState::new(num_cols, num_lines);
 
         Term {
+            inactive_grid,
+            scroll_region,
+            event_proxy,
+            damage,
+            config,
             grid,
-            inactive_grid: alt,
+            tabs,
+            inactive_keyboard_mode_stack: Default::default(),
+            keyboard_mode_stack: Default::default(),
             active_charset: Default::default(),
             vi_mode_cursor: Default::default(),
-            tabs,
-            mode: Default::default(),
-            scroll_region,
+            cursor_style: Default::default(),
             colors: color::Colors::default(),
-            cursor_style: None,
-            event_proxy,
-            is_focused: true,
-            title: None,
             title_stack: Default::default(),
-            keyboard_mode_stack: Default::default(),
-            inactive_keyboard_mode_stack: Default::default(),
-            selection: None,
-            damage,
-            config: options,
+            is_focused: Default::default(),
+            selection: Default::default(),
+            title: Default::default(),
+            mode: Default::default(),
         }
     }
 


### PR DESCRIPTION
Winit explicitly states that the window is not focused by default and the `Focused` event will deliver the state later on.

Closes #7866.

--

An alternative would be to make the `focused` as `false` by default in `alacritty_terminal` as well. Maybe it's a better way forward.