### PR TITLE
Fix description in alacritty-bindings(5)

### DIFF
--- a/extra/man/alacritty-bindings.5.scd
+++ b/extra/man/alacritty-bindings.5.scd
@@ -2,7 +2,7 @@ ALACRITTY-BINDINGS(5)
 
 # NAME
 
-Alacritty Bindings - Default configuration file bindings.
+alacritty-bindings - Default configuration file bindings.
 
 # SYNOPSIS
 


### PR DESCRIPTION
Man pages use the man page name as the first word in description. This also aligns with other man pages we have.