### PR TITLE
Bump winit to 0.30.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,9 +2526,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.6"
+version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d72dfa0f47e429290cd0d236884ca02f22dbd5dd33a43ad2b8bf4d79b6c18"
+checksum = "dba50bc8ef4b6f1a75c9274fb95aa9a8f63fbc66c56f391bd85cf68d51e7b1a3"
 dependencies = [
  "ahash",
  "android-activity",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -41,7 +41,7 @@ tempfile = "3.12.0"
 toml = "0.8.2"
 toml_edit = "0.22.21"
 unicode-width = "0.1"
-winit = { version = "0.30.6", default-features = false, features = ["rwh_06", "serde"] }
+winit = { version = "0.30.7", default-features = false, features = ["rwh_06", "serde"] }
 
 [build-dependencies]
 gl_generator = "0.14.0"


### PR DESCRIPTION
Fixes double input on X11 after update to 0.30.6.