### PR TITLE
Add headless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Support relative path imports from config files
 - `alacritty migrate` support for TOML configuration changes
 - Support for Unicode 16 characters
+- Headless mode using `alacritty --daemon`
 
 ### Changed
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -26,7 +26,7 @@ pub struct Options {
     pub print_events: bool,
 
     /// Generates ref test.
-    #[clap(long)]
+    #[clap(long, conflicts_with("daemon"))]
     pub ref_test: bool,
 
     /// X11 window ID to embed Alacritty within (decimal or hexadecimal with "0x" prefix).

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -62,6 +62,10 @@ pub struct Options {
     #[clap(short, conflicts_with("quiet"), action = ArgAction::Count)]
     verbose: u8,
 
+    /// Do not spawn an initial window.
+    #[clap(long)]
+    pub daemon: bool,
+
     /// CLI options for config overrides.
     #[clap(skip)]
     pub config_options: ParsedOptions,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -170,8 +170,7 @@ impl Processor {
         let mut config = self.config.clone();
         config = config_overrides.override_config_rc(config);
 
-        #[allow(unused_mut)]
-        let mut window_context = WindowContext::additional(
+        let window_context = WindowContext::additional(
             gl_config,
             event_loop,
             self.proxy.clone(),

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -342,12 +342,9 @@ impl ApplicationHandler<Event> for Processor {
                     if let Err(err) = self.create_initial_window(event_loop) {
                         self.initial_window_error = Some(err);
                         event_loop.exit();
-                        return;
                     }
-                } else {
-                    if let Err(err) = self.create_window(event_loop, options.clone()) {
-                        error!("Could not open window: {:?}", err);
-                    }
+                } else if let Err(err) = self.create_window(event_loop, options.clone()) {
+                    error!("Could not open window: {:?}", err);
                 }
             },
             // Process events affecting all windows.

--- a/alacritty/src/ipc.rs
+++ b/alacritty/src/ipc.rs
@@ -20,13 +20,13 @@ const ALACRITTY_SOCKET_ENV: &str = "ALACRITTY_SOCKET";
 
 /// Create an IPC socket.
 pub fn spawn_ipc_socket(options: &Options, event_proxy: EventLoopProxy<Event>) -> Option<PathBuf> {
-    // Create the IPC socket and export its path as env variable if necessary.
+    // Create the IPC socket and export its path as env.
+
     let socket_path = options.socket.clone().unwrap_or_else(|| {
         let mut path = socket_dir();
         path.push(format!("{}-{}.sock", socket_prefix(), process::id()));
         path
     });
-    env::set_var(ALACRITTY_SOCKET_ENV, socket_path.as_os_str());
 
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
@@ -35,6 +35,11 @@ pub fn spawn_ipc_socket(options: &Options, event_proxy: EventLoopProxy<Event>) -
             return None;
         },
     };
+
+    env::set_var(ALACRITTY_SOCKET_ENV, socket_path.as_os_str());
+    if options.daemon {
+        println!("ALACRITTY_SOCKET={}; export ALACRITTY_SOCKET", socket_path.display());
+    }
 
     // Spawn a thread to listen on the IPC socket.
     thread::spawn_named("socket listener", move || {

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -9,7 +9,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use glutin::config::GetGlConfig;
+use glutin::config::Config as GlutinConfig;
 use glutin::display::GetGlDisplay;
 #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
 use glutin::platform::x11::X11GlConfigExt;
@@ -119,18 +119,14 @@ impl WindowContext {
 
     /// Create additional context with the graphics platform other windows are using.
     pub fn additional(
-        &self,
+        gl_config: &GlutinConfig,
         event_loop: &ActiveEventLoop,
         proxy: EventLoopProxy<Event>,
         config: Rc<UiConfig>,
         options: WindowOptions,
         config_overrides: ParsedOptions,
     ) -> Result<Self, Box<dyn Error>> {
-        // Get any window and take its GL config and display to build a new context.
-        let (gl_display, gl_config) = {
-            let gl_context = self.display.gl_context();
-            (gl_context.display(), gl_context.config())
-        };
+        let gl_display = gl_config.display();
 
         let mut identity = config.window.identity.clone();
         options.window_identity.override_identity_config(&mut identity);

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -143,11 +143,8 @@ impl WindowContext {
 
         // Create context.
         let raw_window_handle = window.raw_window_handle();
-        let gl_context = renderer::platform::create_gl_context(
-            &gl_display,
-            &gl_config,
-            Some(raw_window_handle),
-        )?;
+        let gl_context =
+            renderer::platform::create_gl_context(&gl_display, gl_config, Some(raw_window_handle))?;
 
         // Check if new window will be opened as a tab.
         #[cfg(target_os = "macos")]

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -30,6 +30,7 @@ _alacritty() {
 '--ref-test[Generates ref test]' \
 '(-v)*-q[Reduces the level of verbosity (the min level is -qq)]' \
 '(-q)*-v[Increases the level of verbosity (the max level is -vvv)]' \
+'--daemon[Do not spawn an initial window]' \
 '--hold[Remain open after child process exit]' \
 '-h[Print help]' \
 '--help[Print help]' \

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -27,7 +27,7 @@ _alacritty() {
 '*-o+[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION: ' \
 '*--option=[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION: ' \
 '--print-events[Print all events to STDOUT]' \
-'--ref-test[Generates ref test]' \
+'(--daemon)--ref-test[Generates ref test]' \
 '(-v)*-q[Reduces the level of verbosity (the min level is -qq)]' \
 '(-q)*-v[Increases the level of verbosity (the max level is -vvv)]' \
 '--daemon[Do not spawn an initial window]' \

--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -61,7 +61,7 @@ _alacritty() {
 
     case "${cmd}" in
         alacritty)
-            opts="-q -v -e -T -o -h -V --print-events --ref-test --embed --config-file --socket --working-directory --hold --command --title --class --option --help --version msg migrate help"
+            opts="-q -v -e -T -o -h -V --print-events --ref-test --embed --config-file --socket --daemon --working-directory --hold --command --title --class --option --help --version msg migrate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_alacritty_global_optspecs
-	string join \n print-events ref-test embed= config-file= socket= q v working-directory= hold e/command= T/title= class= o/option= h/help V/version
+	string join \n print-events ref-test embed= config-file= socket= q v daemon working-directory= hold e/command= T/title= class= o/option= h/help V/version
 end
 
 function __fish_alacritty_needs_command
@@ -36,6 +36,7 @@ complete -c alacritty -n "__fish_alacritty_needs_command" -l print-events -d 'Pr
 complete -c alacritty -n "__fish_alacritty_needs_command" -l ref-test -d 'Generates ref test'
 complete -c alacritty -n "__fish_alacritty_needs_command" -s q -d 'Reduces the level of verbosity (the min level is -qq)'
 complete -c alacritty -n "__fish_alacritty_needs_command" -s v -d 'Increases the level of verbosity (the max level is -vvv)'
+complete -c alacritty -n "__fish_alacritty_needs_command" -l daemon -d 'Do not spawn an initial window'
 complete -c alacritty -n "__fish_alacritty_needs_command" -l hold -d 'Remain open after child process exit'
 complete -c alacritty -n "__fish_alacritty_needs_command" -s h -l help -d 'Print help'
 complete -c alacritty -n "__fish_alacritty_needs_command" -s V -l version -d 'Print version'

--- a/extra/man/alacritty.1.scd
+++ b/extra/man/alacritty.1.scd
@@ -21,7 +21,7 @@ set of features with high performance.
 
 	Remain open after child process exits.
 
-*--embed*
+*--daemon*
 
 	Do not spawn an initial window.
 

--- a/extra/man/alacritty.1.scd
+++ b/extra/man/alacritty.1.scd
@@ -21,6 +21,10 @@ set of features with high performance.
 
 	Remain open after child process exits.
 
+*--embed*
+
+	Do not spawn an initial window.
+
 *--print-events*
 
 	Print all events to STDOUT.


### PR DESCRIPTION
This patch adds a daemon mode to Alacritty which allows starting the Alacritty process without spawning an initial window.

While this does not provide any significant advantage over the existing behavior of always spawning a window, it does integrate nicer with some setups and is a pretty trivial addition.

---

@kchibisov I still don't think this provides a big benefit, but especially with the macos requests it seems simple enough to just provide a mode that runs in the background. While this does not implement the macos process behavior exactly, it should at least allow people to get a similar functionality.