### PR TITLE
Fix dynamic title override for multiple windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Crash when trying to create a new tab without decorations enabled
 - New window being treated as focused when it's not on Wayland
 - IME preview blending into text below it
+- Dynamic title disabled for new windows when initial one has title as CLI option
 
 ## 0.13.2
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -92,7 +92,6 @@ impl Options {
             config.ipc_socket |= self.socket.is_some();
         }
 
-        config.window.dynamic_title &= self.window_options.window_identity.title.is_none();
         config.window.embed = self.embed.as_ref().and_then(|embed| parse_hex_or_decimal(embed));
         config.debug.print_events |= self.print_events;
         config.debug.log_level = max(config.debug.log_level, self.log_level());
@@ -423,19 +422,6 @@ mod tests {
         Options::default().override_config(&mut config);
 
         assert_eq!(old_dynamic_title, config.window.dynamic_title);
-    }
-
-    #[test]
-    fn dynamic_title_overridden_by_options() {
-        let mut config = UiConfig::default();
-
-        let title = Some(String::from("foo"));
-        let window_identity = WindowIdentity { title, ..WindowIdentity::default() };
-        let new_window_options = WindowOptions { window_identity, ..WindowOptions::default() };
-        let mut options = Options { window_options: new_window_options, ..Options::default() };
-        options.override_config(&mut config);
-
-        assert!(!config.window.dynamic_title);
     }
 
     #[test]

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1313,7 +1313,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     },
                     TerminalEvent::ResetTitle => {
                         let window_config = &self.ctx.config.window;
-                        if window_config.dynamic_title {
+                        if !self.ctx.preserve_title && window_config.dynamic_title {
                             self.ctx.display.window.set_title(window_config.identity.title.clone());
                         }
                     },

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -217,6 +217,8 @@ pub struct ActionContext<'a, N, T> {
     pub message_buffer: &'a mut MessageBuffer,
     pub config: &'a UiConfig,
     pub cursor_blink_timed_out: &'a mut bool,
+    #[cfg(target_os = "macos")]
+    pub event_loop: &'a EventLoopWindowTarget<Event>,
     pub event_proxy: &'a EventLoopProxy<Event>,
     pub scheduler: &'a mut Scheduler,
     pub search_state: &'a mut SearchState,
@@ -1690,7 +1692,14 @@ impl Processor {
                         None => return,
                     };
 
-                    window_context.handle_event(&proxy, &mut clipboard, &mut scheduler, event);
+                    window_context.handle_event(
+                        #[cfg(target_os = "macos")]
+                        event_loop,
+                        &proxy,
+                        &mut clipboard,
+                        &mut scheduler,
+                        event,
+                    );
 
                     window_context.draw(&mut scheduler);
                 },
