### PR TITLE
Fix desktop file name in AppStream metadata

### DIFF
--- a/extra/linux/org.alacritty.Alacritty.appdata.xml
+++ b/extra/linux/org.alacritty.Alacritty.appdata.xml
@@ -30,4 +30,5 @@
   <url type="bugtracker">https://github.com/alacritty/alacritty/issues</url>
   <update_contact>https://github.com/alacritty/alacritty/blob/master/CONTRIBUTING.md#contact</update_contact>
   <developer_name>Christian Duerr</developer_name>
+  <launchable type="desktop-id">Alacritty.desktop</launchable>
 </component>


### PR DESCRIPTION
App id does not match the actual desktop file name. Add [launchable](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable) tag to actually match it.

Fixes Alacritty being missing in GNOME Software / KDE Discover in Fedora and other distributions.