### PR TITLE
Fix error with missing imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - While terminal in mouse mode, mouse bindings that used the shift modifier and
   had multiple actions only performed the first action
 - Leaking FDs when closing windows on Unix systems
+- Config emitting errors for non-existent import paths
 
 ## 0.13.2
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -265,7 +265,6 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
                 continue;
             },
             Err(err) => {
-                println!("{:?}", err);
                 error!(target: LOG_TARGET_CONFIG, "Unable to import config {:?}: {}", path, err)
             },
         }

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -44,9 +44,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Errors occurring during config loading.
 #[derive(Debug)]
 pub enum Error {
-    /// Config file not found.
-    NotFound,
-
     /// Couldn't read $HOME environment variable.
     ReadingEnvHome(env::VarError),
 
@@ -66,7 +63,6 @@ pub enum Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::NotFound => None,
             Error::ReadingEnvHome(err) => err.source(),
             Error::Io(err) => err.source(),
             Error::Toml(err) => err.source(),
@@ -79,7 +75,6 @@ impl std::error::Error for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Error::NotFound => write!(f, "Unable to locate config file"),
             Error::ReadingEnvHome(err) => {
                 write!(f, "Unable to read $HOME environment variable: {}", err)
             },
@@ -99,11 +94,7 @@ impl From<env::VarError> for Error {
 
 impl From<io::Error> for Error {
     fn from(val: io::Error) -> Self {
-        if val.kind() == io::ErrorKind::NotFound {
-            Error::NotFound
-        } else {
-            Error::Io(val)
-        }
+        Error::Io(val)
     }
 }
 
@@ -179,6 +170,10 @@ fn after_loading(config: &mut UiConfig, options: &mut Options) {
 fn load_from(path: &Path) -> Result<UiConfig> {
     match read_config(path) {
         Ok(config) => Ok(config),
+        Err(Error::Io(io)) if io.kind() == io::ErrorKind::NotFound => {
+            error!(target: LOG_TARGET_CONFIG, "Unable to load config {:?}: File not found", path);
+            Err(Error::Io(io))
+        },
         Err(err) => {
             error!(target: LOG_TARGET_CONFIG, "Unable to load config {:?}: {}", path, err);
             Err(err)
@@ -270,6 +265,7 @@ fn load_imports(config: &Value, config_paths: &mut Vec<PathBuf>, recursion_limit
                 continue;
             },
             Err(err) => {
+                println!("{:?}", err);
                 error!(target: LOG_TARGET_CONFIG, "Unable to import config {:?}: {}", path, err)
             },
         }


### PR DESCRIPTION
This fixes a regression, likely introduced in 5d173f6df, which changed the severity of missing imports from `info` back to `error`.

The cause of this issue was a more complicated error handling mechanism, which explicitly translated IO errors to a separate enum variant without accounting for it in all scenarios.

While retrospectively this seems completely unnecessary to me, it did mean shorter error messages in case the main config file was not found. To preserve the benefits of both approaches, explicit handling for the `NotFound` IO error has been added when loading the main configuration file.