### PR TITLE
Fix cut off wide characters in preedit string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - First daemon mode window ignoring window options passed through CLI
 - Report of Enter/Tab/Backspace in kitty keyboard's report event types mode
 - Crash when pressing certain modifier keys on macOS 15+
+- Cut off wide characters in preedit string
 
 ## 0.14.0
 

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -206,10 +206,10 @@ impl Renderer {
         glyph_cache: &mut GlyphCache,
     ) {
         let mut wide_char_spacer = false;
-        let cells = string_chars.enumerate().map(|(i, character)| {
+        let cells = string_chars.enumerate().filter_map(|(i, character)| {
             let flags = if wide_char_spacer {
                 wide_char_spacer = false;
-                Flags::WIDE_CHAR_SPACER
+                return None;
             } else if character.width() == Some(2) {
                 // The spacer is always following the wide char.
                 wide_char_spacer = true;
@@ -218,7 +218,7 @@ impl Renderer {
                 Flags::empty()
             };
 
-            RenderableCell {
+            Some(RenderableCell {
                 point: Point::new(point.line, point.column + i),
                 character,
                 extra: None,
@@ -227,7 +227,7 @@ impl Renderer {
                 fg,
                 bg,
                 underline: fg,
-            }
+            })
         });
 
         self.draw_cells(size_info, glyph_cache, cells);


### PR DESCRIPTION
The wide char spacers must not be drawn, like we do for regular wide characters.

--

Previous fix just made it harder to repro.