### PR TITLE
feat: vi mode features for '*' / '#' / 'o' / '{' / '}'

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -328,6 +328,10 @@ pub enum ViAction {
     InlineSearchNext,
     /// Jump to the previous inline search match.
     InlineSearchPrevious,
+    /// Search forward for highlighted region or word under cursor.
+    CurrentWordSearchForward,
+    /// Search backward for highlighted region or word under cursor.
+    CurrentWordSearchBackward,
 }
 
 /// Search mode specific actions.
@@ -488,6 +492,8 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         "t",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchBackwardShort;
         ";",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchNext;
         ",",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchPrevious;
+        "*",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::CurrentWordSearchForward;
+        "#",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::CurrentWordSearchBackward;
         "k",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Up;
         "j",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Down;
         "h",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Left;
@@ -511,6 +517,9 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         "w",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::WordRight;
         "e",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::WordRightEnd;
         "%",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Bracket;
+        "{",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::ParagraphUp;
+        "}",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::ParagraphDown;
+        "o",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::VisualSelection;
         Enter,                              +BindingMode::VI, +BindingMode::SEARCH; SearchAction::SearchConfirm;
         // Plain search.
         Escape,                             +BindingMode::SEARCH; SearchAction::SearchCancel;

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -295,6 +295,12 @@ impl Selection {
         }
     }
 
+    /// Swap ends of highlighted region, returning new end of region location.
+    pub fn swap_anchors(&mut self) -> Point {
+        mem::swap(&mut self.region.start, &mut self.region.end);
+        self.region.end.point
+    }
+
     fn range_semantic<T>(term: &Term<T>, mut start: Point, mut end: Point) -> SelectionRange {
         if start == end {
             if let Some(matching) = term.bracket_search(start) {

--- a/extra/man/alacritty-bindings.5.scd
+++ b/extra/man/alacritty-bindings.5.scd
@@ -189,6 +189,14 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :[
 :  _"Vi|~Search"_
 :  _"InlineSearchPrevious"_
+|  _"\*"_
+:  _"Shift"_
+:  _"Vi|~Search"_
+:  _"CurrentWordSearchForward"_
+|  _"#"_
+:  _"Shift"_
+:  _"Vi|~Search"_
+:  _"CurrentWordSearchBackward"_
 |  _"K"_
 :[
 :  _"Vi|~Search"_
@@ -281,6 +289,18 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :  _"Shift"_
 :  _"Vi|~Search"_
 :  _"Bracket"_
+|  _"{"_
+:[
+:  _"Vi|~Search"_
+:  _"ParagraphUp"_
+|  _"}"_
+:[
+:  _"Vi|~Search"_
+:  _"ParagraphDown"_
+|  _"o"_
+:[
+:  _"Vi|~Search"_
+:  _"VisualSelection"_
 |  _"/"_
 :[
 :  _"Vi|~Search"_

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -894,6 +894,12 @@ _https://docs.rs/winit/latest/winit/keyboard/enum.Key.html#variant.Dead_
 			Move to end of whitespace separated word.
 		*Bracket*
 			Move to opposing bracket.
+		*ParagraphUp*
+			Move up to first empty row.
+		*ParagraphDown*
+			Move down to first empty row.
+		*VisualSelection*
+			Move to highlighted region opposite selection marker.
 		*ToggleNormalSelection*
 			Toggle normal vi selection.
 		*ToggleLineSelection*
@@ -926,6 +932,10 @@ _https://docs.rs/winit/latest/winit/keyboard/enum.Key.html#variant.Dead_
 			Jump to the next inline search match.
 		*InlineSearchPrevious*
 			Jump to the previous inline search match.
+		*CurrentWordSearchForward*
+			Search forward for highlighted region or word under cursor.
+		*CurrentWordSearchBackward*
+			Search backward for highlighted region or word under cursor.
 
 		_Search actions:_
 


### PR DESCRIPTION
Hi! I saw [this issue](https://github.com/alacritty/alacritty/issues/7961) and thought it'd be an easy way to hopefully start contributing to one of my fav projects!  I added the 3 new commands and updated the scdoc files accordingly.  I briefly describe the behavior with these new changes below...

Upon pressing `*` in visual mode, search for the highlighted text in the region, and in normal mode, grab the first semantic word at/after the cursor point in the same line, searching for that.  `#` similarly searches backwards.

This matches any word containing the search pattern, unlike vim which matches the exact pattern.  I tried getting the search to behave exactly like vim, but wrapping the region in "\\<\\>" didn't work, nor did using the negative lookahead/lookbehind operators (`(?!)`,`(?<!)`), but i figured this was prolly good enough.

Also added the visual `o` keybinding, which will move the cursor to the other side of a visual region.  Works as expected for all visual modes.  Contemplated adding the `O` key for switching the column of a visual block, but i doubt anyone even knows about this key, let alone has use for it.