### PR TITLE
Fix highlight invalidation on grid scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Fullwidth semantic escape characters
 - Windows app icon now displays properly in old alt+tab on Windows
 - Alacritty not being properly activated with startup notify
+- Invalid URL highlights after terminal scrolling
 
 ## 0.13.2
 

--- a/alacritty/src/display/damage.rs
+++ b/alacritty/src/display/damage.rs
@@ -189,6 +189,15 @@ impl FrameDamage {
             self.lines.push(LineDamageBounds::undamaged(line, num_cols));
         }
     }
+
+    /// Check if a range is damaged.
+    #[inline]
+    pub fn intersects(&self, start: Point<usize>, end: Point<usize>) -> bool {
+        self.full
+            || self.lines[start.line].left <= start.column
+            || self.lines[end.line].right >= end.column
+            || (start.line + 1..end.line).any(|line| self.lines[line].is_damaged())
+    }
 }
 
 /// Convert viewport `y` coordinate to [`Rect`] damage coordinate.

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -137,7 +137,7 @@ pub struct Grid<T> {
     max_scroll_limit: usize,
 }
 
-impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
+impl<T: GridCell + Default + PartialEq> Grid<T> {
     pub fn new(lines: usize, columns: usize, max_scroll_limit: usize) -> Grid<T> {
         Grid {
             raw: Storage::with_capacity(lines, columns),
@@ -356,7 +356,7 @@ impl<T> Grid<T> {
     /// Reset a visible region within the grid.
     pub fn reset_region<D, R: RangeBounds<Line>>(&mut self, bounds: R)
     where
-        T: ResetDiscriminant<D> + GridCell + Clone + Default,
+        T: ResetDiscriminant<D> + GridCell + Default,
         D: PartialEq,
     {
         let start = match bounds.start_bound() {
@@ -392,7 +392,7 @@ impl<T> Grid<T> {
     #[inline]
     pub fn initialize_all(&mut self)
     where
-        T: GridCell + Clone + Default,
+        T: GridCell + Default,
     {
         // Remove all cached lines to clear them of any content.
         self.truncate();

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -9,7 +9,7 @@ use crate::term::cell::{Flags, ResetDiscriminant};
 use crate::grid::row::Row;
 use crate::grid::{Dimensions, Grid, GridCell};
 
-impl<T: GridCell + Default + PartialEq + Clone> Grid<T> {
+impl<T: GridCell + Default + PartialEq> Grid<T> {
     /// Resize the grid's width and/or height.
     pub fn resize<D>(&mut self, reflow: bool, lines: usize, columns: usize)
     where

--- a/alacritty_terminal/src/grid/row.rs
+++ b/alacritty_terminal/src/grid/row.rs
@@ -30,7 +30,7 @@ impl<T: PartialEq> PartialEq for Row<T> {
     }
 }
 
-impl<T: Clone + Default> Row<T> {
+impl<T: Default> Row<T> {
     /// Create a new terminal row.
     ///
     /// Ideally the `template` should be `Copy` in all performance sensitive scenarios.

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -66,7 +66,7 @@ impl<T> Storage<T> {
     #[inline]
     pub fn with_capacity(visible_lines: usize, columns: usize) -> Storage<T>
     where
-        T: Clone + Default,
+        T: Default,
     {
         // Initialize visible lines; the scrollback buffer is initialized dynamically.
         let mut inner = Vec::with_capacity(visible_lines);
@@ -79,7 +79,7 @@ impl<T> Storage<T> {
     #[inline]
     pub fn grow_visible_lines(&mut self, next: usize)
     where
-        T: Clone + Default,
+        T: Default,
     {
         // Number of lines the buffer needs to grow.
         let additional_lines = next - self.visible_lines;
@@ -125,7 +125,7 @@ impl<T> Storage<T> {
     #[inline]
     pub fn initialize(&mut self, additional_rows: usize, columns: usize)
     where
-        T: Clone + Default,
+        T: Default,
     {
         if self.len + additional_rows > self.inner.len() {
             self.rezero();

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -124,9 +124,7 @@ impl ResetDiscriminant<Color> for Cell {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CellExtra {
     zerowidth: Vec<char>,
-
     underline_color: Option<Color>,
-
     hyperlink: Option<Hyperlink>,
 }
 


### PR DESCRIPTION
This fixes an issue where hints highlighted by vi or mouse cursor would
produce an underline on the incorrect line since the highlights only
store the initial match boundaries without accounting for new content
scrolling the terminal.

This patch takes the approach of adding a marker ID to one cell in the
hint, allowing us to verify with a single cell check whether the
contents of the hint boundaries could have changed.

This works pretty reliably, but comes with a set of drawbacks. It is
possible that only parts of the URL change, which means the single
stored cell ID is insufficient to track changes. The new ID method is
also somewhat leaking `alacritty` implementation details into
`alacritty_terminal`, but while dangerous if misused, I think the new
method could also be useful to other consumers of `alacritty_terminal`.
This also only does invalidation, so no attempt is made to re-check the
new content at the cursor location.

An alternative implementation that doesn't touch `alacritty_terminal`
would be to create some sort of hash for the hint, however this could
come with a bigger performance impact since hints can potentially be
very long.

Closes #7737.

---

This obviously isn't a perfect patch; it aims at providing an efficient solution for a very minor problem, so the focus is mostly on not harming performance. However I do think the resulting UX isn't too bad either. If there's any better ideas, please do let me know.