### PR TITLE
Fix IME preview overlapping text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.14.0-dev
 
+### Changed
+
+- Pressing `Alt` with unicode input will now add `ESC` like for ASCII input
+
 ### Fixed
 
 - Crash when trying to create a new tab without decorations enabled
 - New window being treated as focused when it's not on Wayland
-
-### Changed
-
-- Pressing `Alt` with unicode input will now add `ESC` like for ASCII input
+- IME preview blending into text below it
 
 ## 0.13.2
 


### PR DESCRIPTION
Fix incorrect usage of the `flags` when drawing the preedit resulting in setting the `flags`, but not actually reading the value back.

The logic to skip things was also used incorrectly, because the renderer does that already based on the `WIDE_CHAR` flag on the cell.

Fixes: 67a433ceed (Skip whitespaces for wide chars in preedit)