### PR TITLE
Change ctrl+shift+u to ctrl+shift+o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Moved config options `import`, `working_directory`, `live_config_reload`, and `ipc_socket`
     to the new `general` section
 - Moved config option `shell` to `terminal.shell`
+- `ctrl+shift+u` binding to open links to `ctrl+shift+o` to avoid collisions with IMEs
 
 ### Fixed
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -282,7 +282,7 @@ impl Default for Hints {
                 mouse: Some(HintMouse { enabled: true, mods: Default::default() }),
                 binding: Some(HintBinding {
                     key: BindingKey::Keycode {
-                        key: Key::Character("u".into()),
+                        key: Key::Character("o".into()),
                         location: KeyLocation::Standard,
                     },
                     mods: ModsWrapper(ModifiersState::SHIFT | ModifiersState::CONTROL),

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -730,7 +730,7 @@ hyperlinks      = _true_++
 post_processing = _true_++
 persist         = _false_++
 mouse.enabled   = _true_++
-binding         = { key = _"U"_, mods = _"Control|Shift"_ }++
+binding         = { key = _"O"_, mods = _"Control|Shift"_ }++
 regex = _"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^\\u0000-\\u001F\\u007F-\\u009F<>\\"\\\\s{-}\\\\^⟨⟩`]+"_
 
 # KEYBOARD


### PR DESCRIPTION
Avoid collisions with IMEs by using ctrl+shift+o. ctrl+shift+u is bound to open unicode input in a lot of IMEs by default meaning that users won't ever see the url hints UI.