### PR TITLE
Bump development version to 0.16.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
-## 0.15.0-dev
+## 0.16.0-dev
+
+## 0.15.0
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty"
-version = "0.15.0-dev"
+version = "0.16.0-dev"
 dependencies = [
  "ahash",
  "alacritty_config",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.24.2-dev"
+version = "0.24.3-dev"
 dependencies = [
  "base64",
  "bitflags 2.6.0",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.15.0-dev"
+version = "0.16.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"
@@ -12,7 +12,7 @@ rust-version = "1.74.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.24.2-dev"
+version = "0.24.3-dev"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.15.0-dev" Manufacturer="Alacritty" InstallerVersion="200">
+   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.16.0-dev" Manufacturer="Alacritty" InstallerVersion="200">
       <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
       <Icon Id="AlacrittyIco" SourceFile=".\alacritty\windows\alacritty.ico" />
       <WixVariable Id="WixUILicenseRtf" Value=".\alacritty\windows\wix\license.rtf" />

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -8,7 +8,9 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.24.2-dev
+## 0.24.3-dev
+
+## 0.24.2
 
 ### Added
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.24.2-dev"
+version = "0.24.3-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.15.0-dev</string>
+  <string>0.16.0-dev</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>


### PR DESCRIPTION
This is only an update to the development version and does not represent a stable release.