### PR TITLE
Add config option `scrolling.unit`

### DIFF
--- a/alacritty/src/config/scrolling.rs
+++ b/alacritty/src/config/scrolling.rs
@@ -7,16 +7,18 @@ use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
 pub const MAX_SCROLLBACK_LINES: u32 = 100_000;
 
 /// Struct for scrolling related settings.
-#[derive(ConfigDeserialize, Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Copy, Clone, Debug, PartialEq)]
 pub struct Scrolling {
-    pub multiplier: u8,
+    pub multiplier: f32,
+
+    pub unit: ScrollingUnit,
 
     history: ScrollingHistory,
 }
 
 impl Default for Scrolling {
     fn default() -> Self {
-        Self { multiplier: 3, history: Default::default() }
+        Self { multiplier: 3.0, unit: Default::default(), history: Default::default() }
     }
 }
 
@@ -24,6 +26,13 @@ impl Scrolling {
     pub fn history(self) -> u32 {
         self.history.0
     }
+}
+
+#[derive(ConfigDeserialize, Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ScrollingUnit {
+    #[default]
+    Line,
+    Page,
 }
 
 #[derive(SerdeReplace, Copy, Clone, Debug, PartialEq, Eq)]

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -36,6 +36,7 @@ use alacritty_terminal::vi_mode::ViMotion;
 use alacritty_terminal::vte::ansi::{ClearMode, Handler};
 
 use crate::clipboard::Clipboard;
+use crate::config::scrolling::ScrollingUnit;
 #[cfg(target_os = "macos")]
 use crate::config::window::Decorations;
 use crate::config::{Action, BindingMode, MouseAction, SearchAction, UiConfig, ViAction};
@@ -699,7 +700,11 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     }
 
     pub fn mouse_wheel_input(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
-        let multiplier = self.ctx.config().scrolling.multiplier;
+        let lines = match self.ctx.config().scrolling.unit {
+            ScrollingUnit::Page => self.ctx.size_info().screen_lines(),
+            ScrollingUnit::Line => 1,
+        };
+        let multiplier = self.ctx.config().scrolling.multiplier * lines as f32;
         match delta {
             MouseScrollDelta::LineDelta(columns, lines) => {
                 let new_scroll_px_x = columns * self.ctx.size_info().cell_width();

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -228,11 +228,17 @@ Limited to _100000_.
 
 	Default: _10000_
 
-*multiplier* = _<integer>_
+*unit* = _"Line"_ | _"Page"_
 
-	Number of line scrolled for every input scroll increment.
+	The unit of measurement for input scroll increments.
 
-	Default: _3_
+	Default: _"Line"_
+
+*multiplier* = _<float>_
+
+	Number of units scrolled for every input scroll increment.
+
+	Default: _3.0_
 
 # FONT
 


### PR DESCRIPTION
Can be either "Line" or "Page", with the latter causing the multiplier to multiply against the number of lines in the viewport.

For example, if `alacritty.toml` contains the following:
```toml
[scrolling]
unit = "Page"
multiplier = 0.9
```
Each input scroll increment will be 90% of a page.