### PR TITLE
Update crossbeam-channel after yanked 0.5.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Noticed this warning when installing the latest master. Figured I'd see if we want to update now.

```
warning: package `crossbeam-channel v0.5.13` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
```