### PR TITLE
Add focus option to create-window command on macOS

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -300,6 +300,11 @@ pub struct WindowOptions {
     /// The window tabbing identifier to use when building a window.
     pub window_tabbing_id: Option<String>,
 
+    #[cfg(target_os = "macos")]
+    #[clap(long)]
+    /// Focus the window after creation.
+    pub focus: bool,
+
     /// Override configuration file options [example: 'cursor.style="Beam"'].
     #[clap(short = 'o', long, num_args = 1..)]
     option: Vec<String>,

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -33,6 +33,7 @@ use alacritty_terminal::term::{
 };
 use alacritty_terminal::vte::ansi::{CursorShape, NamedColor};
 
+use crate::cli::WindowOptions;
 use crate::config::font::Font;
 use crate::config::window::Dimensions;
 #[cfg(not(windows))]
@@ -399,6 +400,7 @@ impl Display {
         window: Window,
         gl_context: NotCurrentContext,
         config: &UiConfig,
+        _options: &WindowOptions,
         _tabbed: bool,
     ) -> Result<Display, Error> {
         let raw_window_handle = window.raw_window_handle();
@@ -483,6 +485,10 @@ impl Display {
         }
 
         window.set_visible(true);
+        #[cfg(target_os = "macos")]
+        if _options.focus {
+            window.focus_window();
+        }
 
         #[allow(clippy::single_match)]
         #[cfg(not(windows))]

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -224,6 +224,12 @@ impl Window {
         self.window.set_visible(visibility);
     }
 
+    #[cfg(target_os = "macos")]
+    #[inline]
+    pub fn focus_window(&self) {
+        self.window.focus_window();
+    }
+
     /// Set the window title.
     #[inline]
     pub fn set_title(&mut self, title: String) {

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -112,7 +112,7 @@ impl WindowContext {
         let gl_context =
             renderer::platform::create_gl_context(&gl_display, &gl_config, raw_window_handle)?;
 
-        let display = Display::new(window, gl_context, &config, false)?;
+        let display = Display::new(window, gl_context, &config, &options, false)?;
 
         Self::new(display, config, options, proxy)
     }
@@ -152,7 +152,7 @@ impl WindowContext {
         #[cfg(not(target_os = "macos"))]
         let tabbed = false;
 
-        let display = Display::new(window, gl_context, &config, tabbed)?;
+        let display = Display::new(window, gl_context, &config, &options, tabbed)?;
 
         let mut window_context = Self::new(display, config, options, proxy)?;
 


### PR DESCRIPTION
This resolves alacritty/alacritty#8282

- Ran `cargo test` locally with no errors.
- Built and ran on macOS. 
- Tested `--focus` command on macOS and got the desired results.