### PR TITLE
Implement dragging and resizing of borderless window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.14.0-dev
 
+### Added
+
+- Moving and resizing of windows without decorations by dragging the padding at the top or bottom-right
+
 ### Changed
 
 - Pressing `Alt` with unicode input will now add `ESC` like for ASCII input

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -34,8 +34,8 @@ use winit::monitor::MonitorHandle;
 #[cfg(windows)]
 use winit::platform::windows::IconExtWindows;
 use winit::window::{
-    CursorIcon, Fullscreen, ImePurpose, Theme, UserAttentionType, Window as WinitWindow,
-    WindowAttributes, WindowId,
+    CursorIcon, Fullscreen, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+    Window as WinitWindow, WindowAttributes, WindowId,
 };
 
 use alacritty_terminal::index::Point;
@@ -370,9 +370,8 @@ impl Window {
         }
     }
 
-    pub fn drag_resize_window(&self) {
-        if let Err(err) = self.window.drag_resize_window(winit::window::ResizeDirection::SouthEast)
-        {
+    pub fn drag_resize_window(&self, direction: ResizeDirection) {
+        if let Err(err) = self.window.drag_resize_window(direction) {
             debug!("Unable to initiate resizing the window: {}", err);
         }
     }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -16,6 +16,7 @@ use {
     png::Decoder,
 };
 
+use log::debug;
 use std::fmt::{self, Display, Formatter};
 
 #[cfg(target_os = "macos")]
@@ -361,6 +362,19 @@ impl Window {
 
     pub fn set_resize_increments(&self, increments: PhysicalSize<f32>) {
         self.window.set_resize_increments(Some(increments));
+    }
+
+    pub fn drag_window(&self) {
+        if let Err(err) = self.window.drag_window() {
+            debug!("Unable to initiate dragging the window: {}", err);
+        }
+    }
+
+    pub fn drag_resize_window(&self) {
+        if let Err(err) = self.window.drag_resize_window(winit::window::ResizeDirection::SouthEast)
+        {
+            debug!("Unable to initiate resizing the window: {}", err);
+        }
     }
 
     /// Toggle the window's fullscreen state.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1582,6 +1582,7 @@ pub struct Mouse {
     pub block_hint_launcher: bool,
     pub hint_highlight_dirty: bool,
     pub inside_text_area: bool,
+    pub padding_interaction: bool,
     pub x: usize,
     pub y: usize,
 }
@@ -1599,6 +1600,7 @@ impl Default for Mouse {
             hint_highlight_dirty: Default::default(),
             block_hint_launcher: Default::default(),
             inside_text_area: Default::default(),
+            padding_interaction: Default::default(),
             accumulated_scroll: Default::default(),
             x: Default::default(),
             y: Default::default(),


### PR DESCRIPTION
Hi, I like using alacritty without decorations (on windows, that's the only alternative to full title bar), but I found it difficult to move and resize the window.

I saw that winit provides the `drag_window` and `drag_resize_window` functions for the use case of defining custom click target areas to move and resize a window.

So I implemented moving the window when dragging the top padding, and resizing it when dragging the bottom-right corner padding, as well as corresponding `CursorIcon` changes.

I hope you like it, I am happy about any criticism.