### PR TITLE
feat: Dynamic font size

### DIFF
--- a/alacritty/src/config/dynamic_font_size.rs
+++ b/alacritty/src/config/dynamic_font_size.rs
@@ -1,0 +1,58 @@
+use std::fmt;
+
+use crossfont::Size as FontSize;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer};
+use winit::dpi::PhysicalSize;
+use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
+
+/// Dynamic font size config.
+///
+/// TODO
+#[derive(ConfigDeserialize, Debug, Clone, Default, PartialEq)]
+pub struct DynamicFontSize {
+    small_font: Option<DynamicFontSizeEntry>,
+    large_font: Option<DynamicFontSizeEntry>,
+}
+
+impl DynamicFontSize {
+    pub fn determine_font_size(self, normal: FontSize, window_size: &PhysicalSize<u32>) -> FontSize {
+        match self.determine_dynamic_font_scaling(window_size) {
+            None => { normal }
+            Some(dynamic_font_scale) => { normal.scale(dynamic_font_scale) }
+        }
+    }
+
+    /// If the given `window_size` matches a `DynamicFontSizeEntry`, return the configured scaling.
+    pub fn determine_dynamic_font_scaling(self, window_size: &PhysicalSize<u32>) -> Option<f32> {
+        // Test for large font if configured.
+        if let Some(dynamic_font) = self.large_font {
+            if window_size.width > dynamic_font.at.width
+                && window_size.height > dynamic_font.at.height {
+                return Some(dynamic_font.scale);
+            }
+        }
+        // Test for small font if configured.
+        if let Some(dynamic_font) = self.small_font {
+            if window_size.width < dynamic_font.at.width
+                || window_size.height < dynamic_font.at.height {
+                return Some(dynamic_font.scale);
+            }
+        }
+        // No configured dynamic font size matches the current window size.
+        None
+    }
+}
+
+#[derive(ConfigDeserialize, Debug, Default, Clone, PartialEq)]
+struct DynamicFontSizeEntry {
+    at: WindowSize,
+    scale: f32
+}
+
+/// Represents TODO comments
+#[derive(ConfigDeserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct WindowSize {
+    width: u32,
+    height: u32,
+}

--- a/alacritty/src/config/dynamic_font_size.rs
+++ b/alacritty/src/config/dynamic_font_size.rs
@@ -8,7 +8,8 @@ use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
 
 /// Dynamic font size config.
 ///
