### PR TITLE
Add * # { } vi motions

### DIFF
--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -328,6 +328,10 @@ pub enum ViAction {
     InlineSearchNext,
     /// Jump to the previous inline search match.
     InlineSearchPrevious,
+    /// Search forward for selection or word under the cursor.
+    SemanticSearchForward,
+    /// Search backward for selection or word under the cursor.
+    SemanticSearchBackward,
 }
 
 /// Search mode specific actions.
@@ -488,6 +492,8 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         "t",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchBackwardShort;
         ";",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchNext;
         ",",                                +BindingMode::VI, ~BindingMode::SEARCH; ViAction::InlineSearchPrevious;
+        "*",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::SemanticSearchForward;
+        "#",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViAction::SemanticSearchBackward;
         "k",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Up;
         "j",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Down;
         "h",                                +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Left;
@@ -511,6 +517,8 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         "w",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::WordRight;
         "e",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::WordRightEnd;
         "%",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::Bracket;
+        "{",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::ParagraphUp;
+        "}",      ModifiersState::SHIFT,    +BindingMode::VI, ~BindingMode::SEARCH; ViMotion::ParagraphDown;
         Enter,                              +BindingMode::VI, +BindingMode::SEARCH; SearchAction::SearchConfirm;
         // Plain search.
         Escape,                             +BindingMode::SEARCH; SearchAction::SearchCancel;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1274,12 +1274,20 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         // Keep moving until we're not on top of a semantic escape character.
         let semantic_chars = terminal.semantic_escape_chars();
-        let wide_spacer = Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER;
         loop {
             let cell = &grid[end];
-            if !cell.flags.intersects(wide_spacer) && !semantic_chars.contains(cell.c) {
+
+            // Get cell's character, taking wide characters into account.
+            let c = if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                grid[end.sub(terminal, Boundary::None, 1)].c
+            } else {
+                cell.c
+            };
+
+            if !semantic_chars.contains(c) {
                 break;
             }
+
             end = terminal.semantic_search_right(end.add(terminal, Boundary::None, 1));
         }
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -35,6 +35,7 @@ use alacritty_terminal::event_loop::Notifier;
 use alacritty_terminal::grid::{BidirectionalIterator, Dimensions, Scroll};
 use alacritty_terminal::index::{Boundary, Column, Direction, Line, Point, Side};
 use alacritty_terminal::selection::{Selection, SelectionType};
+use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::search::{Match, RegexSearch};
 use alacritty_terminal::term::{self, ClipboardType, Term, TermMode};
 use alacritty_terminal::vte::ansi::NamedColor;
@@ -941,6 +942,50 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
     }
 
     #[inline]
