### PR TITLE
feat: Remove unsafe cstr macro, bump rust-version to 1.77

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 homepage = "https://alacritty.org"
 repository = "https://github.com/alacritty/alacritty"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.77.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -33,14 +33,6 @@ pub use text::{GlyphCache, LoaderApi};
 use shader::ShaderVersion;
 use text::{Gles2Renderer, Glsl3Renderer, TextRenderer};
 
-macro_rules! cstr {
-    ($s:literal) => {
-        // This can be optimized into an no-op with pre-allocated NUL-terminated bytes.
-        unsafe { std::ffi::CStr::from_ptr(concat!($s, "\0").as_ptr().cast()) }
-    };
-}
-pub(crate) use cstr;
-
 /// Whether the OpenGL functions have been loaded.
 pub static GL_FUNS_LOADED: AtomicBool = AtomicBool::new(false);
 

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -15,7 +15,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderError, ShaderProgram, ShaderVersion};
-use crate::renderer::{self, cstr};
+use crate::renderer::{self};
 
 #[derive(Debug, Copy, Clone)]
 pub struct RenderRect {
@@ -447,13 +447,13 @@ impl RectShaderProgram {
         let program = ShaderProgram::new(shader_version, header, RECT_SHADER_V, RECT_SHADER_F)?;
 
         Ok(Self {
-            u_cell_width: program.get_uniform_location(cstr!("cellWidth")).ok(),
-            u_cell_height: program.get_uniform_location(cstr!("cellHeight")).ok(),
-            u_padding_x: program.get_uniform_location(cstr!("paddingX")).ok(),
-            u_padding_y: program.get_uniform_location(cstr!("paddingY")).ok(),
-            u_underline_position: program.get_uniform_location(cstr!("underlinePosition")).ok(),
-            u_underline_thickness: program.get_uniform_location(cstr!("underlineThickness")).ok(),
-            u_undercurl_position: program.get_uniform_location(cstr!("undercurlPosition")).ok(),
+            u_cell_width: program.get_uniform_location(c"cellWidth").ok(),
+            u_cell_height: program.get_uniform_location(c"cellHeight").ok(),
+            u_padding_x: program.get_uniform_location(c"paddingX").ok(),
+            u_padding_y: program.get_uniform_location(c"paddingY").ok(),
+            u_underline_position: program.get_uniform_location(c"underlinePosition").ok(),
+            u_underline_thickness: program.get_uniform_location(c"underlineThickness").ok(),
+            u_undercurl_position: program.get_uniform_location(c"undercurlPosition").ok(),
             program,
         })
     }

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -11,7 +11,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderProgram, ShaderVersion};
-use crate::renderer::{cstr, Error, GlExtensions};
+use crate::renderer::{Error, GlExtensions};
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
@@ -482,8 +482,8 @@ impl TextShaderProgram {
         let program = ShaderProgram::new(shader_version, None, TEXT_SHADER_V, fragment_shader)?;
 
         Ok(Self {
-            u_projection: program.get_uniform_location(cstr!("projection"))?,
-            u_rendering_pass: program.get_uniform_location(cstr!("renderingPass"))?,
+            u_projection: program.get_uniform_location(c"projection")?,
+            u_rendering_pass: program.get_uniform_location(c"renderingPass")?,
             program,
         })
     }

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -11,7 +11,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderProgram, ShaderVersion};
-use crate::renderer::{cstr, Error};
+use crate::renderer::Error;
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
@@ -426,9 +426,9 @@ impl TextShaderProgram {
     pub fn new(shader_version: ShaderVersion) -> Result<TextShaderProgram, Error> {
         let program = ShaderProgram::new(shader_version, None, TEXT_SHADER_V, TEXT_SHADER_F)?;
         Ok(Self {
-            u_projection: program.get_uniform_location(cstr!("projection"))?,
-            u_cell_dim: program.get_uniform_location(cstr!("cellDim"))?,
-            u_rendering_pass: program.get_uniform_location(cstr!("renderingPass"))?,
+            u_projection: program.get_uniform_location(c"projection")?,
+            u_cell_dim: program.get_uniform_location(c"cellDim")?,
+            u_rendering_pass: program.get_uniform_location(c"renderingPass")?,
             program,
         })
     }


### PR DESCRIPTION
Per #8002, this PR removes the `cstr!` macro and replaces it with C-string literal syntax. Because that syntax wasn't introduced until Rust 1.77, I have bumped the rust-version as well. All tests pass and benchmarked performance seems excellent. It may need to be bumped in other Cargo.toml files as well, but am unsure, please advise. Thanks.