### PR TITLE
Add backslash to escape characters for URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Changed
 
 - Error out when socket fails to create with `--daemon`
+- Default URL hints now stop before backslashes
 
 ### Fixed
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -37,7 +37,7 @@ use crate::config::LOG_TARGET_CONFIG;
 /// Regex used for the default URL hint.
 #[rustfmt::skip]
 const URL_REGEX: &str = "(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)\
-                         [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+";
+                         [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`\\\\]+";
 
 #[derive(ConfigDeserialize, Default, Clone, Debug, PartialEq)]
 pub struct UiConfig {

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -740,7 +740,8 @@ post_processing = _true_++
 persist         = _false_++
 mouse.enabled   = _true_++
 binding         = { key = _"O"_, mods = _"Control|Shift"_ }++
-regex = _"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^\\u0000-\\u001F\\u007F-\\u009F<>\\"\\\\s{-}\\\\^⟨⟩`]+"_
+regex =
+_"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^\\u0000-\\u001F\\u007F-\\u009F<>\\"\\\\s{-}\\\\^⟨⟩`]+\\\\\\\\"_
 
 # KEYBOARD
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -741,7 +741,7 @@ persist         = _false_++
 mouse.enabled   = _true_++
 binding         = { key = _"O"_, mods = _"Control|Shift"_ }++
 regex =
-_"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^\\u0000-\\u001F\\u007F-\\u009F<>\\"\\\\s{-}\\\\^⟨⟩`]+\\\\\\\\"_
+_"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file:|git://|ssh:|ftp://)[^\\u0000-\\u001F\\u007F-\\u009F<>\\"\\\\s{-}\\\\^⟨⟩`\\\\\\\\]+"_
 
 # KEYBOARD
 


### PR DESCRIPTION
Backslash added to the default URL regex excludes. URL hints now stop before backslashes.

Fixes: #8456