### PR TITLE
remove use of cstr!

### DIFF
--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -33,14 +33,6 @@ pub use text::{GlyphCache, LoaderApi};
 use shader::ShaderVersion;
 use text::{Gles2Renderer, Glsl3Renderer, TextRenderer};
 
-macro_rules! cstr {
-    ($s:literal) => {
-        // This can be optimized into an no-op with pre-allocated NUL-terminated bytes.
-        unsafe { std::ffi::CStr::from_ptr(concat!($s, "\0").as_ptr().cast()) }
-    };
-}
-pub(crate) use cstr;
-
 /// Whether the OpenGL functions have been loaded.
 pub static GL_FUNS_LOADED: AtomicBool = AtomicBool::new(false);
 

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -15,7 +15,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderError, ShaderProgram, ShaderVersion};
-use crate::renderer::{self, cstr};
+use crate::renderer;
 
 #[derive(Debug, Copy, Clone)]
 pub struct RenderRect {
@@ -447,13 +447,13 @@ impl RectShaderProgram {
         let program = ShaderProgram::new(shader_version, header, RECT_SHADER_V, RECT_SHADER_F)?;
 
         Ok(Self {
-            u_cell_width: program.get_uniform_location(cstr!("cellWidth")).ok(),
-            u_cell_height: program.get_uniform_location(cstr!("cellHeight")).ok(),
-            u_padding_x: program.get_uniform_location(cstr!("paddingX")).ok(),
-            u_padding_y: program.get_uniform_location(cstr!("paddingY")).ok(),
-            u_underline_position: program.get_uniform_location(cstr!("underlinePosition")).ok(),
-            u_underline_thickness: program.get_uniform_location(cstr!("underlineThickness")).ok(),
-            u_undercurl_position: program.get_uniform_location(cstr!("undercurlPosition")).ok(),
+            u_cell_width: program.get_uniform_location(c"cellWidth").ok(),
+            u_cell_height: program.get_uniform_location(c"cellHeight").ok(),
+            u_padding_x: program.get_uniform_location(c"paddingX").ok(),
+            u_padding_y: program.get_uniform_location(c"paddingY").ok(),
+            u_underline_position: program.get_uniform_location(c"underlinePosition").ok(),
+            u_underline_thickness: program.get_uniform_location(c"underlineThickness").ok(),
+            u_undercurl_position: program.get_uniform_location(c"undercurlPosition").ok(),
             program,
         })
     }

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -11,7 +11,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderProgram, ShaderVersion};
-use crate::renderer::{cstr, Error, GlExtensions};
+use crate::renderer::{Error, GlExtensions};
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
@@ -482,8 +482,8 @@ impl TextShaderProgram {
         let program = ShaderProgram::new(shader_version, None, TEXT_SHADER_V, fragment_shader)?;
 
         Ok(Self {
-            u_projection: program.get_uniform_location(cstr!("projection"))?,
-            u_rendering_pass: program.get_uniform_location(cstr!("renderingPass"))?,
+            u_projection: program.get_uniform_location(c"projection")?,
+            u_rendering_pass: program.get_uniform_location(c"renderingPass")?,
             program,
         })
     }

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -11,7 +11,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderProgram, ShaderVersion};
-use crate::renderer::{cstr, Error};
+use crate::renderer::Error;
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
@@ -426,9 +426,9 @@ impl TextShaderProgram {
     pub fn new(shader_version: ShaderVersion) -> Result<TextShaderProgram, Error> {
         let program = ShaderProgram::new(shader_version, None, TEXT_SHADER_V, TEXT_SHADER_F)?;
         Ok(Self {
-            u_projection: program.get_uniform_location(cstr!("projection"))?,
-            u_cell_dim: program.get_uniform_location(cstr!("cellDim"))?,
-            u_rendering_pass: program.get_uniform_location(cstr!("renderingPass"))?,
+            u_projection: program.get_uniform_location(c"projection")?,
+            u_cell_dim: program.get_uniform_location(c"cellDim")?,
+            u_rendering_pass: program.get_uniform_location(c"renderingPass")?,
             program,
         })
     }


### PR DESCRIPTION
In Rust 1.77 a way to create C string literals was introduced with the `c"123"` syntax.

Currently alacritty uses a macro to concatenate a null byte to a `&str` instead of the modern syntax.

None of the changes made should break anything, this is just to modernize the code a bit.
Related issue: https://github.com/alacritty/alacritty/issues/8002