### PR TITLE
windows: Make the creation of `ConPty` failable

### DIFF
--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -236,7 +236,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> std::io::Result<Pty> {
     let conin = UnblockedWriter::new(conin, PIPE_CAPACITY);
     let conout = UnblockedReader::new(conout, PIPE_CAPACITY);
 
-    let child_watcher = ChildExitWatcher::new(proc_info.hProcess).unwrap();
+    let child_watcher = ChildExitWatcher::new(proc_info.hProcess)?;
     let conpty = Conpty { handle: pty_handle as HPCON, api };
 
     Ok(Pty::new(conpty, conout, conin, child_watcher))

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -1,6 +1,7 @@
 use log::{info, warn};
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
+use std::io::{Error, Result};
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::io::IntoRawHandle;
 use std::{mem, ptr};
@@ -106,7 +107,7 @@ impl Drop for Conpty {
 // The ConPTY handle can be sent between threads.
 unsafe impl Send for Conpty {}
 
-pub fn new(config: &Options, window_size: WindowSize) -> std::io::Result<Pty> {
+pub fn new(config: &Options, window_size: WindowSize) -> Result<Pty> {
     let api = ConptyApi::new();
     let mut pty_handle: HPCON = 0;
 
@@ -153,7 +154,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> std::io::Result<Pty> {
 
         // This call was expected to return false.
         if failure {
-            return Err(std::io::Error::last_os_error());
+            return Err(Error::last_os_error());
         }
     }
 
@@ -179,7 +180,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> std::io::Result<Pty> {
         ) > 0;
 
         if !success {
-            return Err(std::io::Error::last_os_error());
+            return Err(Error::last_os_error());
         }
     }
 
@@ -196,7 +197,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> std::io::Result<Pty> {
         ) > 0;
 
         if !success {
-            return Err(std::io::Error::last_os_error());
+            return Err(Error::last_os_error());
         }
     }
 
@@ -229,7 +230,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> std::io::Result<Pty> {
         ) > 0;
 
         if !success {
-            return Err(std::io::Error::last_os_error());
+            return Err(Error::last_os_error());
         }
     }
 

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -1,7 +1,6 @@
 use log::{info, warn};
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
-use std::io::Error;
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::io::IntoRawHandle;
 use std::{mem, ptr};
@@ -107,7 +106,7 @@ impl Drop for Conpty {
 // The ConPTY handle can be sent between threads.
 unsafe impl Send for Conpty {}
 
-pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
+pub fn new(config: &Options, window_size: WindowSize) -> std::io::Result<Pty> {
     let api = ConptyApi::new();
     let mut pty_handle: HPCON = 0;
 
@@ -115,8 +114,8 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
     // size to be used. There may be small performance and memory advantages
     // to be gained by tuning this in the future, but it's likely a reasonable
     // start point.
-    let (conout, conout_pty_handle) = miow::pipe::anonymous(0).unwrap();
-    let (conin_pty_handle, conin) = miow::pipe::anonymous(0).unwrap();
+    let (conout, conout_pty_handle) = miow::pipe::anonymous(0)?;
+    let (conin_pty_handle, conin) = miow::pipe::anonymous(0)?;
 
     // Create the Pseudo Console, using the pipes.
     let result = unsafe {
@@ -154,7 +153,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
 
         // This call was expected to return false.
         if failure {
-            panic_shell_spawn();
+            return Err(std::io::Error::last_os_error());
         }
     }
 
@@ -180,7 +179,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
         ) > 0;
 
         if !success {
-            panic_shell_spawn();
+            return Err(std::io::Error::last_os_error());
         }
     }
 
@@ -197,7 +196,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
         ) > 0;
 
         if !success {
-            panic_shell_spawn();
+            return Err(std::io::Error::last_os_error());
         }
     }
 
@@ -230,7 +229,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
         ) > 0;
 
         if !success {
-            panic_shell_spawn();
+            return Err(std::io::Error::last_os_error());
         }
     }
 
@@ -240,7 +239,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Option<Pty> {
     let child_watcher = ChildExitWatcher::new(proc_info.hProcess).unwrap();
     let conpty = Conpty { handle: pty_handle as HPCON, api };
 
-    Some(Pty::new(conpty, conout, conin, child_watcher))
+    Ok(Pty::new(conpty, conout, conin, child_watcher))
 }
 
 // Windows environment variables are case-insensitive, and the caller is responsible for
@@ -298,11 +297,6 @@ fn add_windows_env_key_value_to_block(block: &mut Vec<u16>, key: &OsStr, value: 
     block.push('=' as u16);
     block.extend(value.encode_wide());
     block.push(0);
-}
-
-// Panic with the last os error as message.
-fn panic_shell_spawn() {
-    panic!("Unable to spawn shell: {}", Error::last_os_error());
 }
 
 impl OnResize for Conpty {

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsStr;
-use std::io::{self, Error, ErrorKind, Result};
+use std::io::{self, Result};
 use std::iter::once;
 use std::os::windows::ffi::OsStrExt;
 use std::sync::mpsc::TryRecvError;
@@ -35,7 +35,6 @@ pub struct Pty {
 
 pub fn new(config: &Options, window_size: WindowSize, _window_id: u64) -> Result<Pty> {
     conpty::new(config, window_size)
-        .ok_or_else(|| Error::new(ErrorKind::Other, "failed to spawn conpty"))
 }
 
 impl Pty {


### PR DESCRIPTION
Currently, if the creation of `ConPty` fails, it triggers a `panic`, causing the application to exit abruptly. This PR modifies that behavior by returning an `Err` instead of panicking when the creation fails. 

For more details, please refer to the related issue: https://github.com/zed-industries/zed/issues/16352.