### PR TITLE
Ignore cursor color request with default colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Kitty keyboard protocol reporting shifted key codes
 - Broken search with words broken across line boundary on the first character
 - Config import changes not being live reloaded
+- Cursor color requests with default cursor colors
 
 ## 0.13.2
 


### PR DESCRIPTION
Currently when the cursor colors are requested for the default cursor color, Alacritty always responds with #000000. Since this is most likely incorrect, this response is misleading.

Realistically there's very little reason why any application would need to know the color of the (often dynamically changing) default cursor. So instead of always reporting an incorrect black value, this patch just stops reporting values unless the cursor color was explicitly changed.

Closes #8169.