### PR TITLE
Don't execute `zsh` startup files as part of our default macOS wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Pressing `Alt` with unicode input will now add `ESC` like for ASCII input
 - Decorations use opaque style and system window background on macOS
+- No longer source `~/.zshenv` on macOS
 
 ### Fixed
 

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -177,7 +177,7 @@ fn default_shell_command(shell: &str, user: &str) -> Command {
     // -p: Preserves the environment.
     //
     // XXX: we use zsh here over sh due to `exec -a`.
-    login_command.args(["-flp", user, "/bin/zsh", "-c", &exec]);
+    login_command.args(["-flp", user, "/bin/zsh", "-fc", &exec]);
     login_command
 }
 


### PR DESCRIPTION
Given a `~/.zshenv` with `echo hit` inside, I've tested with both `chsh -s /bin/sh` which does not print `hit` anymore, while `chsh -s /bin/zsh` continues to print `hit` as it does on master.

fixes #7886