### PR TITLE
Account for glyph offset when determining strikeout position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Crash when OpenGL context resets
 - Modifier keys clearing selection with kitty keyboard protocol enabled
+- Strikeout rendering not displaying correctly when `glyph_offset` config is set greater than 0
 
 ## 0.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Crash when OpenGL context resets
 - Modifier keys clearing selection with kitty keyboard protocol enabled
-- Strikeout rendering not displaying correctly when `glyph_offset` config is set greater than 0
+- `glyph_offset.y` not applied to strikeout
 
 ## 0.15.1
 

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -82,7 +82,7 @@ impl GlyphCache {
     pub fn new(mut rasterizer: Rasterizer, font: &Font) -> Result<GlyphCache, crossfont::Error> {
         let (regular, bold, italic, bold_italic) = Self::compute_font_keys(font, &mut rasterizer)?;
 
-        let metrics = GlyphCache::get_offset_adjusted_metrics(&mut rasterizer, font, regular)?;
+        let metrics = GlyphCache::load_font_metrics(&mut rasterizer, font, regular)?;
         Ok(Self {
             cache: Default::default(),
             rasterizer,
@@ -98,8 +98,8 @@ impl GlyphCache {
         })
     }
 
-    // Get metrics adjusted for glyph offset.
-    fn get_offset_adjusted_metrics(
+    // Load font metrics and adjust for glyph offset.
+    fn load_font_metrics(
         rasterizer: &mut Rasterizer,
         font: &Font,
         key: FontKey,
@@ -289,7 +289,7 @@ impl GlyphCache {
         let (regular, bold, italic, bold_italic) =
             Self::compute_font_keys(font, &mut self.rasterizer)?;
 
-        let metrics = GlyphCache::get_offset_adjusted_metrics(&mut self.rasterizer, font, regular)?;
+        let metrics = GlyphCache::load_font_metrics(&mut self.rasterizer, font, regular)?;
 
         info!("Font size changed to {:?} px", font.size().as_px());
 

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -82,13 +82,7 @@ impl GlyphCache {
     pub fn new(mut rasterizer: Rasterizer, font: &Font) -> Result<GlyphCache, crossfont::Error> {
         let (regular, bold, italic, bold_italic) = Self::compute_font_keys(font, &mut rasterizer)?;
 
-        // Need to load at least one glyph for the face before calling metrics.
-        // The glyph requested here ('m' at the time of writing) has no special
-        // meaning.
-        rasterizer.get_glyph(GlyphKey { font_key: regular, character: 'm', size: font.size() })?;
-
-        let metrics = rasterizer.metrics(regular, font.size())?;
-
+        let metrics = GlyphCache::get_offset_adjusted_metrics(&mut rasterizer, font, regular)?;
         Ok(Self {
             cache: Default::default(),
             rasterizer,
@@ -102,6 +96,22 @@ impl GlyphCache {
             metrics,
             builtin_box_drawing: font.builtin_box_drawing,
         })
+    }
+
+    // Get metrics adjusted for glyph offset.
+    fn get_offset_adjusted_metrics(
+        rasterizer: &mut Rasterizer,
+        font: &Font,
+        key: FontKey,
+    ) -> Result<Metrics, crossfont::Error> {
+        // Need to load at least one glyph for the face before calling metrics.
+        // The glyph requested here ('m' at the time of writing) has no special
+        // meaning.
+        rasterizer.get_glyph(GlyphKey { font_key: key, character: 'm', size: font.size() })?;
+
+        let mut metrics = rasterizer.metrics(key, font.size())?;
+        metrics.strikeout_position += font.glyph_offset.y as f32;
+        Ok(metrics)
     }
 
     fn load_glyphs_for_font<L: LoadGlyph>(&mut self, font: FontKey, loader: &mut L) {
@@ -279,12 +289,7 @@ impl GlyphCache {
         let (regular, bold, italic, bold_italic) =
             Self::compute_font_keys(font, &mut self.rasterizer)?;
 
-        self.rasterizer.get_glyph(GlyphKey {
-            font_key: regular,
-            character: 'm',
-            size: font.size(),
-        })?;
-        let metrics = self.rasterizer.metrics(regular, font.size())?;
+        let metrics = GlyphCache::get_offset_adjusted_metrics(&mut self.rasterizer, font, regular)?;
 
         info!("Font size changed to {:?} px", font.size().as_px());
 


### PR DESCRIPTION
It seems the strikeout position is wrong when `font.glyph_offset.y` is not `0`;

Before:
![Screenshot From 2025-03-21 11-30-39](https://github.com/user-attachments/assets/b6229246-4e0f-4a4b-97cc-9b53c5bebee6)

After:
![image](https://github.com/user-attachments/assets/1da6e1e2-eef3-4b17-9365-d8de2acf95f2)


Closes #8524