### PR TITLE
Remove startup notify variables only for shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Cursor color requests with default cursor colors
 - Fullwidth semantic escape characters
 - Windows app icon now displays properly in old alt+tab on Windows
+- Alacritty not being properly activated with startup notify
 
 ## 0.13.2
 

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -98,10 +98,6 @@ pub fn setup_env() {
 
     // Advertise 24-bit color support.
     env::set_var("COLORTERM", "truecolor");
-
-    // Prevent child processes from inheriting startup notification env.
-    env::remove_var("DESKTOP_STARTUP_ID");
-    env::remove_var("XDG_ACTIVATION_TOKEN");
 }
 
 /// Check if a terminfo entry exists on the system.

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -227,6 +227,10 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
         builder.env(key, value);
     }
 
+    // Prevent child processes from inheriting linux-specific startup notification env.
+    builder.env_remove("XDG_ACTIVATION_TOKEN");
+    builder.env_remove("DESKTOP_STARTUP_ID");
+
     unsafe {
         builder.pre_exec(move || {
             // Create a new process group.


### PR DESCRIPTION
This will prevent issues when `setup_env` from `alacritty_terminal` will remove potentially useful variables for users of the library.

Fixes #8202.