### PR TITLE
Fix pipe FD leak on X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "x11-clipboard"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98785a09322d7446e28a13203d2cae1059a0dd3dfb32cb06d0a225f023d8286"
+checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
 dependencies = [
  "libc",
  "x11rb",


### PR DESCRIPTION
The pipe was not using O_CLOEXEC, so it was leaked into the child.

Fixes #8249.