+    fn start_seeded_search(&mut self, direction: Direction, text: String) {
+        let origin = self.terminal.vi_mode_cursor.point;
+
+        // Start new search.
+        self.clear_selection();
+        self.start_search(direction);
+
+        // Enter initial selection text.
+        for c in text.chars() {
+            if let '$' | '('..='+' | '?' | '['..='^' | '{'..='}' = c {
+                self.search_input('\\');
+            }
+            self.search_input(c);
+        }
+
+        // Leave search mode.
+        self.confirm_search();
+
+        if self.terminal.mode().contains(TermMode::VI) {
+            // Find the target vi cursor point by going to the next match to the right of the
+            // origin, then jump to the next search match in the target direction.
+            let target = self.search_next(origin, Direction::Right, Side::Right).and_then(|rm| {
+                let regex_match = match direction {
+                    Direction::Right => {
+                        let origin = rm.end().add(self.terminal, Boundary::None, 1);
+                        self.search_next(origin, Direction::Right, Side::Left)?
+                    },
+                    Direction::Left => {
+                        let origin = rm.start().sub(self.terminal, Boundary::None, 1);
+                        self.search_next(origin, Direction::Left, Side::Left)?
+                    },
+                };
+                Some(*regex_match.start())
+            });
+
+            // Move the vi cursor to the target position.
+            if let Some(target) = target {
+                self.terminal_mut().vi_goto_point(target);
+                self.mark_dirty();
+            }
+        }
+    }
+
+    #[inline]
     fn confirm_search(&mut self) {
         // Just cancel search when not in vi mode.
         if !self.terminal.mode().contains(TermMode::VI) {
@@ -1215,6 +1260,31 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         if self.terminal().mode().contains(TermMode::VI) && !self.search_active() {
             self.terminal_mut().vi_mode_cursor.point = point;
         }
+    }
+
+    /// Get the semantic word at the specified point.
+    fn semantic_word(&self, point: Point) -> String {
+        let terminal = self.terminal();
+        let grid = terminal.grid();
+
+        // Find the next semantic word boundary to the right.
+        let mut end = terminal.semantic_search_right(point);
+
+        // Keep moving until we're not on top of a semantic escape character.
+        let semantic_chars = terminal.semantic_escape_chars();
+        let wide_spacer = Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER;
+        loop {
+            let cell = &grid[end];
+            if !cell.flags.intersects(wide_spacer) && !semantic_chars.contains(cell.c) {
+                break;
+            }
+            end = terminal.semantic_search_right(end.add(terminal, Boundary::None, 1));
+        }
+
+        // Find the beginning of the semantic word.
+        let start = terminal.semantic_search_left(end);
+
+        terminal.bounds_to_string(start, end)
     }
 
     /// Handle beginning of terminal text input.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1272,7 +1272,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
 
         // Keep moving until we're not on top of a semantic escape character.
         let semantic_chars = terminal.semantic_escape_chars();
-        let wide_spacer = Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER;
+        let wide_spacer = Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER;
         loop {
             let cell = &grid[end];
             if !cell.flags.intersects(wide_spacer) && !semantic_chars.contains(cell.c) {

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -280,7 +280,7 @@ impl<T: EventListener> Execute<T> for Action {
             },
             Action::Vi(ViAction::InlineSearchNext) => ctx.inline_search_next(),
             Action::Vi(ViAction::InlineSearchPrevious) => ctx.inline_search_previous(),
-            Action::Vi(ViAction::SemanticSearchForward) => {
+            Action::Vi(ViAction::SemanticSearchForward | ViAction::SemanticSearchBackward) => {
                 let seed_text = match ctx.terminal().selection_to_string() {
                     Some(selection) if !selection.is_empty() => selection,
                     // Get semantic word at the vi cursor position.
@@ -288,18 +288,11 @@ impl<T: EventListener> Execute<T> for Action {
                 };
 
                 if !seed_text.is_empty() {
-                    ctx.start_seeded_search(Direction::Right, seed_text);
-                }
-            },
-            Action::Vi(ViAction::SemanticSearchBackward) => {
-                let seed_text = match ctx.terminal().selection_to_string() {
-                    Some(selection) if !selection.is_empty() => selection,
-                    // Get semantic word at the vi cursor position.
-                    _ => ctx.semantic_word(ctx.terminal().vi_mode_cursor.point),
-                };
-
-                if !seed_text.is_empty() {
-                    ctx.start_seeded_search(Direction::Left, seed_text);
+                    let direction = match self {
+                        Action::Vi(ViAction::SemanticSearchForward) => Direction::Right,
+                        _ => Direction::Left,
+                    };
+                    ctx.start_seeded_search(direction, seed_text);
                 }
             },
             action @ Action::Search(_) if !ctx.search_active() => {

--- a/extra/man/alacritty-bindings.5.scd
+++ b/extra/man/alacritty-bindings.5.scd
@@ -290,11 +290,11 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :  _"Vi|~Search"_
 :  _"Bracket"_
 |  _"{"_
-:[
+:  _"Shift"_
 :  _"Vi|~Search"_
 :  _"ParagraphUp"_
 |  _"}"_
-:[
+:  _"Shift"_
 :  _"Vi|~Search"_
 :  _"ParagraphDown"_
 |  _"/"_

--- a/extra/man/alacritty-bindings.5.scd
+++ b/extra/man/alacritty-bindings.5.scd
@@ -189,6 +189,14 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :[
 :  _"Vi|~Search"_
 :  _"InlineSearchPrevious"_
+|  _"\*"_
+:  _"Shift"_
+:  _"Vi|~Search"_
+:  _"SemanticSearchForward"_
+|  _"#"_
+:  _"Shift"_
+:  _"Vi|~Search"_
+:  _"SemanticSearchBackward"_
 |  _"K"_
 :[
 :  _"Vi|~Search"_
@@ -281,6 +289,14 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :  _"Shift"_
 :  _"Vi|~Search"_
 :  _"Bracket"_
+|  _"{"_
+:[
+:  _"Vi|~Search"_
+:  _"ParagraphUp"_
+|  _"}"_
+:[
+:  _"Vi|~Search"_
+:  _"ParagraphDown"_
 |  _"/"_
 :[
 :  _"Vi|~Search"_

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -894,6 +894,10 @@ _https://docs.rs/winit/latest/winit/keyboard/enum.Key.html#variant.Dead_
 			Move to end of whitespace separated word.
 		*Bracket*
 			Move to opposing bracket.
+		*ParagraphUp*
+			Move above the current paragraph.
+		*ParagraphDown*
+			Move below the current paragraph.
 		*ToggleNormalSelection*
 			Toggle normal vi selection.
 		*ToggleLineSelection*
@@ -926,6 +930,10 @@ _https://docs.rs/winit/latest/winit/keyboard/enum.Key.html#variant.Dead_
 			Jump to the next inline search match.
 		*InlineSearchPrevious*
 			Jump to the previous inline search match.
+		*SemanticSearchForward*
+			Search forward for selection or word under the cursor.
+		*SemanticSearchBackward*
+			Search backward for selection or word under the cursor.
 
 		_Search actions:_
 


### PR DESCRIPTION
This patch adds Vi's semantic search and paragraph motion.

The semantic search uses either the selection or the semantic word under the cursor and jumps to the next match in the desired direction.

Paragraph motion jumps to just above or below the current paragraph.

Closes #7961.