### PR TITLE
Fix fullwidth semantic escape characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Broken search with words broken across line boundary on the first character
 - Config import changes not being live reloaded
 - Cursor color requests with default cursor colors
+- Fullwidth semantic escape characters
 
 ## 0.13.2
 

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -519,12 +519,10 @@ impl<T> Term<T> {
             // If we found a match, reverse for at least one cell, skipping over wide cell spacers.
             Ok(point) => {
                 let wide_spacer = Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER;
-                for cell in self.grid.iter_from(point) {
-                    if !cell.flags.intersects(wide_spacer) {
-                        return cell.point;
-                    }
-                }
-                point
+                self.grid
+                    .iter_from(point)
+                    .find(|cell| !cell.flags.intersects(wide_spacer))
+                    .map_or(point, |cell| cell.point)
             },
             Err(point) => point,
         }


### PR DESCRIPTION
Semantic escape characters occupying two two grid cells were always skipped over, making it impossible to have functional fullwidth characters as part of semantic escape characters.

This patch fixes this by only skipping over fullwidth spacer cells, rather than skipping those cells entirely.

Closes #8188.