### PR TITLE
Bump development version to 0.15.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
-## 0.14.0-dev
+## 0.15.0-dev
+
+## 0.14.0
 
 ### Packaging
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty"
-version = "0.14.0-dev"
+version = "0.15.0-dev"
 dependencies = [
  "ahash",
  "alacritty_config",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_config"
-version = "0.2.1-dev"
+version = "0.2.3-dev"
 dependencies = [
  "alacritty_config_derive",
  "log",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_config_derive"
-version = "0.2.3-dev"
+version = "0.2.5-dev"
 dependencies = [
  "alacritty_config",
  "log",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.24.1-dev"
+version = "0.24.2-dev"
 dependencies = [
  "base64",
  "bitflags 2.6.0",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.14.0-dev"
+version = "0.15.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"
@@ -12,15 +12,15 @@ rust-version = "1.74.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.24.1-dev"
+version = "0.24.2-dev"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"
-version = "0.2.3-dev"
+version = "0.2.5-dev"
 
 [dependencies.alacritty_config]
 path = "../alacritty_config"
-version = "0.2.1-dev"
+version = "0.2.3-dev"
 
 [dependencies]
 ahash = { version = "0.8.6", features = ["no-rng"] }

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.14.0-dev" Manufacturer="Alacritty" InstallerVersion="200">
+   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.15.0-dev" Manufacturer="Alacritty" InstallerVersion="200">
       <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
       <Icon Id="AlacrittyIco" SourceFile=".\alacritty\windows\alacritty.ico" />
       <WixVariable Id="WixUILicenseRtf" Value=".\alacritty\windows\wix\license.rtf" />

--- a/alacritty_config/Cargo.toml
+++ b/alacritty_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_config"
-version = "0.2.1-dev"
+version = "0.2.3-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT OR Apache-2.0"
 description = "Alacritty configuration abstractions"
@@ -15,5 +15,5 @@ serde = "1.0.163"
 toml = "0.8.2"
 
 [dev-dependencies]
-alacritty_config_derive = { version = "0.2.3-dev", path = "../alacritty_config_derive" }
+alacritty_config_derive = { version = "0.2.5-dev", path = "../alacritty_config_derive" }
 serde = { version = "1.0.163", features = ["derive"] }

--- a/alacritty_config_derive/Cargo.toml
+++ b/alacritty_config_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_config_derive"
-version = "0.2.3-dev"
+version = "0.2.5-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT OR Apache-2.0"
 description = "Failure resistant deserialization derive"
@@ -19,7 +19,7 @@ syn = { version = "2.0.16", features = ["derive", "parsing", "proc-macro", "prin
 
 [dev-dependencies.alacritty_config]
 path = "../alacritty_config"
-version = "0.2.1-dev"
+version = "0.2.3-dev"
 
 [dev-dependencies]
 log = "0.4.11"

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -8,7 +8,21 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.24.1-dev
+## 0.24.2-dev
+
+## 0.24.1
+
+### Changed
+
+- Shell RCs are no longer sourced on macOs
+
+### Fixed
+
+- Semantic search handling of fullwidth characters
+- Inline search ignoring line wrapping flag
+- Clearing of `XDG_ACTIVATION_TOKEN` and `DESKTOP_STARTUP_ID` in the main process
+- FD leaks when closing PTYs on Unix
+- Crash when ConPTY creation failed
 
 ## 0.24.0
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.24.1-dev"
+version = "0.24.2-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.14.0-dev</string>
+  <string>0.15.0-dev</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>


### PR DESCRIPTION
This is only an update to the development version and does not represent a stable release.

---

Should be merged after https://github.com/alacritty/alacritty/pull/8251, since that will be pulled for another RC.