### PR TITLE
refactor: replace static with const for global constants

### DIFF
--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -44,7 +44,7 @@ use crate::display::SizeInfo;
 
 /// Window icon for `_NET_WM_ICON` property.
 #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
-static WINDOW_ICON: &[u8] = include_bytes!("../../extra/logo/compat/alacritty-term.png");
+const WINDOW_ICON: &[u8] = include_bytes!("../../extra/logo/compat/alacritty-term.png");
 
 /// This should match the definition of IDI_ICON from `alacritty.rc`.
 #[cfg(windows)]

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -228,8 +228,8 @@ impl RenderLines {
 }
 
 /// Shader sources for rect rendering program.
-static RECT_SHADER_F: &str = include_str!("../../res/rect.f.glsl");
-static RECT_SHADER_V: &str = include_str!("../../res/rect.v.glsl");
+const RECT_SHADER_F: &str = include_str!("../../res/rect.f.glsl");
+const RECT_SHADER_V: &str = include_str!("../../res/rect.v.glsl");
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -20,8 +20,8 @@ use super::{
 };
 
 // Shader source.
-static TEXT_SHADER_F: &str = include_str!("../../../res/gles2/text.f.glsl");
-static TEXT_SHADER_V: &str = include_str!("../../../res/gles2/text.v.glsl");
+const TEXT_SHADER_F: &str = include_str!("../../../res/gles2/text.f.glsl");
+const TEXT_SHADER_V: &str = include_str!("../../../res/gles2/text.v.glsl");
 
 #[derive(Debug)]
 pub struct Gles2Renderer {

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -20,8 +20,8 @@ use super::{
 };
 
 // Shader source.
-pub static TEXT_SHADER_F: &str = include_str!("../../../res/glsl3/text.f.glsl");
-static TEXT_SHADER_V: &str = include_str!("../../../res/glsl3/text.v.glsl");
+pub const TEXT_SHADER_F: &str = include_str!("../../../res/glsl3/text.f.glsl");
+const TEXT_SHADER_V: &str = include_str!("../../../res/glsl3/text.v.glsl");
 
 /// Maximum items to be drawn in a batch.
 const BATCH_MAX: usize = 0x1_0000;


### PR DESCRIPTION
Before:
```
Results:

  cursor_motion (495 samples @ 1.73 MiB):
    19.7ms avg (90% < 24ms) +-2.17ms

  dense_cells (163 samples @ 5.01 MiB):
    61.19ms avg (90% < 67ms) +-5.13ms

  light_cells (562 samples @ 1.11 MiB):
    17.32ms avg (90% < 21ms) +-1.89ms

  scrolling (71 samples @ 1 MiB):
    109.82ms avg (90% < 141ms) +-19.55ms

  scrolling_bottom_region (93 samples @ 1 MiB):
    107.1ms avg (90% < 133ms) +-16.06ms

  scrolling_bottom_small_region (93 samples @ 1 MiB):
    108.02ms avg (90% < 131ms) +-22.71ms

  scrolling_fullscreen (191 samples @ 1 MiB):
    17.69ms avg (90% < 19ms) +-1.64ms

  scrolling_top_region (84 samples @ 1 MiB):
    119.04ms avg (90% < 154ms) +-26.35ms

  scrolling_top_small_region (89 samples @ 1 MiB):
    111.92ms avg (90% < 143ms) +-20.32ms

  unicode (588 samples @ 1.06 MiB):
    16.52ms avg (90% < 19ms) +-1.63ms
```

After:
```
Results:

  cursor_motion (528 samples @ 1.73 MiB):
    18.48ms avg (90% < 21ms) +-2.02ms

  dense_cells (168 samples @ 5.01 MiB):
    59.29ms avg (90% < 68ms) +-5.56ms

  light_cells (586 samples @ 1.11 MiB):
    16.57ms avg (90% < 20ms) +-1.8ms

  scrolling (68 samples @ 1 MiB):
    117.19ms avg (90% < 156ms) +-21.57ms

  scrolling_bottom_region (87 samples @ 1 MiB):
    115.37ms avg (90% < 148ms) +-19.87ms

  scrolling_bottom_small_region (96 samples @ 1 MiB):
    105.03ms avg (90% < 128ms) +-14.85ms

  scrolling_fullscreen (188 samples @ 1 MiB):
    18.11ms avg (90% < 22ms) +-1.9ms

  scrolling_top_region (94 samples @ 1 MiB):
    106.95ms avg (90% < 136ms) +-16.9ms

  scrolling_top_small_region (97 samples @ 1 MiB):
    103.91ms avg (90% < 123ms) +-14.81ms

  unicode (576 samples @ 1.06 MiB):
    16.9ms avg (90% < 19ms) +-1.5ms
```