### PR TITLE
Fix FD leak after closing child windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Dynamic title disabled for new windows when initial one has title as CLI option
 - While terminal in mouse mode, mouse bindings that used the shift modifier and
   had multiple actions only performed the first action
+- Leaking FDs when closing windows on Unix systems
 
 ## 0.13.2
 


### PR DESCRIPTION
This patch fixes an issue with signal handling where Alacritty would permanently create one signal handling FD for each alacritty window created by an instance. This FD was never released, causing a leak of the FD.

Closes #7983.