### PR TITLE
Don't start semantic/line selection when control is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Changed
 
 - Always focus new windows on macOS
+- Don't switch to semantic/line selection when control is pressed
 
 ### Fixed
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1183,17 +1183,13 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     /// Expand the selection to the current mouse cursor position.
     #[inline]
     fn expand_selection(&mut self) {
+        let control = self.modifiers().state().control_key();
         let selection_type = match self.mouse().click_state {
-            ClickState::Click => {
-                if self.modifiers().state().control_key() {
-                    SelectionType::Block
-                } else {
-                    SelectionType::Simple
-                }
-            },
+            ClickState::None => return,
+            _ if control => SelectionType::Block,
+            ClickState::Click => SelectionType::Simple,
             ClickState::DoubleClick => SelectionType::Semantic,
             ClickState::TripleClick => SelectionType::Lines,
-            ClickState::None => return,
         };
 
         // Load mouse point, treating message bar and padding as the closest cell.

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -637,6 +637,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     /// Handle left click selection and vi mode cursor movement.
     fn on_left_click(&mut self, point: Point) {
         let side = self.ctx.mouse().cell_side;
+        let control = self.ctx.modifiers().state().control_key();
 
         match self.ctx.mouse().click_state {
             ClickState::Click => {
@@ -646,21 +647,21 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 self.ctx.clear_selection();
 
                 // Start new empty selection.
-                if self.ctx.modifiers().state().control_key() {
+                if control {
                     self.ctx.start_selection(SelectionType::Block, point, side);
                 } else {
                     self.ctx.start_selection(SelectionType::Simple, point, side);
                 }
             },
-            ClickState::DoubleClick => {
+            ClickState::DoubleClick if !control => {
                 self.ctx.mouse_mut().block_hint_launcher = true;
                 self.ctx.start_selection(SelectionType::Semantic, point, side);
             },
-            ClickState::TripleClick => {
+            ClickState::TripleClick if !control => {
                 self.ctx.mouse_mut().block_hint_launcher = true;
                 self.ctx.start_selection(SelectionType::Lines, point, side);
             },
-            ClickState::None => (),
+            _ => (),
         };
 
         // Move vi mode cursor to mouse click position.


### PR DESCRIPTION
Changing block selection to regular semantic one doesn't feel intuitive, thus don't start it when user has control pressed.