### PR TITLE
Do not depend on serde when the feature is not enabled

### DIFF
--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = "0.12.0"
 polling = "3.0.0"
 regex-automata = "0.4.3"
 unicode-width = "0.1"
-vte = { version = "0.13.0", default-features = false, features = ["ansi", "serde"] }
+vte = { version = "0.13.0", default-features = false, features = ["ansi"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Currently, `alacritty_terminal` will pull in `serde` even when the `serde` feature is not enabled. This PR fixes that.