### PR TITLE
improved default color scheme

### DIFF
--- a/alacritty/src/config/color.rs
+++ b/alacritty/src/config/color.rs
@@ -201,7 +201,7 @@ pub struct NormalColors {
 impl Default for NormalColors {
     fn default() -> Self {
         NormalColors {
-            black: Rgb::new(0x18, 0x18, 0x18),
+            black: Rgb::new(0x33, 0x33, 0x33),
             red: Rgb::new(0xac, 0x42, 0x42),
             green: Rgb::new(0x90, 0xa9, 0x59),
             yellow: Rgb::new(0xf4, 0xbf, 0x75),


### PR DESCRIPTION
The default color scheme of alacritty has 'color.normal.black' as "#181818" which is the same as 'color.primary.background' due to which text with 'normal.black' color is impossible to view. This pull request fixes that issue by making the value of 'normal.color' to '#333333' (just a lighter shade). This will improve the experience of default color scheme users.

Before:
<img width="494" alt="Screenshot 2024-05-12 at 1 19 42 PM" src="https://github.com/alacritty/alacritty/assets/29015374/0819fb5f-5bcb-4249-a145-227757fe13c5">

After:
<img width="494" alt="Screenshot 2024-05-12 at 1 20 05 PM" src="https://github.com/alacritty/alacritty/assets/29015374/62a161ab-9099-4a24-b10c-7ebc05d4fab0">