-/// TODO
+/// The config contains two optional `DynamicFontSizeEntry`s, which specify
+/// how much the font should be scaled if the window is larger or smaller than specified.
 #[derive(ConfigDeserialize, Debug, Clone, Default, PartialEq)]
 pub struct DynamicFontSize {
     small_font: Option<DynamicFontSizeEntry>,
@@ -16,41 +17,40 @@ pub struct DynamicFontSize {
 }
 
 impl DynamicFontSize {
+    /// Determines the `FontSize` to be displayed with the current `window_size`, based on the user's
+    /// dynamic font size configuration.
     pub fn determine_font_size(self, normal: FontSize, window_size: &PhysicalSize<u32>) -> FontSize {
-        match self.determine_dynamic_font_scaling(window_size) {
-            None => { normal }
-            Some(dynamic_font_scale) => { normal.scale(dynamic_font_scale) }
-        }
+        self.determine_dynamic_font_scaling(window_size).map_or(normal, |s| normal.scale(s))
     }
 
     /// If the given `window_size` matches a `DynamicFontSizeEntry`, return the configured scaling.
     pub fn determine_dynamic_font_scaling(self, window_size: &PhysicalSize<u32>) -> Option<f32> {
         // Test for large font if configured.
-        if let Some(dynamic_font) = self.large_font {
-            if window_size.width > dynamic_font.at.width
-                && window_size.height > dynamic_font.at.height {
-                return Some(dynamic_font.scale);
-            }
-        }
+        self.large_font.and_then(|dynamic_font| {
+            (window_size.width > dynamic_font.at.width
+                && window_size.height > dynamic_font.at.height
+            ).then_some(dynamic_font.scale)
         // Test for small font if configured.
-        if let Some(dynamic_font) = self.small_font {
-            if window_size.width < dynamic_font.at.width
-                || window_size.height < dynamic_font.at.height {
-                return Some(dynamic_font.scale);
-            }
-        }
-        // No configured dynamic font size matches the current window size.
-        None
+        }).xor(self.small_font.and_then(|dynamic_font| {
+            (window_size.width < dynamic_font.at.width
+                || window_size.height < dynamic_font.at.height
+            ).then_some(dynamic_font.scale)
+        }))
+        // No configured dynamic font size matches the current window size if None.
     }
 }
 
+/// Defines how much the font size should be scaled, when the window size goes beyond the specified
+/// `WindowSize`. At this scope, the entry is agnostic of whether it is used for defining the small
+/// or large font, and thus whether 'beyond' means smaller or larger than the specified `WindowSize`.
 #[derive(ConfigDeserialize, Debug, Default, Clone, PartialEq)]
 struct DynamicFontSizeEntry {
     at: WindowSize,
     scale: f32
 }
 
-/// Represents TODO comments
+/// Represents the size of the terminal window, as minimalistic as possible such that it can be
+/// parsed from the config.
 #[derive(ConfigDeserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct WindowSize {
     width: u32,

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -38,9 +38,6 @@ pub struct Font {
     /// Font size in points.
     size: Size,
 
-    /// Parameters which dynamically update the font to a specified font
-    dynamic_size: DynamicFontDescription, // TODO move to other config field
-
     /// Whether to use the built-in font for box drawing characters.
     pub builtin_box_drawing: bool,
 }
@@ -75,9 +72,6 @@ impl Font {
     pub fn bold_italic(&self) -> FontDescription {
         self.bold_italic.desc(&self.normal)
     }
-
-    /// Get dynamic font description.
-    pub fn dynamic_font(&self) -> &DynamicFontDescription { &self.dynamic_size }
 }
 
 impl Default for Font {
@@ -91,7 +85,6 @@ impl Default for Font {
             offset: Default::default(),
             normal: Default::default(),
             bold: Default::default(),
-            dynamic_size: Default::default(),
             size: Default::default(),
         }
     }
@@ -134,49 +127,6 @@ impl SecondaryFontDescription {
     }
 }
 
-// TODO set proper defaults
-#[derive(ConfigDeserialize, Debug, Default, Clone, PartialEq, Eq)]
-pub struct DynamicFontThreshold {
-    pub window_width: u32,
-    pub window_height: u32,
-}
-
-impl DynamicFontThreshold {
-    pub fn new(window_width: u32, window_height: u32) -> DynamicFontThreshold {
-        DynamicFontThreshold { window_width, window_height }
-    }
-}
-
-/// Dynamic font threshold description.
-#[derive(ConfigDeserialize, Debug, Default, Clone, PartialEq, Eq)]
-pub struct DynamicFontDescription {
-    pub small_at: Option<DynamicFontThreshold>,
-    pub large_at: Option<DynamicFontThreshold>,
-    pub small_scale_factor: Option<u32>,
-    pub large_scale_factor: Option<u32>,
-}
-
-// TODO hide public fields with this
-// impl DynamicFontDescription {
-//     pub fn determine_current_font_size<T>(&self, window_size: PhysicalSize<T>, font_size: &FontSize){
-//         if window_size.width > self.large_at.width && window_size.height > self.large_at.height { // TODO move to another function
-//             // Use enlarged configured font.
-//             let large_font_window_size = FontSize::new(dynamic_font.large_scale_factor.unwrap());
-//             let large_font = config_font.with_window_size(large_font_window_size);
-//             display_update_pending.set_font(large_font);
-//         }
-//         else if window_size.width < small_at.width && window_size.height < small_at.height {
-//             // Use shrunk configured font.
-//             let small_font_window_size = FontSize::new(dynamic_font.small_scale_factor.unwrap());
-//             let small_font = config_font.with_window_size(small_font_window_size);
-//             display_update_pending.set_font(small_font);
-//         }
-//         else {
-//             // Use normal-window_sized configured font.
-//             display_update_pending.set_font(config_font);
-//         }
-//     }
-// }
 
 #[derive(SerdeReplace, Debug, Clone, PartialEq, Eq)]
 struct Size(FontSize);

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -3,7 +3,9 @@ use std::fmt;
 use crossfont::Size as FontSize;
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
+
 use alacritty_config_derive::{ConfigDeserialize, SerdeReplace};
