### PR TITLE
Add g++ dependency to install doc

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ to build Alacritty. Here's an apt command that should install all of them. If
 something is still found to be missing, please open an issue.
 
 ```sh
-apt install cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
+apt install cmake g++ pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
 ```
 
 #### Arch Linux


### PR DESCRIPTION
Hey, 

Just a quick fix of the docs: 
As noted in #8048 and #8134, `g++` is missing from the list of dependencies.
