### PR TITLE
Bump alacritty_terminal to 0.24.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.23.0-dev"
+version = "0.24.1-dev"
 dependencies = [
  "base64",
  "bitflags 2.4.2",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.70.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.23.0-dev"
+version = "0.24.1-dev"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -8,7 +8,9 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.23.0-dev
+## 0.24.1-dev
+
+## 0.24.0
 
 ### Added
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.23.0-dev"
+version = "0.24.1-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"


### PR DESCRIPTION
This is only an update to the development version and does not represent a stable release.