### PR TITLE
man(5): align example [terminal] with doc

### DIFF
--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -601,9 +601,8 @@ This section documents the *[terminal]* table of the configuration file.
 Windows: _"powershell"_
 
 	Example:
-		*[shell]*++
-program = _"/bin/zsh"_++
-args = [_"-l"_]
+		*[terminal]*++
+shell = { program = _"/bin/zsh"_, args = [_"-l"_] }
 
 *osc52* = _"Disabled"_ | _"OnlyCopy"_ | _"OnlyPaste"_ | _"CopyPaste"_
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -601,8 +601,7 @@ This section documents the *[terminal]* table of the configuration file.
 Windows: _"powershell"_
 
 	Example:
-		*[terminal]*++
-shell = { program = _"/bin/zsh"_, args = [_"-l"_] }
+		*shell* = { program = _"/bin/zsh"_, args = [_"-l"_] }
 
 *osc52* = _"Disabled"_ | _"OnlyCopy"_ | _"OnlyPaste"_ | _"CopyPaste"_
 


### PR DESCRIPTION
Don't know if this is the proper way to suggest a really small fix that doesn't even touch upon any functionality, but since I noticed that today, I figured I'd just try.