### PR TITLE
escape the '&' char in windows links

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1111,6 +1111,10 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         match &hint.action() {
             // Launch an external program.
             HintAction::Command(command) => {
+                // Windows requires an escape character (^) before occurrences of ampersand (&)
+                #[cfg(windows)]
+                let text = text.replace('&', "^&");
+
                 let mut args = command.args().to_vec();
                 args.push(text);
                 self.spawn_daemon(command.program(), &args);


### PR DESCRIPTION
The & character is special in windows, so escape it when passing strings that contain '&' as arguments to cmd.exe.

This fixes a bug where ctrl-clicking on a link with multiple parameters would only open the substring of the link up to (and not including) the first ampersand, e.g.,

http://www.foo.bar/index.html?foo=bar&baz=wat

would direct me to:

http://www.foo.bar/index.html?foo=bar