### PR TITLE
Dont fail exec() on deleted directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Crash when OpenGL context resets
 - Modifiers being out of sync for fast/synthetic input on X11
+- Spawning program and creating windows while inside the deleted directory
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Crash when OpenGL context resets
 - Modifiers being out of sync for fast/synthetic input on X11
-- Spawning program and creating windows while inside the deleted directory
+- Child process creation failing while inside a deleted directory
 
 ## 0.15.0
 

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -9,6 +9,7 @@ use std::process::{Command, Stdio};
 #[rustfmt::skip]
 #[cfg(not(windows))]
 use {
+    std::env,
     std::error::Error,
     std::os::unix::process::CommandExt,
     std::os::unix::io::RawFd,
@@ -58,16 +59,20 @@ where
 {
     let mut command = Command::new(program);
     command.args(args).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
-    if let Ok(cwd) = foreground_process_path(master_fd, shell_pid) {
-        command.current_dir(cwd);
-    }
+
+    let working_directory = foreground_process_path(master_fd, shell_pid).ok();
     unsafe {
         command
-            .pre_exec(|| {
+            .pre_exec(move || {
                 match libc::fork() {
                     -1 => return Err(io::Error::last_os_error()),
                     0 => (),
                     _ => libc::_exit(0),
+                }
+
+                // Copy foreground process' working directory, ignoring invalid paths.
+                if let Some(working_directory) = working_directory.as_ref() {
+                    let _ = env::set_current_dir(working_directory);
                 }
 
                 if libc::setsid() == -1 {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -844,9 +844,8 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     #[cfg(not(windows))]
     fn create_new_window(&mut self, #[cfg(target_os = "macos")] tabbing_id: Option<String>) {
         let mut options = WindowOptions::default();
-        if let Ok(working_directory) = foreground_process_path(self.master_fd, self.shell_pid) {
-            options.terminal_options.working_directory = Some(working_directory);
-        }
+        options.terminal_options.working_directory =
+            foreground_process_path(self.master_fd, self.shell_pid).ok();
 
         #[cfg(target_os = "macos")]
         {
@@ -875,7 +874,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         match result {
             Ok(_) => debug!("Launched {} with args {:?}", program, args),
-            Err(_) => warn!("Unable to launch {} with args {:?}", program, args),
+            Err(err) => warn!("Unable to launch {program} with args {args:?}: {err}"),
         }
     }
 


### PR DESCRIPTION
See patch notes for details, but the gist is: Linux adds " (deleted)" from `readlink("/proc/pid/cwd")` when it doesn't exist, and that causes problems for executing hints.