### PR TITLE
Add option for mouse hints mouse button (issue #8486)

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -830,10 +830,10 @@ impl<'a> Deserialize<'a> for ModeWrapper {
     }
 }
 
-struct MouseButtonWrapper(MouseButton);
+pub struct MouseButtonWrapper(MouseButton);
 
 impl MouseButtonWrapper {
-    fn into_inner(self) -> MouseButton {
+    pub fn into_inner(self) -> MouseButton {
         self.0
     }
 }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -830,10 +830,10 @@ impl<'a> Deserialize<'a> for ModeWrapper {
     }
 }
 
-pub struct MouseButtonWrapper(MouseButton);
+struct MouseButtonWrapper(MouseButton);
 
 impl MouseButtonWrapper {
-    pub fn into_inner(self) -> MouseButton {
+    fn into_inner(self) -> MouseButton {
         self.0
     }
 }

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -19,10 +19,9 @@ use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
 use alacritty_terminal::term::search::RegexSearch;
 
 use crate::config::bell::BellConfig;
-use crate::config::bindings::MouseButtonWrapper;
 use crate::config::bindings::{
     self, Action, Binding, BindingKey, KeyBinding, KeyLocation, ModeWrapper, ModsWrapper,
-    MouseBinding,
+    MouseBinding, MouseButtonWrapper,
 };
 use crate::config::color::Colors;
 use crate::config::cursor::Cursor;

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -19,6 +19,7 @@ use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
 use alacritty_terminal::term::search::RegexSearch;
 
 use crate::config::bell::BellConfig;
+use crate::config::bindings::MouseButtonWrapper;
 use crate::config::bindings::{
     self, Action, Binding, BindingKey, KeyBinding, KeyLocation, ModeWrapper, ModsWrapper,
     MouseBinding,
@@ -283,7 +284,7 @@ impl Default for Hints {
                 mouse: Some(HintMouse {
                     enabled: true,
                     mods: Default::default(),
-                    button: HintMouseButton::default(),
+                    button: Default::default(),
                 }),
                 binding: Some(HintBinding {
                     key: BindingKey::Keycode {
@@ -484,19 +485,17 @@ pub struct HintMouse {
     /// Required mouse modifiers for hint highlighting.
     pub mods: ModsWrapper,
 
-    /// Mouse button to run command.
+    /// Mouse button which triggers the command.
     pub button: HintMouseButton,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HintMouseButton(pub MouseButton);
 impl<'de> Deserialize<'de> for HintMouseButton {
-    // To avoid copy pasting, reusing MouseButtonWrapper Deserialize implementation
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        use crate::config::bindings::MouseButtonWrapper;
         let mouse_button = MouseButtonWrapper::deserialize(deserializer)?.into_inner();
         Ok(Self(mouse_button))
     }

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -477,7 +477,7 @@ pub struct HintMouse {
     /// Required mouse modifiers for hint highlighting.
     pub mods: ModsWrapper,
 
-    /// Mouse button which triggers the command. None to disable mouse hints
+    /// Mouse button which triggers the command.
     #[config(alias = "enabled")]
     pub button: HintMouseButton,
 }

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -280,7 +280,7 @@ impl Default for Hints {
                 action,
                 persist: false,
                 post_processing: true,
-                mouse: Some(HintMouse { mods: Default::default(), button: Default::default() }),
+                mouse: Some(Default::default()),
                 binding: Some(HintBinding {
                     key: BindingKey::Keycode {
                         key: Key::Character("o".into()),

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -12,6 +12,7 @@ use log::{error, warn};
 use serde::de::{Error as SerdeError, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use unicode_width::UnicodeWidthChar;
+use winit::event::MouseButton;
 use winit::keyboard::{Key, ModifiersState};
 
 use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
@@ -279,7 +280,11 @@ impl Default for Hints {
                 action,
                 persist: false,
                 post_processing: true,
-                mouse: Some(HintMouse { enabled: true, mods: Default::default() }),
+                mouse: Some(HintMouse {
+                    enabled: true,
+                    mods: Default::default(),
+                    button: HintMouseButton::default(),
+                }),
                 binding: Some(HintBinding {
                     key: BindingKey::Keycode {
                         key: Key::Character("o".into()),
@@ -478,6 +483,26 @@ pub struct HintMouse {
 
     /// Required mouse modifiers for hint highlighting.
     pub mods: ModsWrapper,
+
+    /// Mouse button to run command.
+    pub button: HintMouseButton,
+}
+
+#[derive(Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
+pub struct HintMouseButton(pub MouseButton);
+
+impl Default for HintMouseButton {
+    fn default() -> Self {
+        Self(MouseButton::Left)
+    }
+}
+
+impl SerdeReplace for HintMouseButton {
+    fn replace(&mut self, value: toml::Value) -> Result<(), Box<dyn Error>> {
+        *self = Self::deserialize(value)?;
+
+        Ok(())
+    }
 }
 
 /// Lazy regex with interior mutability.

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -488,8 +488,19 @@ pub struct HintMouse {
     pub button: HintMouseButton,
 }
 
-#[derive(Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HintMouseButton(pub MouseButton);
+impl<'de> Deserialize<'de> for HintMouseButton {
+    // To avoid copy pasting, reusing MouseButtonWrapper Deserialize implementation
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use crate::config::bindings::MouseButtonWrapper;
+        let mouse_button = MouseButtonWrapper::deserialize(deserializer)?.into_inner();
+        Ok(Self(mouse_button))
+    }
+}
 
 impl Default for HintMouseButton {
     fn default() -> Self {

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -227,9 +227,8 @@ impl HintMatch {
     }
 
     /// Returns the mouse button that is associated with the hint.
-    /// Defaults to MouseButton::Left if lf.hint.mouse is None
-    pub fn mouse_button(&self) -> MouseButton {
-        self.hint.mouse.map_or(MouseButton::Left, |hint_mouse| hint_mouse.button.0)
+    pub fn mouse_button(&self) -> Option<MouseButton> {
+        self.hint.mouse.and_then(|hint_mouse| hint_mouse.button.0)
     }
 
     /// Get the text content of the hint match.
@@ -404,7 +403,7 @@ pub fn highlighted_at<T>(
     config.hints.enabled.iter().find_map(|hint| {
         // Check if all required modifiers are pressed.
         let highlight = hint.mouse.map_or(false, |mouse| {
-            mouse.enabled
+            mouse.enabled()
                 && mouse_mods.contains(mouse.mods.0)
                 && (!mouse_mode || mouse_mods.contains(ModifiersState::SHIFT))
         });

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -5,6 +5,7 @@ use std::iter;
 use std::rc::Rc;
 
 use ahash::RandomState;
+use winit::event::MouseButton;
 use winit::keyboard::ModifiersState;
 
 use alacritty_terminal::grid::{BidirectionalIterator, Dimensions};
@@ -223,6 +224,13 @@ impl HintMatch {
 
     pub fn hyperlink(&self) -> Option<&Hyperlink> {
         self.hyperlink.as_ref()
+    }
+
+    pub fn get_hint_mouse_button(&self) -> MouseButton {
+        match self.hint.mouse {
+            None => MouseButton::Left,
+            Some(c) => c.button.0,
+        }
     }
 
     /// Get the text content of the hint match.

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -226,11 +226,10 @@ impl HintMatch {
         self.hyperlink.as_ref()
     }
 
-    pub fn get_hint_mouse_button(&self) -> MouseButton {
-        match self.hint.mouse {
-            None => MouseButton::Left,
-            Some(c) => c.button.0,
-        }
+    /// Returns the mouse button that is associated with the hint.
+    /// Defaults to MouseButton::Left if lf.hint.mouse is None
+    pub fn mouse_button(&self) -> MouseButton {
+        self.hint.mouse.map_or(MouseButton::Left, |hint_mouse| hint_mouse.button.0)
     }
 
     /// Get the text content of the hint match.

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -627,6 +627,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 _ => ClickState::Click,
             };
 
+            // Don'launch mouse hints if there is a selection active.
+            self.ctx.mouse_mut().block_hint_launcher = !self.ctx.selection_is_empty();
+
             // Load mouse point, treating message bar and padding as the closest cell.
             let display_offset = self.ctx.terminal().grid().display_offset();
             let point = self.ctx.mouse().point(&self.ctx.size_info(), display_offset);
@@ -644,9 +647,6 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         match self.ctx.mouse().click_state {
             ClickState::Click => {
-                // Don't launch URLs if this click cleared the selection.
-                self.ctx.mouse_mut().block_hint_launcher = !self.ctx.selection_is_empty();
-
                 self.ctx.clear_selection();
 
                 // Start new empty selection.
@@ -692,7 +692,6 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         if let Some(hint) =
             hint.as_ref().filter(|hint_match| Some(button) == hint_match.mouse_button())
         {
-            self.ctx.mouse_mut().block_hint_launcher = false;
             self.ctx.trigger_hint(hint);
         }
         self.ctx.display().highlighted_hint = hint;

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -627,7 +627,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 _ => ClickState::Click,
             };
 
-            // Don'launch mouse hints if there is a selection active.
+            // Don't launch mouse hints if there is a selection active.
             self.ctx.mouse_mut().block_hint_launcher = !self.ctx.selection_is_empty();
 
             // Load mouse point, treating message bar and padding as the closest cell.

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -689,7 +689,10 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         // Trigger hints highlighted by the mouse.
         let hint = self.ctx.display().highlighted_hint.take();
-        if let Some(hint) = hint.as_ref().filter(|_| button == MouseButton::Left) {
+        if let Some(hint) =
+            hint.as_ref().filter(|hint_match| button == hint_match.get_hint_mouse_button())
+        {
+            self.ctx.mouse_mut().block_hint_launcher = false;
             self.ctx.trigger_hint(hint);
         }
         self.ctx.display().highlighted_hint = hint;

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -689,9 +689,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         // Trigger hints highlighted by the mouse.
         let hint = self.ctx.display().highlighted_hint.take();
-        if let Some(hint) =
-            hint.as_ref().filter(|hint_match| button == hint_match.get_hint_mouse_button())
-        {
+        if let Some(hint) = hint.as_ref().filter(|hint_match| button == hint_match.mouse_button()) {
             self.ctx.mouse_mut().block_hint_launcher = false;
             self.ctx.trigger_hint(hint);
         }

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -689,7 +689,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         // Trigger hints highlighted by the mouse.
         let hint = self.ctx.display().highlighted_hint.take();
-        if let Some(hint) = hint.as_ref().filter(|hint_match| button == hint_match.mouse_button()) {
+        if let Some(hint) =
+            hint.as_ref().filter(|hint_match| Some(button) == hint_match.mouse_button())
+        {
             self.ctx.mouse_mut().block_hint_launcher = false;
             self.ctx.trigger_hint(hint);
         }

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -729,12 +729,12 @@ _action_ or a _command_.
 
 		The _enabled_ field controls if the hint should be underlined when
 		hovering over the hint text with all _mods_ pressed. Setting this
-        to true is equivalent to button to _"Left"_.
+		to true is equivalent to button to _"Left"_.
 
 		The _button_ field is controls which mouse button which needs to be 
 		pressed to trigger this hint. If set to _"None"_, mouse hints are
-        disabled. If changed, it may be wise to unbind the default bind for 
-        that button by setting the action to _"None"_ in _mouse.bindings_.
+		disabled. If changed, it may be wise to unbind the default bind for 
+		that button by setting the action to _"None"_ in _mouse.bindings_.
 
 	Default:
 		*[[hints.enabled]]*++

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -723,7 +723,7 @@ _action_ or a _command_.
 		This controls which key binding is used to start the keyboard hint
 		selection process.
 
-	*mouse* = { mods = _"<string>"_, enabled = _true_ | _false_ } | { mods = _"<string>"_, button = _"Left"_ | _"Right"_ | _"Middle"_ | _"Back"_ | _"Forward"_ | _<integer>_ | _"None"_ }
+	*mouse* = { mods = _"<string>"_, button = _"Left"_ | _"Right"_ | _"Middle"_ | _"Back"_ | _"Forward"_ | _<integer>_ | _"None"_ }
 
 		See _keyboard.bindings_ for documentation on available _mods_.
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -723,17 +723,18 @@ _action_ or a _command_.
 		This controls which key binding is used to start the keyboard hint
 		selection process.
 
-	*mouse* = { mods = _"<string>"_, enabled = _true_ | _false_, button = _"Left"_ | _"Right"_ | _"Middle"_ | _"Back"_ | _"Forward"_ | _<integer>_ }
+	*mouse* = { mods = _"<string>"_, enabled = _true_ | _false_ } | { mods = _"<string>"_, button = _"Left"_ | _"Right"_ | _"Middle"_ | _"Back"_ | _"Forward"_ | _<integer>_ | _"None"_ }
 
 		See _keyboard.bindings_ for documentation on available _mods_.
 
 		The _enabled_ field controls if the hint should be underlined when
-		hovering over the hint text with all _mods_ pressed.
+		hovering over the hint text with all _mods_ pressed. Setting this
+        to true is equivalent to button to _"Left"_.
 
 		The _button_ field is controls which mouse button which needs to be 
-		pressed to trigger this hint. If changed, it may be wise to unbind the
-		default bind for that button by setting the action to _"None"_ in
-		_mouse.bindings_.
+		pressed to trigger this hint. If set to _"None"_, mouse hints are
+        disabled. If changed, it may be wise to unbind the default bind for 
+        that button by setting the action to _"None"_ in _mouse.bindings_.
 
 	Default:
 		*[[hints.enabled]]*++

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -730,10 +730,10 @@ _action_ or a _command_.
 		The _enabled_ field controls if the hint should be underlined when
 		hovering over the hint text with all _mods_ pressed.
 
-        The _button_ field is controls which mouse button which needs to be 
-        pressed to trigger this hint. If changed, it may be wise to unbind the
-        default bind for that button by setting the action to _"None"_ in
-        _mouse.bindings_.
+		The _button_ field is controls which mouse button which needs to be 
+		pressed to trigger this hint. If changed, it may be wise to unbind the
+		default bind for that button by setting the action to _"None"_ in
+		_mouse.bindings_.
 
 	Default:
 		*[[hints.enabled]]*++

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -727,14 +727,9 @@ _action_ or a _command_.
 
 		See _keyboard.bindings_ for documentation on available _mods_.
 
-		The _enabled_ field controls if the hint should be underlined when
-		hovering over the hint text with all _mods_ pressed. Setting this
-		to true is equivalent to button to _"Left"_.
-
 		The _button_ field is controls which mouse button which needs to be 
 		pressed to trigger this hint. If set to _"None"_, mouse hints are
-		disabled. If changed, it may be wise to unbind the default bind for 
-		that button by setting the action to _"None"_ in _mouse.bindings_.
+		disabled.
 
 	Default:
 		*[[hints.enabled]]*++

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -723,12 +723,17 @@ _action_ or a _command_.
 		This controls which key binding is used to start the keyboard hint
 		selection process.
 
-	*mouse* = { mods = _"<string>"_, enabled = _true_ | _false_ }
+	*mouse* = { mods = _"<string>"_, enabled = _true_ | _false_, button = _"Left"_ | _"Right"_ | _"Middle"_ | _"Back"_ | _"Forward"_ | _<integer>_ }
 
 		See _keyboard.bindings_ for documentation on available _mods_.
 
 		The _enabled_ field controls if the hint should be underlined when
 		hovering over the hint text with all _mods_ pressed.
+
+        The _button_ field is controls which mouse button which needs to be 
+        pressed to trigger this hint. If changed, it may be wise to unbind the
+        default bind for that button by setting the action to _"None"_ in
+        _mouse.bindings_.
 
 	Default:
 		*[[hints.enabled]]*++


### PR DESCRIPTION
Not very sure about this line :
```rust
self.ctx.mouse_mut().block_hint_launcher = false;
```

Seems wrong to do this, however otherwise `block_hint_launcher` blocks every trigger of `trigger_hint(...)` and I could not figure out why