### PR TITLE
Add an option to drain child process output before termination

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -189,7 +189,7 @@ impl TerminalOptions {
             pty_config.shell = Some(command.into());
         }
 
-        pty_config.hold |= self.hold;
+        pty_config.drain_on_exit |= self.hold;
     }
 }
 
@@ -198,7 +198,7 @@ impl From<TerminalOptions> for PtyOptions {
         PtyOptions {
             working_directory: options.working_directory.take(),
             shell: options.command().map(Into::into),
-            hold: options.hold,
+            drain_on_exit: options.hold,
             env: HashMap::new(),
         }
     }

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -130,7 +130,7 @@ impl UiConfig {
         let shell = self.terminal.shell.clone().or_else(|| self.shell.clone()).map(Into::into);
         let working_directory =
             self.working_directory.clone().or_else(|| self.general.working_directory.clone());
-        PtyOptions { working_directory, shell, hold: false, env: HashMap::new() }
+        PtyOptions { working_directory, shell, drain_on_exit: false, env: HashMap::new() }
     }
 
     /// Generate key bindings for all keyboard hints.

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -109,6 +109,9 @@ pub struct Window {
     /// Flag indicating whether redraw was requested.
     pub requested_redraw: bool,
 
+    /// Hold the window when terminal exits.
+    pub hold: bool,
+
     window: WinitWindow,
 
     /// Current window title.
@@ -127,7 +130,7 @@ impl Window {
         event_loop: &ActiveEventLoop,
         config: &UiConfig,
         identity: &Identity,
-        _options: &mut WindowOptions,
+        options: &mut WindowOptions,
         #[rustfmt::skip]
         #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
         x11_visual: Option<X11VisualInfo>,
@@ -139,7 +142,7 @@ impl Window {
             #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
             x11_visual,
             #[cfg(target_os = "macos")]
-            &_options.window_tabbing_id.take(),
+            &options.window_tabbing_id.take(),
         );
 
         if let Some(position) = config.window.position {
@@ -148,7 +151,7 @@ impl Window {
         }
 
         #[cfg(not(any(target_os = "macos", windows)))]
-        if let Some(token) = _options
+        if let Some(token) = options
             .activation_token
             .take()
             .map(ActivationToken::from_raw)
@@ -199,6 +202,7 @@ impl Window {
         let is_x11 = matches!(window.window_handle().unwrap().as_raw(), RawWindowHandle::Xlib(_));
 
         Ok(Self {
+            hold: options.terminal_options.hold,
             requested_redraw: false,
             title: identity.title,
             current_mouse_cursor,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -4,6 +4,7 @@ use crate::ConfigMonitor;
 use glutin::config::GetGlConfig;
 use std::borrow::Cow;
 use std::cmp::min;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::error::Error;
 use std::ffi::OsStr;
@@ -380,9 +381,14 @@ impl ApplicationHandler<Event> for Processor {
             },
             (EventType::Terminal(TerminalEvent::Exit), Some(window_id)) => {
                 // Remove the closed terminal.
-                let window_context = match self.windows.remove(window_id) {
-                    Some(window_context) => window_context,
-                    None => return,
+                let window_context = match self.windows.entry(*window_id) {
+                    // Don't exit when terminal exits if user asked to hold the window.
+                    Entry::Occupied(window_context)
+                        if !window_context.get().display.window.hold =>
+                    {
+                        window_context.remove()
+                    },
+                    _ => return,
                 };
 
                 // Unschedule pending events.
@@ -1793,7 +1799,11 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
             },
             WinitEvent::WindowEvent { event, .. } => {
                 match event {
-                    WindowEvent::CloseRequested => self.ctx.terminal.exit(),
+                    WindowEvent::CloseRequested => {
+                        // User asked to hold the window, so no need to hold it.
+                        self.ctx.window().hold = false;
+                        self.ctx.terminal.exit();
+                    },
                     WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                         let old_scale_factor =
                             mem::replace(&mut self.ctx.window().scale_factor, scale_factor);

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1800,7 +1800,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
             WinitEvent::WindowEvent { event, .. } => {
                 match event {
                     WindowEvent::CloseRequested => {
-                        // User asked to hold the window, so no need to hold it.
+                        // User asked to close the window, so no need to hold it.
                         self.ctx.window().hold = false;
                         self.ctx.terminal.exit();
                     },

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -324,7 +324,10 @@ impl<T: EventListener> Execute<T> for Action {
             #[cfg(not(target_os = "macos"))]
             Action::Hide => ctx.window().set_visible(false),
             Action::Minimize => ctx.window().set_minimized(true),
-            Action::Quit => ctx.terminal_mut().exit(),
+            Action::Quit => {
+                ctx.window().hold = false;
+                ctx.terminal_mut().exit();
+            },
             Action::IncreaseFontSize => ctx.change_font_size(FONT_SIZE_STEP),
             Action::DecreaseFontSize => ctx.change_font_size(-FONT_SIZE_STEP),
             Action::ResetFontSize => ctx.reset_font_size(),

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -212,7 +212,7 @@ impl WindowContext {
             Arc::clone(&terminal),
             event_proxy.clone(),
             pty,
-            pty_config.hold,
+            pty_config.drain_on_exit,
             config.debug.ref_test,
         )?;
 

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -8,7 +8,11 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.24.3-dev
+## 0.25.0-dev
+
+### Changed
+
+- Replaced `Options::hold` with `Options::drain_on_exit` that drains, but doesn't hold, since holding could be easily done by user
 
 ## 0.24.2
 

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Replaced `Options::hold` with `Options::drain_on_exit` that drains, but doesn't hold, since holding could be easily done by user
+- Replaced `Options::hold` with `Options::drain_on_exit` that drains, but doesn't hold, since holding can be done outside of alacritty_terminal
 
 ## 0.24.2
 

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -28,8 +28,8 @@ pub struct Options {
     /// Shell startup directory.
     pub working_directory: Option<PathBuf>,
 
-    /// Remain open after child process exits.
-    pub hold: bool,
+    /// Drain the child process output before exiting the terminal.
+    pub drain_on_exit: bool,
 
     /// Extra environment variables.
     pub env: HashMap<String, String>,


### PR DESCRIPTION
This PR introduced the ability to drain the PTY output before terminating the child process.
This is needed to fix a [bug](https://github.com/zed-industries/zed/issues/18342) with missing output in Zed editor that programmatically uses `alacritty_terminal` to run the user-defined tasks and report their progress in the terminal.

Previously, Zed used `hold: true` feature, but it led to [incorrect](https://github.com/zed-industries/zed/issues/16590) [behavior](https://github.com/zed-industries/zed/issues/16104) when trying to terminate long-running programs with Ctrl+C.

This behavior replaces the old `hold` behavior that is now expected to be implemented by the user.