### PR TITLE
Revert "Add unicode 16 support"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Support relative path imports from config files
 - `alacritty migrate` support for TOML configuration changes
-- Support for Unicode 16 characters
 - Headless mode using `alacritty --daemon`
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "tempfile",
  "toml",
  "toml_edit 0.22.21",
- "unicode-width-16",
+ "unicode-width",
  "windows-sys 0.52.0",
  "winit",
  "xdg",
@@ -108,7 +108,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
- "unicode-width-16",
+ "unicode-width",
  "vte",
  "windows-sys 0.52.0",
 ]
@@ -2011,10 +2011,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
-name = "unicode-width-16"
-version = "0.1.0"
+name = "unicode-width"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -40,7 +40,7 @@ serde_yaml = "0.9.25"
 tempfile = "3.12.0"
 toml = "0.8.2"
 toml_edit = "0.22.21"
-unicode-width = { package = "unicode-width-16", version = "0.1.0" }
+unicode-width = "0.1"
 winit = { version = "0.30.4", default-features = false, features = ["rwh_06", "serde"] }
 
 [build-dependencies]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 parking_lot = "0.12.0"
 polling = "3.0.0"
 regex-automata = "0.4.3"
-unicode-width = { package = "unicode-width-16", version = "0.1.0" }
+unicode-width = "0.1"
 vte = { version = "0.13.0", default-features = false, features = ["ansi", "serde"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 


### PR DESCRIPTION
This reverts commit 5dca7a85e7d8e98f8e770c17af8efb442c2277d0.

---

It won't be until February until a new glibc version with support for Unicode 16 is released. For optimal support it's probably best to wait until at least the latest stable glibc version has support.