### PR TITLE
Make font size step configurable

### DIFF
--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -61,6 +61,9 @@ pub struct WindowConfig {
 
     /// System decorations theme variant.
     decorations_theme_variant: Option<Theme>,
+
+    /// Font size change interval in px.
+    pub font_size_step: f32,
 }
 
 impl Default for WindowConfig {
@@ -80,6 +83,7 @@ impl Default for WindowConfig {
             resize_increments: Default::default(),
             decorations_theme_variant: Default::default(),
             option_as_alt: Default::default(),
+            font_size_step: 1.0,
         }
     }
 }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -47,7 +47,7 @@ use crate::display::color::Rgb;
 use crate::display::hint::HintMatch;
 use crate::display::window::Window;
 use crate::display::{Display, Preedit, SizeInfo};
-use crate::input::{self, ActionContext as _, FONT_SIZE_STEP};
+use crate::input::{self, ActionContext as _};
 use crate::logging::{LOG_TARGET_CONFIG, LOG_TARGET_WINIT};
 use crate::message_bar::{Message, MessageBuffer};
 use crate::scheduler::{Scheduler, TimerId, Topic};
@@ -1538,7 +1538,7 @@ impl TouchZoom {
     }
 
     /// Get slot distance change since last update.
-    pub fn font_delta(&mut self, slot: TouchEvent) -> f32 {
+    pub fn font_delta(&mut self, slot: TouchEvent, font_size_step: f32) -> f32 {
         let old_distance = self.distance();
 
         // Update touch slots.
@@ -1548,9 +1548,9 @@ impl TouchZoom {
             self.slots.1 = slot;
         }
 
-        // Calculate font change in `FONT_SIZE_STEP` increments.
+        // Calculate font change in `font_size_step` increments.
         let delta = (self.distance() - old_distance) * TOUCH_ZOOM_FACTOR + self.fractions;
-        let font_delta = (delta.abs() / FONT_SIZE_STEP).floor() * FONT_SIZE_STEP * delta.signum();
+        let font_delta = (delta.abs() / font_size_step).floor() * font_size_step * delta.signum();
         self.fractions = delta - font_delta;
 
         font_delta

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -50,9 +50,6 @@ use crate::scheduler::{Scheduler, TimerId, Topic};
 
 pub mod keyboard;
 
-/// Font size change interval in px.
-pub const FONT_SIZE_STEP: f32 = 1.;
-
 /// Interval for mouse scrolling during selection outside of the boundaries.
 const SELECTION_SCROLLING_INTERVAL: Duration = Duration::from_millis(15);
 
@@ -324,8 +321,8 @@ impl<T: EventListener> Execute<T> for Action {
             Action::Hide => ctx.window().set_visible(false),
             Action::Minimize => ctx.window().set_minimized(true),
             Action::Quit => ctx.terminal_mut().exit(),
-            Action::IncreaseFontSize => ctx.change_font_size(FONT_SIZE_STEP),
-            Action::DecreaseFontSize => ctx.change_font_size(-FONT_SIZE_STEP),
+            Action::IncreaseFontSize => ctx.change_font_size(ctx.config().window.font_size_step),
+            Action::DecreaseFontSize => ctx.change_font_size(-ctx.config().window.font_size_step),
             Action::ResetFontSize => ctx.reset_font_size(),
             Action::ScrollPageUp
             | Action::ScrollPageDown
@@ -844,6 +841,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
     /// Handle touch input movement.
     pub fn on_touch_motion(&mut self, touch: TouchEvent) {
+        let font_size_step = self.ctx.config().window.font_size_step;
         let touch_purpose = self.ctx.touch_purpose();
         match touch_purpose {
             TouchPurpose::None => (),
@@ -871,7 +869,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 }
             },
             TouchPurpose::Zoom(zoom) => {
-                let font_delta = zoom.font_delta(touch);
+                let font_delta = zoom.font_delta(touch, font_size_step);
                 self.ctx.change_font_size(font_delta);
             },
             TouchPurpose::Scroll(last_touch) => {


### PR DESCRIPTION
For me, the hardcoded delta for font size increase (1px) always felt too small. A quick zoom in, e.g., during a screencast, currently requires too many button presses. For comparison, check a browser increases font size on Ctrl-+. For me, alacritty should behave the same.

This will introduce a new configuration variable for the font size step. The default is still 1px to not break anything. In my config, I would set it to ~4-6px.