### PR TITLE
Improve transparency on macOS

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -349,7 +349,9 @@ impl Window {
     pub fn set_transparent(&self, transparent: bool) {
         self.window.set_transparent(transparent);
         #[cfg(target_os = "macos")]
-        set_background_transparent_macos(&self.window, transparent)
+        set_background_transparent_macos(&self.window, transparent);
+        #[cfg(target_os = "macos")]
+        set_titlebar_transparent_macos(&self.window, transparent);
     }
 
     pub fn set_blur(&self, blur: bool) {
@@ -521,4 +523,17 @@ fn set_background_transparent_macos(window: &WinitWindow, transparent: bool) {
         };
         let _: () = msg_send![raw_window, setBackgroundColor: bg_color];
     }
+}
+
+/// Set the transparency of the window titlebar on macOS.
+#[cfg(target_os = "macos")]
+fn set_titlebar_transparent_macos(window: &WinitWindow, transparent: bool) {
+    let raw_window = match window.raw_window_handle() {
+        RawWindowHandle::AppKit(handle) => handle.ns_window as id,
+        _ => return,
+    };
+
+    let transparent = if transparent { YES } else { NO };
+
+    let _: () = unsafe { msg_send![raw_window, setTitlebarAppearsTransparent: transparent] };
 }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -168,6 +168,8 @@ impl Window {
             .with_title(&identity.title)
             .with_theme(config.window.theme())
             .with_visible(false)
+            // Needed on X11 and perhaps on Windows to enable configuring
+            // transparency later on.
             .with_transparent(true)
             .with_blur(config.window.blur)
             .with_maximized(config.window.maximized())


### PR DESCRIPTION
Extension upon https://github.com/alacritty/alacritty/pull/7928, see that for discussion. I've improved a bit on the window background, by setting the alpha channel to follow the window opacity.

When `window.opacity < 1`, we do two things:
- Set the title bar as transparent (new).
- Disable window border shadows (existing behaviour).
