### PR TITLE
Remove `dbg!` in Migration Command

### DIFF
--- a/alacritty/src/migrate/mod.rs
+++ b/alacritty/src/migrate/mod.rs
@@ -175,7 +175,6 @@ fn move_value(document: &mut DocumentMut, origin: &[&str], target: &[&str]) -> R
             None => return Ok(()),
         };
 
-        dbg!(&key);
         origin_key = Some(key);
         origin_item = item;
 


### PR DESCRIPTION
Just a small oversight with the new migration tweaks.