@@ -1699,6 +1708,8 @@ impl Processor {
                     // Dispatch event to all windows.
                     for window_context in self.windows.values_mut() {
                         window_context.handle_event(
+                            #[cfg(target_os = "macos")]
+                            event_loop,
                             &proxy,
                             &mut clipboard,
                             &mut scheduler,
@@ -1784,6 +1795,8 @@ impl Processor {
                 WinitEvent::UserEvent(event @ Event { window_id: None, .. }) => {
                     for window_context in self.windows.values_mut() {
                         window_context.handle_event(
+                            #[cfg(target_os = "macos")]
+                            event_loop,
                             &proxy,
                             &mut clipboard,
                             &mut scheduler,
@@ -1795,7 +1808,14 @@ impl Processor {
                 WinitEvent::WindowEvent { window_id, .. }
                 | WinitEvent::UserEvent(Event { window_id: Some(window_id), .. }) => {
                     if let Some(window_context) = self.windows.get_mut(&window_id) {
-                        window_context.handle_event(&proxy, &mut clipboard, &mut scheduler, event);
+                        window_context.handle_event(
+                            #[cfg(target_os = "macos")]
+                            event_loop,
+                            &proxy,
+                            &mut clipboard,
+                            &mut scheduler,
+                            event,
+                        );
                     }
                 },
                 _ => (),

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -217,7 +217,6 @@ pub struct ActionContext<'a, N, T> {
     pub message_buffer: &'a mut MessageBuffer,
     pub config: &'a UiConfig,
     pub cursor_blink_timed_out: &'a mut bool,
-    pub event_loop: &'a EventLoopWindowTarget<Event>,
     pub event_proxy: &'a EventLoopProxy<Event>,
     pub scheduler: &'a mut Scheduler,
     pub search_state: &'a mut SearchState,
@@ -1213,7 +1212,6 @@ pub struct Mouse {
     pub click_state: ClickState,
     pub accumulated_scroll: AccumulatedScroll,
     pub cell_side: Side,
-    pub lines_scrolled: f32,
     pub block_hint_launcher: bool,
     pub hint_highlight_dirty: bool,
     pub inside_text_area: bool,
@@ -1234,7 +1232,6 @@ impl Default for Mouse {
             hint_highlight_dirty: Default::default(),
             block_hint_launcher: Default::default(),
             inside_text_area: Default::default(),
-            lines_scrolled: Default::default(),
             accumulated_scroll: Default::default(),
             x: Default::default(),
             y: Default::default(),
@@ -1693,13 +1690,7 @@ impl Processor {
                         None => return,
                     };
 
-                    window_context.handle_event(
-                        event_loop,
-                        &proxy,
-                        &mut clipboard,
-                        &mut scheduler,
-                        event,
-                    );
+                    window_context.handle_event(&proxy, &mut clipboard, &mut scheduler, event);
 
                     window_context.draw(&mut scheduler);
                 },
@@ -1708,7 +1699,6 @@ impl Processor {
                     // Dispatch event to all windows.
                     for window_context in self.windows.values_mut() {
                         window_context.handle_event(
-                            event_loop,
                             &proxy,
                             &mut clipboard,
                             &mut scheduler,
@@ -1794,7 +1784,6 @@ impl Processor {
                 WinitEvent::UserEvent(event @ Event { window_id: None, .. }) => {
                     for window_context in self.windows.values_mut() {
                         window_context.handle_event(
-                            event_loop,
                             &proxy,
                             &mut clipboard,
                             &mut scheduler,
@@ -1806,13 +1795,7 @@ impl Processor {
                 WinitEvent::WindowEvent { window_id, .. }
                 | WinitEvent::UserEvent(Event { window_id: Some(window_id), .. }) => {
                     if let Some(window_context) = self.windows.get_mut(&window_id) {
-                        window_context.handle_event(
-                            event_loop,
-                            &proxy,
-                            &mut clipboard,
-                            &mut scheduler,
-                            event,
-                        );
+                        window_context.handle_event(&proxy, &mut clipboard, &mut scheduler, event);
                     }
                 },
                 _ => (),

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -399,6 +399,7 @@ impl WindowContext {
     /// Process events for this terminal window.
     pub fn handle_event(
         &mut self,
+        #[cfg(target_os = "macos")] event_loop: &EventLoopWindowTarget<Event>,
         event_proxy: &EventLoopProxy<Event>,
         clipboard: &mut Clipboard,
         scheduler: &mut Scheduler,
@@ -444,6 +445,8 @@ impl WindowContext {
             preserve_title: self.preserve_title,
             config: &self.config,
             event_proxy,
+            #[cfg(target_os = "macos")]
+            event_loop,
             clipboard,
             scheduler,
         };

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -399,7 +399,6 @@ impl WindowContext {
     /// Process events for this terminal window.
     pub fn handle_event(
         &mut self,
-        event_loop: &EventLoopWindowTarget<Event>,
         event_proxy: &EventLoopProxy<Event>,
         clipboard: &mut Clipboard,
         scheduler: &mut Scheduler,
@@ -445,7 +444,6 @@ impl WindowContext {
             preserve_title: self.preserve_title,
             config: &self.config,
             event_proxy,
-            event_loop,
             clipboard,
             scheduler,
         };


### PR DESCRIPTION
This fixes an issue where Windows spawned after the initial one through
IPC or bindings would not update their title due to the initial window
having its title set through the CLI.

Title changes are still inhibited for additional windows when they are
spawned through `alacritty msg create-window` with the `--title` CLI
option added.

Closes #6836.