### PR TITLE
Fix licenses in AppStream metadata

### DIFF
--- a/extra/linux/org.alacritty.Alacritty.appdata.xml
+++ b/extra/linux/org.alacritty.Alacritty.appdata.xml
@@ -4,8 +4,8 @@
   <id>org.alacritty.Alacritty</id>
   <!-- Translators: The application name -->
   <name>Alacritty</name>
-  <project_license>APACHE-2.0</project_license>
-  <metadata_license>APACHE-2.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <metadata_license>Apache-2.0</metadata_license>
   <!-- Translators: The application's summary / tagline -->
   <summary>A fast, cross-platform, OpenGL terminal emulator</summary>
   <description>


### PR DESCRIPTION
One more problem that makes the AppStream metadata file invalid. The correct Apache license name is a case sensitive "Apache-2.0". Also changed the metadata license to "CC0-1.0" since that is the license that is in 99% cases used for the metadata (the AppStream file). I can change it to "Apache-2.0" if you want, but I have never seen this license in AppStream metadata_license of any project. **edit:** Actually, "Apache-2.0" seems to be an invalid metadata license according to the appstreamcli validator. **another edit:** Changed it to "Apache-2.0" for now, see [this thread](https://github.com/alacritty/alacritty/pull/8391#pullrequestreview-2528169033).

More information about the usage of licenses in AppStream:
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-project_license
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-metadata_license

Before this PR:
```
$ appstreamcli validate org.alacritty.Alacritty.appdata.xml
W: org.alacritty.Alacritty:7: spdx-license-unknown APACHE-2.0
E: org.alacritty.Alacritty:8: metadata-license-invalid APACHE-2.0
I: org.alacritty.Alacritty:32: developer-name-tag-deprecated
I: org.alacritty.Alacritty:~: content-rating-missing
I: org.alacritty.Alacritty:~: developer-info-missing

✘ Validation failed: errors: 1, warnings: 1, infos: 3, pedantic: 2
```

After this PR:
```
$ appstreamcli validate org.alacritty.Alacritty.appdata.xml
I: org.alacritty.Alacritty:32: developer-name-tag-deprecated
I: org.alacritty.Alacritty:~: content-rating-missing
I: org.alacritty.Alacritty:~: developer-info-missing

✔ Validation was successful: infos: 3, pedantic: 2
```

(Don't worry about the developer_name tag deprecation for now. It is still supported and will be for years to come.)