### PR TITLE
Use `objc2`, `objc2-foundation` and `objc2-app-kit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,6 @@ dependencies = [
  "bitflags 2.6.0",
  "clap",
  "clap_complete",
- "cocoa 0.26.0",
  "copypasta",
  "crossfont",
  "dirs",
@@ -52,7 +51,9 @@ dependencies = [
  "libc",
  "log",
  "notify",
- "objc",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "parking_lot",
  "png",
  "serde",
@@ -404,25 +405,9 @@ checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
 dependencies = [
  "bitflags 1.3.2",
  "block",
- "cocoa-foundation 0.1.2",
- "core-foundation 0.9.4",
- "core-graphics 0.23.2",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
-dependencies = [
- "bitflags 2.6.0",
- "block",
- "cocoa-foundation 0.2.0",
- "core-foundation 0.10.0",
- "core-graphics 0.24.0",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
  "foreign-types",
  "libc",
  "objc",
@@ -436,22 +421,8 @@ checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
  "bitflags 1.3.2",
  "block",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
-dependencies = [
- "bitflags 2.6.0",
- "block",
- "core-foundation 0.10.0",
- "core-graphics-types 0.2.0",
+ "core-foundation",
+ "core-graphics-types",
  "libc",
  "objc",
 ]
@@ -506,16 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,21 +489,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.10.0",
- "core-graphics-types 0.2.0",
+ "core-foundation",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -554,18 +502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.10.0",
+ "core-foundation",
  "libc",
 ]
 
@@ -575,8 +512,8 @@ version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
- "core-foundation 0.9.4",
- "core-graphics 0.23.2",
+ "core-foundation",
+ "core-graphics",
  "foreign-types",
  "libc",
 ]
@@ -611,10 +548,10 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44e28d120f3c9254800ea53349b09cbb45ac1f15f09215011a16241ae0289bc"
 dependencies = [
- "cocoa 0.25.0",
- "core-foundation 0.9.4",
+ "cocoa",
+ "core-foundation",
  "core-foundation-sys",
- "core-graphics 0.23.2",
+ "core-graphics",
  "core-text",
  "dwrote",
  "foreign-types",
@@ -884,7 +821,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cfg_aliases",
  "cgl",
- "core-foundation 0.9.4",
+ "core-foundation",
  "dispatch",
  "glutin_egl_sys",
  "glutin_glx_sys",
@@ -2601,8 +2538,8 @@ dependencies = [
  "calloop",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation 0.9.4",
- "core-graphics 0.23.2",
+ "core-foundation",
+ "core-graphics",
  "cursor-icon",
  "dpi",
  "js-sys",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -56,8 +56,19 @@ xdg = "2.5.0"
 png = { version = "0.17.5", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26.0"
-objc = "0.2.2"
+objc2 = "0.5.2"
+objc2-foundation = { version = "0.2.2", default-features = false, features = [
+    "std",
+    "NSString",
+    "NSLocale",
+] }
+objc2-app-kit = { version = "0.2.2", default-features = false, features = [
+    "std",
+    "NSColorSpace",
+    "NSResponder",
+    "NSView",
+    "NSWindow",
+] }
 
 [target.'cfg(windows)'.dependencies]
 dirs = "5.0.1"

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -20,9 +20,7 @@ use std::fmt::{self, Display, Formatter};
 
 #[cfg(target_os = "macos")]
 use {
-    cocoa::appkit::NSColorSpace,
-    cocoa::base::{id, nil, NO, YES},
-    objc::{msg_send, sel, sel_impl},
+    objc2_app_kit::{NSColorSpace, NSView},
     winit::platform::macos::{OptionAsAlt, WindowAttributesExtMacOS, WindowExtMacOS},
 };
 
@@ -451,16 +449,12 @@ impl Window {
     /// This prevents rendering artifacts from showing up when the window is transparent.
     #[cfg(target_os = "macos")]
     pub fn set_has_shadow(&self, has_shadows: bool) {
-        let ns_view = match self.raw_window_handle() {
-            RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr() as id,
+        let view = match self.raw_window_handle() {
+            RawWindowHandle::AppKit(handle) => unsafe { handle.ns_view.cast::<NSView>().as_ref() },
             _ => return,
         };
 
-        let value = if has_shadows { YES } else { NO };
-        unsafe {
-            let ns_window: id = msg_send![ns_view, window];
-            let _: id = msg_send![ns_window, setHasShadow: value];
-        }
+        view.window().unwrap().setHasShadow(has_shadows);
     }
 
     /// Select tab at the given `index`.
@@ -495,13 +489,12 @@ impl Window {
 
 #[cfg(target_os = "macos")]
 fn use_srgb_color_space(window: &WinitWindow) {
-    let ns_view = match window.window_handle().unwrap().as_raw() {
-        RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr() as id,
+    let view = match window.window_handle().unwrap().as_raw() {
+        RawWindowHandle::AppKit(handle) => unsafe { handle.ns_view.cast::<NSView>().as_ref() },
         _ => return,
     };
 
     unsafe {
-        let ns_window: id = msg_send![ns_view, window];
-        let _: () = msg_send![ns_window, setColorSpace: NSColorSpace::sRGBColorSpace(nil)];
+        view.window().unwrap().setColorSpace(Some(&NSColorSpace::sRGBColorSpace()));
     }
 }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -21,6 +21,7 @@ use std::fmt::{self, Display, Formatter};
 #[cfg(target_os = "macos")]
 use {
     objc2_app_kit::{NSColorSpace, NSView},
+    objc2_foundation::is_main_thread,
     winit::platform::macos::{OptionAsAlt, WindowAttributesExtMacOS, WindowExtMacOS},
 };
 
@@ -450,7 +451,10 @@ impl Window {
     #[cfg(target_os = "macos")]
     pub fn set_has_shadow(&self, has_shadows: bool) {
         let view = match self.raw_window_handle() {
-            RawWindowHandle::AppKit(handle) => unsafe { handle.ns_view.cast::<NSView>().as_ref() },
+            RawWindowHandle::AppKit(handle) => {
+                assert!(is_main_thread());
+                unsafe { handle.ns_view.cast::<NSView>().as_ref() }
+            },
             _ => return,
         };
 
@@ -490,7 +494,10 @@ impl Window {
 #[cfg(target_os = "macos")]
 fn use_srgb_color_space(window: &WinitWindow) {
     let view = match window.window_handle().unwrap().as_raw() {
-        RawWindowHandle::AppKit(handle) => unsafe { handle.ns_view.cast::<NSView>().as_ref() },
+        RawWindowHandle::AppKit(handle) => {
+            assert!(is_main_thread());
+            unsafe { handle.ns_view.cast::<NSView>().as_ref() }
+        },
         _ => return,
     };
 

--- a/alacritty/src/macos/locale.rs
+++ b/alacritty/src/macos/locale.rs
@@ -66,7 +66,7 @@ fn system_locale() -> String {
             if let Some(country_code) = locale.countryCode() {
                 format!("{}_{}.UTF-8", language_code, country_code)
             } else {
-                // Fall back to en_US in case the country code is not available
+                // Fall back to en_US in case the country code is not available.
                 "en_US.UTF-8".into()
             }
         } else {

--- a/alacritty/src/macos/locale.rs
+++ b/alacritty/src/macos/locale.rs
@@ -1,13 +1,12 @@
 #![allow(clippy::let_unit_value)]
 
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
-use std::{env, slice, str};
+use std::{env, str};
 
 use libc::{setlocale, LC_ALL, LC_CTYPE};
 use log::debug;
-use objc::runtime::{Class, Object};
-use objc::{msg_send, sel, sel_impl};
+use objc2::sel;
+use objc2_foundation::{NSLocale, NSObjectProtocol};
 
 const FALLBACK_LOCALE: &str = "UTF-8";
 
@@ -50,9 +49,7 @@ pub fn set_locale_environment() {
 /// Determine system locale based on language and country code.
 fn system_locale() -> String {
     unsafe {
-        let locale_class = Class::get("NSLocale").unwrap();
-        let locale: *const Object = msg_send![locale_class, currentLocale];
-        let _: () = msg_send![locale_class, release];
+        let locale = NSLocale::currentLocale();
 
         // `localeIdentifier` returns extra metadata with the locale (including currency and
         // collator) on newer versions of macOS. This is not a valid locale, so we use
@@ -61,38 +58,15 @@ fn system_locale() -> String {
         // https://developer.apple.com/documentation/foundation/nslocale/1416263-localeidentifier?language=objc
         // https://developer.apple.com/documentation/foundation/nslocale/1643060-countrycode?language=objc
         // https://developer.apple.com/documentation/foundation/nslocale/1643026-languagecode?language=objc
-        let is_language_code_supported: bool =
-            msg_send![locale, respondsToSelector: sel!(languageCode)];
-        let is_country_code_supported: bool =
-            msg_send![locale, respondsToSelector: sel!(countryCode)];
-        let locale_id = if is_language_code_supported && is_country_code_supported {
-            let language_code: *const Object = msg_send![locale, languageCode];
-            let language_code_str = nsstring_as_str(language_code).to_owned();
-            let _: () = msg_send![language_code, release];
-
-            let country_code: *const Object = msg_send![locale, countryCode];
-            let country_code_str = nsstring_as_str(country_code).to_owned();
-            let _: () = msg_send![country_code, release];
-
-            format!("{}_{}.UTF-8", &language_code_str, &country_code_str)
+        let is_language_code_supported: bool = locale.respondsToSelector(sel!(languageCode));
+        let is_country_code_supported: bool = locale.respondsToSelector(sel!(countryCode));
+        if is_language_code_supported && is_country_code_supported {
+            let language_code = locale.languageCode();
+            #[allow(deprecated)]
+            let country_code = locale.countryCode().unwrap();
+            format!("{}_{}.UTF-8", language_code, country_code)
         } else {
-            let identifier: *const Object = msg_send![locale, localeIdentifier];
-            let identifier_str = nsstring_as_str(identifier).to_owned();
-            let _: () = msg_send![identifier, release];
-
-            identifier_str + ".UTF-8"
-        };
-
-        let _: () = msg_send![locale, release];
-
-        locale_id
+            locale.localeIdentifier().to_string() + ".UTF-8"
+        }
     }
-}
-
-const UTF8_ENCODING: usize = 4;
-
-unsafe fn nsstring_as_str<'a>(nsstring: *const Object) -> &'a str {
-    let cstr: *const c_char = msg_send![nsstring, UTF8String];
-    let len: usize = msg_send![nsstring, lengthOfBytesUsingEncoding: UTF8_ENCODING];
-    str::from_utf8(slice::from_raw_parts(cstr as *const u8, len)).unwrap()
 }

--- a/alacritty/src/macos/locale.rs
+++ b/alacritty/src/macos/locale.rs
@@ -63,8 +63,12 @@ fn system_locale() -> String {
         if is_language_code_supported && is_country_code_supported {
             let language_code = locale.languageCode();
             #[allow(deprecated)]
-            let country_code = locale.countryCode().unwrap();
-            format!("{}_{}.UTF-8", language_code, country_code)
+            if let Some(country_code) = locale.countryCode() {
+                format!("{}_{}.UTF-8", language_code, country_code)
+            } else {
+                // Fall back to en_US in case the country code is not available
+                "en_US.UTF-8".into()
+            }
         } else {
             locale.localeIdentifier().to_string() + ".UTF-8"
         }


### PR DESCRIPTION
`objc2` is the successor to `objc` and `cocoa`. Concretely, it makes memory management much easier, as Alacritty no longer has to worry about `release` calls, since `objc2` handles those internally.

This matches https://github.com/alacritty/copypasta/pull/74 and https://github.com/alacritty/crossfont/pull/69 (both of which have yet to be released), and is also used by Winit internally.