### PR TITLE
remove libfreetype6-dev from installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ to build Alacritty. Here's an apt command that should install all of them. If
 something is still found to be missing, please open an issue.
 
 ```sh
-apt install cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
+apt install cmake pkg-config libfreetype-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
 ```
 
 #### Arch Linux


### PR DESCRIPTION
libfreetype6-dev is a transitional package (https://salsa.debian.org/debian/freetype/-/commit/45a29b92d55464c1887959b06578bb09314b1aa5) that depends on an older version of libfreetype-dev. This results in this current installation instruction failing with 

Unsatisfied dependencies:
libfreetype6-dev : Depends: libfreetype-dev (= 2.13.0+dfsg-1) but 2.13.2+dfsg-1 is to be installed
Error: Unable to correct problems, you have held broken packages.

Test: successful installation of Alacritty on Debian Linux

