### PR TITLE
Support CSI n I to move the cursor forward n tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Added
 
 - Config option `window.level = "AlwaysOnTop"` to force Alacritty to always be the toplevel window
+- Support `CSI n I` to move the cursor forward by n tabs
 
 ### Changed
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1377,6 +1377,7 @@ impl<T: EventListener> Handler for Term<T> {
             let cell = self.grid.cursor_cell();
             if cell.c == ' ' {
                 cell.c = c;
+                self.damage_cursor();
             }
 
             loop {
@@ -1586,7 +1587,9 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_forward_tabs(&mut self, count: u16) {
-        trace!("[unimplemented] Moving forward {} tabs", count);
+        trace!("Moving forward {} tabs", count);
+
+        self.put_tab(count);
     }
 
     #[inline]


### PR DESCRIPTION
This adds support for the CSI n I sequence to move the cursor forward n tabs. This sequence behaves exactly like sending tab characters, but allows for moving the cursor forward multiple tabs at once.