### PR TITLE
Add `strength` factor and setting for visual bell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.14.0-dev
 
+### Added
+
+- New `strength` factor and setting for the visual bell effect
+
 ### Changed
 
 - Pressing `Alt` with unicode input will now add `ESC` like for ASCII input

--- a/alacritty/src/config/bell.rs
+++ b/alacritty/src/config/bell.rs
@@ -18,6 +18,9 @@ pub struct BellConfig {
 
     /// Visual bell duration in milliseconds.
     duration: u16,
+
+    /// Stength of visual effect, in percent.
+    strength: u16,
 }
 
 impl Default for BellConfig {
@@ -27,6 +30,7 @@ impl Default for BellConfig {
             animation: Default::default(),
             command: Default::default(),
             duration: Default::default(),
+            strength: 100,
         }
     }
 }
@@ -34,6 +38,10 @@ impl Default for BellConfig {
 impl BellConfig {
     pub fn duration(&self) -> Duration {
         Duration::from_millis(self.duration as u64)
+    }
+
+    pub fn strength(&self) -> f64 {
+        f64::from(self.strength) / 100f64
     }
 }
 

--- a/alacritty/src/display/bell.rs
+++ b/alacritty/src/display/bell.rs
@@ -11,6 +11,9 @@ pub struct VisualBell {
 
     /// The last time the visual bell rang, if at all.
     start_time: Option<Instant>,
+
+    /// Strength factor of the visual effect.
+    strength: f64,
 }
 
 impl VisualBell {
@@ -93,7 +96,8 @@ impl VisualBell {
 
                 // Since we want the `intensity` of the VisualBell to decay over
                 // `time`, we subtract the `inverse_intensity` from 1.0.
-                1.0 - inverse_intensity
+                // And finally, multiply the result with a `strength` factor.
+                self.strength * (1.0 - inverse_intensity)
             },
         }
     }
@@ -101,6 +105,7 @@ impl VisualBell {
     pub fn update_config(&mut self, bell_config: &BellConfig) {
         self.animation = bell_config.animation;
         self.duration = bell_config.duration();
+        self.strength = bell_config.strength();
     }
 }
 
@@ -110,6 +115,7 @@ impl From<&BellConfig> for VisualBell {
             animation: bell_config.animation,
             duration: bell_config.duration(),
             start_time: None,
+            strength: bell_config.strength(),
         }
     }
 }

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -510,6 +510,12 @@ This section documents the *[bell]* table of the configuration file.
 
 	Default: _0_
 
+*strength* = _<integer>_
+
+	Visual bell animation strength, in percentage.
+
+	Default: _100_
+
 *color* = _"<string>"_
 
 	Visual bell animation color.


### PR DESCRIPTION
The visual bell has a color setting, however it's more like a "solid" color.  
For example, user might want to set the color to a less intense one (#808080 rather than #FFFFFF) to not flash his/her eyes blind, but setting it too low will actually make the terminal flashed in "black", instead of flash in dim white. Setting it to a moderate value can be a good solution, but for bright areas on the terminal, it's still flashing "black".  

(I know this is actually not a big issue, but I have been itchy to make it better)

This `strength` factor solves this problem. This factor is applied to visual bell intensity. Users now can have softer (or stronger, if they wish) bell flashes. 