### PR TITLE
Use malloc_trim on Term reset_state

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1824,6 +1824,16 @@ impl<T: EventListener> Handler for Term<T> {
 
         self.event_proxy.send_event(Event::CursorBlinkingChange);
         self.mark_fully_damaged();
+
+        // glibc tends to not release the memory until everything associated with the `Term` is
+        // removed due to fragmentation. Though, even there's a fragmentation we could still
+        // release the _physical_ memory back fragmenting the address space.
+        //
+        // The fragmentation will fixup itself once the `Term` is fully dropped.
+        #[cfg(all(target_env = "gnu", target_os = "linux"))]
+        unsafe {
+            libc::malloc_trim(0);
+        }
     }
 
     #[inline]


### PR DESCRIPTION
This prevents the memory with glibc allocator from sticking around and just results in address space fragmentation until you close the given alacritty window.

--

I'm not sure how good idea that is, but it seems to kind of solve https://github.com/alacritty/alacritty/issues/5438 .

This issue is also less noticeable with the default mimalloc settings.

The main issue with this thing is that it's relatively slow when you have a lot of junk and it's likely not a great way to solve this, but it really seems that we're just fighting the allocator.

probably the better option is to figure out what exactly breaks the ability of glibc allocator to release everything back.

Draft because I have no idea whether it's a _good_ solution for that...