### PR TITLE
Expose the command execution interface using ExecArg

### DIFF
--- a/extra/linux/Alacritty.desktop
+++ b/extra/linux/Alacritty.desktop
@@ -2,6 +2,7 @@
 Type=Application
 TryExec=alacritty
 Exec=alacritty
+X-ExecArg=-e
 Icon=Alacritty
 Terminal=false
 Categories=System;TerminalEmulator;


### PR DESCRIPTION
According to the upcoming xdg-terminal-exec specification. 

This is the only change needed to support the spec. No fancy dbus or such.