### PR TITLE
Allow requesting Bluetooth permission on Mac

### DIFF
--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -54,5 +54,7 @@
     <string>An application in Alacritty would like to access your reminders.</string>
     <key>NSSystemAdministrationUsageDescription</key>
     <string>An application in Alacritty requires elevated permissions.</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>An application in Alacritty wants to use Bluetooth.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Command line programs that use CoreBluetooth will crash if this is not included in info.plist.