### PR TITLE
Fix vi motion with wide semantic escape chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Mouse/Vi cursor hint highlighting broken on the terminal cursor line
 - Hint launcher opening arbitrary text, when terminal content changed while opening
+- `SemanticRight`/`SemanticLeft` vi motions breaking with wide semantic escape characters
 
 ## 0.14.0
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -930,6 +930,11 @@ impl<T> Term<T> {
         &self.config.semantic_escape_chars
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_semantic_escape_chars(&mut self, semantic_escape_chars: &str) {
+        self.config.semantic_escape_chars = semantic_escape_chars.into();
+    }
+
     /// Active terminal cursor style.
     ///
     /// While vi mode is active, this will automatically return the vi mode cursor style.


### PR DESCRIPTION
This patch fixes an issue where the semantic vi motion commands `SemanticRight` and `SemanticLeft` were not behaving as expected when a fullwidth character was used as a semantic character.

Closes #8314.

---

This is probably not a perfect patch, but it's the simplest solution I found and it adds a new test to prevent this issue from getting reintroduced in the future. So I think it should bring us closer to a "bug free" implementation at least.