### PR TITLE
Windows app icon to display in old alt+tab on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Config import changes not being live reloaded
 - Cursor color requests with default cursor colors
 - Fullwidth semantic escape characters
+- Windows app icon now displays properly in old alt+tab on Windows
 
 ## 0.13.2
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -31,6 +31,7 @@ use winit::event_loop::ActiveEventLoop;
 use winit::monitor::MonitorHandle;
 #[cfg(windows)]
 use winit::platform::windows::IconExtWindows;
+#[cfg(windows)]
 use winit::platform::windows::WindowAttributesExtWindows;
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::window::{

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -30,9 +30,7 @@ use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event_loop::ActiveEventLoop;
 use winit::monitor::MonitorHandle;
 #[cfg(windows)]
-use winit::platform::windows::{
-    IconExtWindows, WindowAttributesExtWindows,
-};
+use winit::platform::windows::{IconExtWindows, WindowAttributesExtWindows};
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::window::{
     CursorIcon, Fullscreen, ImePurpose, Theme, UserAttentionType, Window as WinitWindow,

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -31,6 +31,7 @@ use winit::event_loop::ActiveEventLoop;
 use winit::monitor::MonitorHandle;
 #[cfg(windows)]
 use winit::platform::windows::IconExtWindows;
+use winit::platform::windows::WindowAttributesExtWindows;
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::window::{
     CursorIcon, Fullscreen, ImePurpose, Theme, UserAttentionType, Window as WinitWindow,
@@ -299,10 +300,12 @@ impl Window {
     #[cfg(windows)]
     pub fn get_platform_window(_: &Identity, window_config: &WindowConfig) -> WindowAttributes {
         let icon = winit::window::Icon::from_resource(IDI_ICON, None);
+        let taskbar_icon = winit::window::Icon::from_resource(IDI_ICON, None);
 
         WinitWindow::default_attributes()
             .with_decorations(window_config.decorations != Decorations::None)
             .with_window_icon(icon.ok())
+            .with_taskbar_icon(taskbar_icon.ok())
     }
 
     #[cfg(target_os = "macos")]

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -30,9 +30,9 @@ use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event_loop::ActiveEventLoop;
 use winit::monitor::MonitorHandle;
 #[cfg(windows)]
-use winit::platform::windows::IconExtWindows;
-#[cfg(windows)]
-use winit::platform::windows::WindowAttributesExtWindows;
+use winit::platform::windows::{
+    IconExtWindows, WindowAttributesExtWindows,
+};
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::window::{
     CursorIcon, Fullscreen, ImePurpose, Theme, UserAttentionType, Window as WinitWindow,
@@ -301,12 +301,11 @@ impl Window {
     #[cfg(windows)]
     pub fn get_platform_window(_: &Identity, window_config: &WindowConfig) -> WindowAttributes {
         let icon = winit::window::Icon::from_resource(IDI_ICON, None);
-        let taskbar_icon = winit::window::Icon::from_resource(IDI_ICON, None);
 
         WinitWindow::default_attributes()
             .with_decorations(window_config.decorations != Decorations::None)
-            .with_window_icon(icon.ok())
-            .with_taskbar_icon(taskbar_icon.ok())
+            .with_window_icon(icon.as_ref().ok().cloned())
+            .with_taskbar_icon(icon.ok())
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Feature: Able to see the windows app icon in the old alt+tab dialog on Windows.