### PR TITLE
Add config file locations into config manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,9 @@ following locations:
 3. `$HOME/.config/alacritty/alacritty.toml`
 4. `$HOME/.alacritty.toml`
 
-### Windows
+On Windows, the config file will be looked for in:
 
-On Windows, the config file should be located at:
-
-`%APPDATA%\alacritty\alacritty.toml`
+* `%APPDATA%\alacritty\alacritty.toml`
 
 ## Contributing
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -19,7 +19,7 @@ following locations on UNIX systems:
 . `$HOME/.config/alacritty/alacritty.toml`
 . `$HOME/.alacritty.toml`
 
-On Windows, the config file should be located at:
+On Windows, the config file will be looked for in:
 
 . `%APPDATA%\alacritty\alacritty.toml`
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -9,6 +9,20 @@ Alacritty - TOML configuration file format.
 Alacritty's configuration file uses the TOML format. The format's specification
 can be found at _https://toml.io/en/v1.0.0_.
 
+# LOCATION
+
+Alacritty doesn't create the config file for you, but it looks for one in the
+following locations on UNIX systems:
+
+. `$XDG_CONFIG_HOME/alacritty/alacritty.toml`
+. `$XDG_CONFIG_HOME/alacritty.toml`
+. `$HOME/.config/alacritty/alacritty.toml`
+. `$HOME/.alacritty.toml`
+
+On Windows, the config file should be located at:
+
+. `%APPDATA%\alacritty\alacritty.toml`
+
 # GENERAL
 
 This section documents the root level of the configuration file.


### PR DESCRIPTION
I was trying to look for this information in https://alacritty.org/config-alacritty.html, but it wasn't there! Had to spelunk around a bit to find it in the readme instead...