### PR TITLE
Bump vte to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,26 +2045,15 @@ dependencies = [
 
 [[package]]
 name = "vte"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5507b53f7756f79bdb968d038a8f8db570d88028aee3c3cdc20427a8fb3482f4"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "bitflags 2.6.0",
  "cursor-icon",
  "log",
  "memchr",
  "serde",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e658bbb246cd98d720db0b7553764f7e841e25d9ac0c9ecfbc09452dc95a8cce"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = "0.12.0"
 polling = "3.0.0"
 regex-automata = "0.4.3"
 unicode-width = "0.1"
-vte = { version = "0.14.0", default-features = false, features = ["ansi"] }
+vte = { version = "0.14.1", default-features = false, features = ["ansi"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This fixes a crash with partial utf8 input and also speeds up parsing in some cases.