+
 use crate::config::ui_config::Delta;
 
 /// Font config.
@@ -126,7 +128,6 @@ impl SecondaryFontDescription {
         }
     }
 }
-
 
 #[derive(SerdeReplace, Debug, Clone, PartialEq, Eq)]
 struct Size(FontSize);

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -15,6 +15,7 @@ pub mod color;
 pub mod cursor;
 pub mod debug;
 pub mod font;
+pub mod dynamic_font_size;
 pub mod general;
 pub mod monitor;
 pub mod scrolling;

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -25,6 +25,7 @@ use crate::config::bindings::{
 use crate::config::color::Colors;
 use crate::config::cursor::Cursor;
 use crate::config::debug::Debug;
+use crate::config::dynamic_font_size::DynamicFontSize;
 use crate::config::font::Font;
 use crate::config::general::General;
 use crate::config::mouse::Mouse;
@@ -58,6 +59,9 @@ pub struct UiConfig {
 
     /// Font configuration.
     pub font: Font,
+
+    /// Dynamic font size.
+    pub dynamic_font_size: DynamicFontSize,
 
     /// Window configuration.
     pub window: WindowConfig,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1828,10 +1828,10 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         self.ctx.display.pending_update.set_dimensions(size);
 
                         // If the user configured dynamic font sizes, we update the font size if the
-                        // resized window matches a dynamic font size.
+                        // new window size corresponds with a dynamic font size.
                         let normal_font = self.ctx.config.font.clone();
-                        let dynamic_font = self.ctx.config.dynamic_font_size.clone();
-                        let font_size = dynamic_font.determine_font_size(normal_font.size(), &size);
+                        let dynamic_font_size_config = self.ctx.config.dynamic_font_size.clone();
+                        let font_size = dynamic_font_size_config.determine_font_size(normal_font.size(), &size);
                         let font = normal_font.with_size(font_size);
                         self.ctx.display.font_size = font_size;
                         self.ctx.display.pending_update.set_font(font);


### PR DESCRIPTION
## In short

This feature request/implementation aims to add the ability to configure dynamic font sizes, as discussed in #8554.
When the window gets too small or large enough, the font size can be dynamically scaled up or down, putting less strain on your eyes.

## Details

In more detail, the user can specify two dynamic font sizes: one for when the window becomes too small and one for when the window becomes large enough. Each dynamic font size entry thus contains a window size (when to trigger) and a scale (how much the font should be scaled). If the user does not expand his configuration, the config defaults to not using any dynamic font sizes.

## Design choices

I made some design choices which I believe help make the feature intuitive, but can of course be changed:
- The user can only specify two fonts (smaller and larger)
- The larger font triggers once both specified width and height fall above the required window size (upperbound), whilst the smaller font is already applied if one of both falls below the required window size (lower bound). You don't want the text to become too large if the window is really slim, but you do want the text to scale down if it is.
- The user specifies how much the default font size should be scaled (`f32`), and does not specify absolute font sizes. This makes it independent on the default config, and feels more intuitive.

## Why still draft?

There are two reasons this PR is still a draft:
- The structs `DynamicFontSizeEntry` and `WindowSize`, added to parse the new config elements, derive the `Default` trait because I did not understand how to implement my own parsers, which is required when they have no `Default` implementation.
- I was unsure how to make this feature interact with zooming in and out manually (ctrl+ and ctrl-). Currently, zooming in and out just works, but when resizing the zoom gets reset. This might be desired. If not, remembering the amount of zoom requires more complicated adjustments, and there are many different ways of interaction which might be desired.

## How to test

Add the following to your config, and resize your terminal!

```
[dynamic_font_size]
small_font.at = { width = 500, height = 400 }
small_font.scale = 0.9
large_font.at = { width = 1000, height = 500 }
large_font.scale = 1.4
```

(These sizes feel nice to me on 1080p)

## Thanks

Lastly, this is my first ever production rust code, and I am eager to learn! Please be strict, and hold no feedback back.
And yes, my commit names are messy, but I would assume that we squash this before merging. If not, I will restructure my commits with a force-push.

Thanks for reading this way too long PR description, and hopefully it fits the alacritty design!