### PR TITLE
Don't clear selection on writing escaped modifier key events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Fixed
 
 - Crash when OpenGL context resets
+- Modifier keys clearing selection with kitty keyboard protocol enabled
 
 ## 0.15.1
 


### PR DESCRIPTION
# Summary

This fixes #8509.

When Kitty's keyboard protocol is used and [Report all keys as escape codes flag (8)](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#report-all-keys-as-escape-codes) is enabled, modifier key escape codes trigger the usual "write something to the terminal" code path, which clears the selection / scrolls down etc.

This behavior is mostly unexpected, and makes some actions more painful to perform (for instance copying text becomes harder: hitting CTRL to begin the CTRL+SHIFT+C sequence clears the selection).

This patch clears the selection only if the key event is **not** a modifier key, which aligns with Alacritty's usual behavior.

# Notes

- I have not included any tests because as far as I can see there's no way to have a proper test: from my attempts ref tests can't handle such niche behavior, but I might be wrong.
- Reviewers should keep in mind that I'm not fluent in Rust, if there's a more elegant / canonical way to write this, please let me know!