### PR TITLE
fix IO Safety violation from dropping `OwnedFd` multiple times

### DIFF
--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -212,8 +212,8 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
     };
 
     // Setup child stdin/stdout/stderr as slave fd of PTY.
-    builder.stdin(rustix_openpty::rustix::io::dup(&slave)?);
-    builder.stderr(rustix_openpty::rustix::io::dup(&slave)?);
+    builder.stdin(slave.try_clone()?);
+    builder.stderr(slave.try_clone()?);
     builder.stdout(slave);
 
     // Setup shell environment.

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -212,9 +212,6 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
     };
 
     // Setup child stdin/stdout/stderr as slave fd of PTY.
-    // Ownership of fd is transferred to the Stdio structs and will be closed by them at the end of
-    // this scope. (It is not an issue that the fd is closed three times since File::drop ignores
-    // error on libc::close.).
     builder.stdin(rustix_openpty::rustix::io::dup(&slave)?);
     builder.stderr(rustix_openpty::rustix::io::dup(&slave)?);
     builder.stdout(slave);

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -5,10 +5,10 @@ use std::fs::File;
 use std::io::{Error, ErrorKind, Read, Result};
 use std::mem::MaybeUninit;
 use std::os::fd::OwnedFd;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command};
 use std::sync::Arc;
 use std::{env, ptr};
 
@@ -215,9 +215,9 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
     // Ownership of fd is transferred to the Stdio structs and will be closed by them at the end of
     // this scope. (It is not an issue that the fd is closed three times since File::drop ignores
     // error on libc::close.).
-    builder.stdin(unsafe { Stdio::from_raw_fd(slave_fd) });
-    builder.stderr(unsafe { Stdio::from_raw_fd(slave_fd) });
-    builder.stdout(unsafe { Stdio::from_raw_fd(slave_fd) });
+    builder.stdin(rustix_openpty::rustix::io::dup(&slave)?);
+    builder.stderr(rustix_openpty::rustix::io::dup(&slave)?);
+    builder.stdout(slave);
 
     // Setup shell environment.
     let window_id = window_id.to_string();


### PR DESCRIPTION
fixes https://github.com/zed-industries/zed/issues/12114

> When running zed (cargo zed) on linux, the process crashes trying to open the alacritty terminal with
>`fatal runtime error: IO Safety violation: owned file descriptor already closed`

The error only happens on nightly because they recently enabled late debug assertions in std which work on the compiled binary: https://github.com/rust-lang/rust/commit/1ba00d9cb2fcfef464b6a188fa3a7543c66eecaa



I don't know much about linux fd handling so I don't know if `dup`ing here is the correct solution, I got this suggestion from chatgpt:
> In Rust, when you want to attach the same file descriptor (fd) to multiple streams (like stdin and stdout) for a Command, you need to duplicate the file descriptor to avoid having it dropped twice. You can use the nix crate to achieve this safely. The dup system call duplicates the file descriptor, giving you a new one that you can safely pass to another Stdio instance.