### PR TITLE
On macOS, explicitly focus the new window in case Alacritty isn't the active app, otherwise it won't get focus automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.15.0-dev
 
+### Changed
+
+- Automatically focus new windows on macOS, even if no Alacritty windows are currently focused
+
 ### Fixed
 
 - Mouse/Vi cursor hint highlighting broken on the terminal cursor line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ### Changed
 
-- Automatically focus new windows on macOS, even if no Alacritty windows are currently focused
+- Always focus new windows on macOS
 
 ### Fixed
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -484,8 +484,7 @@ impl Display {
 
         window.set_visible(true);
 
-        // On macOS, explicitly focus the new window in case Alacritty isn't the active app,
-        // otherwise it won't get focus automatically.
+        // Automatically focus new windows, even if no Alacritty windows are currently focused.
         #[cfg(target_os = "macos")]
         window.focus_window();
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -484,7 +484,7 @@ impl Display {
 
         window.set_visible(true);
 
-        // Automatically focus new windows, even if no Alacritty windows are currently focused.
+        // Always focus new windows, even if no Alacritty window is currently focused.
         #[cfg(target_os = "macos")]
         window.focus_window();
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -484,6 +484,11 @@ impl Display {
 
         window.set_visible(true);
 
+        // On macOS, explicitly focus the new window in case Alacritty isn't the active app,
+        // otherwise it won't get focus automatically.
+        #[cfg(target_os = "macos")]
+        window.focus_window();
+
         #[allow(clippy::single_match)]
         #[cfg(not(windows))]
         if !_tabbed {

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -224,6 +224,12 @@ impl Window {
         self.window.set_visible(visibility);
     }
 
+    #[cfg(target_os = "macos")]
+    #[inline]
+    pub fn focus_window(&self) {
+        self.window.focus_window();
+    }
+
     /// Set the window title.
     #[inline]
     pub fn set_title(&mut self, title: String) {


### PR DESCRIPTION
On macOS, explicitly focus the new window in case Alacritty isn't the active app, otherwise it won't get focus automatically.

This is continuing from [PR !8283](https://github.com/alacritty/alacritty/pull/8283) for issue #8283

On macOS, when [`window.set_visible(true)`](https://github.com/alacritty/alacritty/blob/d552c6b251d199b4913754dd25fca330f87651fd/alacritty/src/display/mod.rs#L485) is called, winit's [AppKit delegate](https://github.com/rust-windowing/winit/blob/d3207a8d76c7b6a6283dee36c19c1dac4e378fa7/src/platform_impl/apple/appkit/window_delegate.rs#L921) calls [`NSWindow.makeKeyAndOrderFront`](https://developer.apple.com/documentation/appkit/nswindow/1419208-makekeyandorderfront) which moves the window to the front of the application's screen list and makes it the key window for that application. If the application itself is already active, then great, the window has focus. If the application isn't active, then the window doesn't get focus.

This change explicitly focuses the window.

I kept `focus_window` in `alacritty::display::window::Window` and called it from `alacritty::display::Display::new`; cramming the call to `self.window.focus_window()` in `set_visible` didn't seem appropriate. Setting `.with_active(true)` on `window_attributes` has no effect.

`make app` and `cargo test` succeed on macOS 15.1. Manual tested and the change seems to work as expected.  
`make binary`  and `cargo test` succeed on Ubuntu 24.04. Manual tested and the app still works.