### PR TITLE
fix(docs): FIX Config Key for Shell Optoon

### DIFF
--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -612,7 +612,7 @@ This section documents the *[terminal]* table of the configuration file.
 Windows: _"powershell"_
 
 	Example:
-		*shell* = { program = _"/bin/zsh"_, args = [_"-l"_] }
+		*terminal.shell* = { program = _"/bin/zsh"_, args = [_"-l"_] }
 
 *osc52* = _"Disabled"_ | _"OnlyCopy"_ | _"OnlyPaste"_ | _"CopyPaste"_
 


### PR DESCRIPTION
https://github.com/alacritty/alacritty/blob/a26174890e2184fa29b68fde7b72de5a566ad711/CHANGELOG.md?plain=1#L57

When I set `shell`, a warning message appeared.
I checked the Change Log and found that it had been changed to `terminal.shell`, so I modified the Example.
