### PR TITLE
Avoid relative image links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <img alt="Alacritty - A fast, cross-platform, OpenGL terminal emulator"
-       src="extra/promo/alacritty-readme.png">
+       src="https://raw.githubusercontent.com/alacritty/alacritty/master/extra/promo/alacritty-readme.png">
 </p>
 
 ## About


### PR DESCRIPTION
This should fix the image on crates.io.

See https://github.com/rust-lang/crates.io/issues/5318