### PR TITLE
Restart config monitor on import change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Config emitting errors for nonexistent import paths
 - Kitty keyboard protocol reporting shifted key codes
 - Broken search with words broken across line boundary on the first character
+- Config import changes not being live reloaded
 
 ## 0.13.2
 

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -1,4 +1,5 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::thread::JoinHandle;

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -180,7 +180,7 @@ impl ConfigMonitor {
         // Sort files to avoid restart on order change.
         let mut sorted_files = [None; MAX_PATHS];
         for (i, file) in files.iter().enumerate() {
-            sorted_files[i] = Some(file.as_path());
+            sorted_files[i] = Some(file);
         }
         sorted_files.sort_unstable();
 

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -1,3 +1,4 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::thread::JoinHandle;
@@ -23,6 +24,7 @@ const FALLBACK_POLLING_TIMEOUT: Duration = Duration::from_secs(1);
 pub struct ConfigMonitor {
     thread: JoinHandle<()>,
     shutdown_tx: Sender<Result<NotifyEvent, NotifyError>>,
+    watched_hash: u64,
 }
 
 impl ConfigMonitor {
@@ -31,6 +33,9 @@ impl ConfigMonitor {
         if paths.is_empty() {
             return None;
         }
+
+        // Calculate the hash for the unmodified list of paths.
+        let watched_hash = Self::hash_paths(&paths);
 
         // Exclude char devices like `/dev/null`, sockets, and so on, by checking that file type is
         // a regular file.
@@ -139,7 +144,7 @@ impl ConfigMonitor {
             }
         });
 
-        Some(Self { thread: join_handle, shutdown_tx: tx })
+        Some(Self { watched_hash, thread: join_handle, shutdown_tx: tx })
     }
 
     /// Synchronously shut down the monitor.
@@ -153,5 +158,20 @@ impl ConfigMonitor {
         if let Err(err) = self.thread.join() {
             warn!("config monitor shutdown failed: {err:?}");
         }
+    }
+
+    /// Check if the config monitor needs to be restarted.
+    ///
+    /// This checks the supplied list of files against the monitored files to determine if a
+    /// restart is necessary.
+    pub fn needs_restart(&self, files: &[PathBuf]) -> bool {
+        self.watched_hash != Self::hash_paths(files)
+    }
+
+    /// Generate the hash for a list of paths.
+    fn hash_paths(files: &[PathBuf]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        Hash::hash_slice(files, &mut hasher);
+        hasher.finish()
     }
 }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1,5 +1,6 @@
 //! Process window events.
 
+use crate::ConfigMonitor;
 use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -70,6 +71,8 @@ const TOUCH_ZOOM_FACTOR: f32 = 0.01;
 /// Stores some state from received events and dispatches actions when they are
 /// triggered.
 pub struct Processor {
+    pub config_monitor: Option<ConfigMonitor>,
+
     clipboard: Clipboard,
     scheduler: Scheduler,
     initial_window_options: Option<WindowOptions>,
@@ -101,6 +104,16 @@ impl Processor {
         // which is done in `loop_exiting`.
         let clipboard = unsafe { Clipboard::new(event_loop.display_handle().unwrap().as_raw()) };
 
+        // Create a config monitor.
+        //
+        // The monitor watches the config file for changes and reloads it. Pending
+        // config changes are processed in the main loop.
+        let mut config_monitor = None;
+        if config.live_config_reload {
+            config_monitor =
+                ConfigMonitor::new(config.config_paths.clone(), event_loop.create_proxy());
+        }
+
         Processor {
             initial_window_options,
             initial_window_error: None,
@@ -113,6 +126,7 @@ impl Processor {
             windows: Default::default(),
             #[cfg(unix)]
             global_ipc_options: Default::default(),
+            config_monitor,
         }
     }
 
@@ -160,8 +174,8 @@ impl Processor {
     /// Run the event loop.
     ///
     /// The result is exit code generate from the loop.
-    pub fn run(mut self, event_loop: EventLoop<Event>) -> Result<(), Box<dyn Error>> {
-        let result = event_loop.run_app(&mut self);
+    pub fn run(&mut self, event_loop: EventLoop<Event>) -> Result<(), Box<dyn Error>> {
+        let result = event_loop.run_app(self);
         if let Some(initial_window_error) = self.initial_window_error.take() {
             Err(initial_window_error)
         } else {
@@ -296,6 +310,17 @@ impl ApplicationHandler<Event> for Processor {
                 // Load config and update each terminal.
                 if let Ok(config) = config::reload(path, &mut self.cli_options) {
                     self.config = Rc::new(config);
+
+                    // Restart config monitor if imports changed.
+                    if let Some(monitor) = self.config_monitor.take() {
+                        let paths = &self.config.config_paths;
+                        self.config_monitor = if monitor.needs_restart(paths) {
+                            monitor.shutdown();
+                            ConfigMonitor::new(paths.clone(), self.proxy.clone())
+                        } else {
+                            Some(monitor)
+                        }
+                    }
 
                     for window_context in self.windows.values_mut() {
                         window_context.update_config(self.config.clone());

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -319,7 +319,7 @@ impl ApplicationHandler<Event> for Processor {
                             ConfigMonitor::new(paths.clone(), self.proxy.clone())
                         } else {
                             Some(monitor)
-                        }
+                        };
                     }
 
                     for window_context in self.windows.values_mut() {


### PR DESCRIPTION
This patch checks the hash of the import paths on every config change and restarts the config monitor whenever the current monitor's hash diverges from the updated config's list of imports.

Closes #7981.

---

I've verified that this doesn't leak any threads, though obviously check yourself if in doubt.