### PR TITLE
fix: Modified config file path details

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ following locations:
 
 On Windows, the config file will be looked for in (if not found, you should create it):
 
-* `%APPDATA%\roaming\alacritty\alacritty.toml`
+* `%APPDATA%\Roaming\alacritty\alacritty.toml`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ following locations:
 3. `$HOME/.config/alacritty/alacritty.toml`
 4. `$HOME/.alacritty.toml`
 
-On Windows, the config file will be looked for in:
+On Windows, the config file will be looked for in (if not found, you should create it):
 
-* `%APPDATA%\alacritty\alacritty.toml`
+* `%APPDATA%\roaming\alacritty\alacritty.toml`
 
 ## Contributing
 


### PR DESCRIPTION
When I installed Alacritty in two of my windows laptops, it doesn't create alacritty.toml file by itself I had to manually create it on the path %appdata%/roaming/alacritty/alacritty.toml, and then it worked.

That's why I thought of creating a PR. 