### PR TITLE
Add unicode 16 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Support relative path imports from config files
 - `alacritty migrate` support for TOML configuration changes
+- Support for Unicode 16 characters
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "tempfile",
  "toml",
  "toml_edit 0.22.21",
- "unicode-width",
+ "unicode-width-16",
  "windows-sys 0.52.0",
  "winit",
  "xdg",
@@ -108,7 +108,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
- "unicode-width",
+ "unicode-width-16",
  "vte",
  "windows-sys 0.52.0",
 ]
@@ -2011,10 +2011,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.13"
+name = "unicode-width-16"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -40,7 +40,7 @@ serde_yaml = "0.9.25"
 tempfile = "3.12.0"
 toml = "0.8.2"
 toml_edit = "0.22.21"
-unicode-width = "0.1"
+unicode-width = { package = "unicode-width-16", version = "0.1.0" }
 winit = { version = "0.30.4", default-features = false, features = ["rwh_06", "serde"] }
 
 [build-dependencies]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 parking_lot = "0.12.0"
 polling = "3.0.0"
 regex-automata = "0.4.3"
-unicode-width = "0.1"
+unicode-width = { package = "unicode-width-16", version = "0.1.0" }
 vte = { version = "0.13.0", default-features = false, features = ["ansi", "serde"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 


### PR DESCRIPTION
This fixes issues in width calculation for symbols added in Unicode version 16.

Since the upstream unicode-width crate has not been updated yet, this makes use of the temporary unicode-width-16 version to support Unicode 16 with Alacritty 0.14.0.