### PR TITLE
Bump VTE to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.24.3-dev"
+version = "0.25.0-dev"
 dependencies = [
  "base64",
  "bitflags 2.6.0",
@@ -2045,23 +2045,23 @@ dependencies = [
 
 [[package]]
 name = "vte"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0b683b20ef64071ff03745b14391751f6beab06a54347885459b77a3f2caa5"
+checksum = "5507b53f7756f79bdb968d038a8f8db570d88028aee3c3cdc20427a8fb3482f4"
 dependencies = [
  "bitflags 2.6.0",
  "cursor-icon",
  "log",
+ "memchr",
  "serde",
- "utf8parse",
  "vte_generate_state_changes",
 ]
 
 [[package]]
 name = "vte_generate_state_changes"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+checksum = "e658bbb246cd98d720db0b7553764f7e841e25d9ac0c9ecfbc09452dc95a8cce"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.74.0"
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.24.3-dev"
+version = "0.25.0-dev"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.24.3-dev"
+version = "0.25.0-dev"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"
@@ -24,7 +24,7 @@ parking_lot = "0.12.0"
 polling = "3.0.0"
 regex-automata = "0.4.3"
 unicode-width = "0.1"
-vte = { version = "0.13.0", default-features = false, features = ["ansi"] }
+vte = { version = "0.14.0", default-features = false, features = ["ansi"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -17,8 +17,8 @@ use polling::{Event as PollingEvent, Events, PollMode};
 use crate::event::{self, Event, EventListener, WindowSize};
 use crate::sync::FairMutex;
 use crate::term::Term;
-use crate::vte::ansi;
 use crate::{thread, tty};
+use vte::ansi;
 
 /// Max bytes to read from the PTY before forced terminal synchronization.
 pub(crate) const READ_BUFFER_SIZE: usize = 0x10_0000;
@@ -151,9 +151,7 @@ where
             }
 
             // Parse the incoming bytes.
-            for byte in &buf[..unprocessed] {
-                state.parser.advance(&mut **terminal, *byte);
-            }
+            state.parser.advance(&mut **terminal, &buf[..unprocessed]);
 
             processed += unprocessed;
             unprocessed = 0;

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -112,9 +112,7 @@ fn ref_test(dir: &Path) {
     let mut terminal = Term::new(options, &size, Mock);
     let mut parser: ansi::Processor = ansi::Processor::new();
 
-    for byte in recording {
-        parser.advance(&mut terminal, byte);
-    }
+    parser.advance(&mut terminal, &recording);
 
     // Truncate invisible lines from the grid.
     let mut term_grid = terminal.grid().clone();


### PR DESCRIPTION
Since this is a breaking change, it also bumps the alacritty_terminal development version to 0.25.0-dev.