### PR TITLE
Allow customizing `activation_policy` on winit startup in macOS

### DIFF
--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -27,6 +27,9 @@ pub struct WindowConfig {
     /// Startup mode.
     pub startup_mode: StartupMode,
 
+    /// Whether Alacritty should run in the background
+    pub run_in_background: bool,
+
     /// XEmbed parent.
     #[config(skip)]
     pub embed: Option<u32>,
@@ -76,6 +79,7 @@ impl Default for WindowConfig {
             dimensions: Default::default(),
             decorations: Default::default(),
             startup_mode: Default::default(),
+            run_in_background: Default::default(),
             dynamic_padding: Default::default(),
             resize_increments: Default::default(),
             decorations_theme_variant: Default::default(),

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -172,7 +172,7 @@ This section documents the *[window]* table of the configuration file.
 
 *run_in_background* = _true_ | _false_ # _(works on macOS)_
 
-	Run the application in the background, removing it from standard window management
+	Run the application in the background, removing it from standard window management,
 	allowing it to be accessed only programmatically or via a direct click.
 
 	Default: _false_

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -170,6 +170,14 @@ This section documents the *[window]* table of the configuration file.
 
 	Default: _"Windowed"_
 
+*run_in_background* = _true_ | _false_ # _(works on macOS)_
+
+	Run the application in the background, removing it from standard window management
+    (and on macOS, removing it from the dock), allowing it to be accessed only
+    programmatically or via a direct click.
+
+	Default: _false_
+
 *title* = _"<string>"_
 
 	Window title.

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -173,8 +173,7 @@ This section documents the *[window]* table of the configuration file.
 *run_in_background* = _true_ | _false_ # _(works on macOS)_
 
 	Run the application in the background, removing it from standard window management
-	(and on macOS, removing it from the dock), allowing it to be accessed only
-	programmatically or via a direct click.
+	allowing it to be accessed only programmatically or via a direct click.
 
 	Default: _false_
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -173,8 +173,8 @@ This section documents the *[window]* table of the configuration file.
 *run_in_background* = _true_ | _false_ # _(works on macOS)_
 
 	Run the application in the background, removing it from standard window management
-    (and on macOS, removing it from the dock), allowing it to be accessed only
-    programmatically or via a direct click.
+	(and on macOS, removing it from the dock), allowing it to be accessed only
+	programmatically or via a direct click.
 
 	Default: _false_
 


### PR DESCRIPTION
This essentially allows Alacritty to run in the "background" on macOS, as in, remove itself from the dock
and window switcher.

This has been attempted before with hacks and burdening Alacritty with responsibilities it shouldn't have, 
but I believe this case is different - we need to set a specific configuration accepted by `winit`, and it
needs to be set at startup. All this PR does is set it based on a config, since there is no separate way to
override this after-the-fact, nor with any system changes, environment variables, etc. This also allows the
window manager to decide how to handle this based on its native capabilities, rather than implementing 
anything here. This implementation is similar to `startup_mode`.

Currently marked it as macOS-only since that's all I've implemented; if window managers people use support 
passing this down, it could be expanded.

I'm down to change the name "background", since not married to anything in particular. In macOS they're called
"agent" apps. If we wish to name it directly as `macos_activation_policy` to avoid inserting a layer of Alacritty
defining what it means for an app to "run in the background", I'm down to change that too, and make it completely
specific to macOS, though I'd prefer abstracting that from the user and making the Alacritty config more related
to how Alacritty behaves, rather than how an underlying window system names something.

Tested by replacing the binary in my `Alacritty.app` and running with and without the new config.

[ActivationPolicy documentation](https://developer.apple.com/documentation/appkit/nsapplication/activationpolicy
)
[`winit` default behavior](https://github.com/rust-windowing/winit/blob/dfea49f48850670cdfe3dc91949a9f8f2e267a38/src/platform_impl/apple/appkit/event_loop.rs#L201)
[`winit` setting `activation_policy` for the `NSApplication` on startup](https://github.com/rust-windowing/winit/blob/dfea49f48850670cdfe3dc91949a9f8f2e267a38/src/platform_impl/apple/appkit/app_state.rs#L116)