### PR TITLE
Fix hint binding IPC overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Modifier keys clearing selection with kitty keyboard protocol enabled
 - `glyph_offset.y` not applied to strikeout
 - `Enter`,`Tab`, `Backspace` not disambiguated with `shift` in kitty keyboard's disambiguate mode
+- Hint bindings not respecting IPC overrides
 
 ## 0.15.1
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -31,7 +31,7 @@ use crate::cli::Options;
 #[cfg(test)]
 pub use crate::config::bindings::Binding;
 pub use crate::config::bindings::{
-    Action, BindingKey, BindingMode, MouseAction, SearchAction, ViAction,
+    Action, BindingKey, BindingMode, KeyBinding, MouseAction, SearchAction, ViAction,
 };
 pub use crate::config::ui_config::UiConfig;
 use crate::logging::LOG_TARGET_CONFIG;
@@ -162,9 +162,6 @@ pub fn reload(config_path: &Path, options: &mut Options) -> Result<UiConfig> {
 fn after_loading(config: &mut UiConfig, options: &mut Options) {
     // Override config with CLI options.
     options.override_config(config);
-
-    // Create key bindings for regex hints.
-    config.generate_hint_bindings();
 }
 
 /// Load configuration file and log errors.

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{self, Formatter};
@@ -131,26 +131,6 @@ impl UiConfig {
         let working_directory =
             self.working_directory.clone().or_else(|| self.general.working_directory.clone());
         PtyOptions { working_directory, shell, drain_on_exit: false, env: HashMap::new() }
-    }
-
-    /// Generate key bindings for all keyboard hints.
-    pub fn generate_hint_bindings(&mut self) {
-        for hint in &self.hints.enabled {
-            let binding = match &hint.binding {
-                Some(binding) => binding,
-                None => continue,
-            };
-
-            let binding = KeyBinding {
-                trigger: binding.key.clone(),
-                mods: binding.mods.0,
-                mode: binding.mode.mode,
-                notmode: binding.mode.not_mode,
-                action: Action::Hint(hint.clone()),
-            };
-
-            self.keyboard.bindings.0.push(binding);
-        }
     }
 
     #[inline]
@@ -286,6 +266,7 @@ impl Default for Hints {
                         location: KeyLocation::Standard,
                     },
                     mods: ModsWrapper(ModifiersState::SHIFT | ModifiersState::CONTROL),
+                    cache: Default::default(),
                     mode: Default::default(),
                 }),
             })],
@@ -381,7 +362,7 @@ pub struct Hint {
     pub mouse: Option<HintMouse>,
 
     /// Binding required to search for this hint.
-    binding: Option<HintBinding>,
+    pub binding: Option<HintBinding>,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
@@ -468,6 +449,23 @@ pub struct HintBinding {
     pub mods: ModsWrapper,
     #[serde(default)]
     pub mode: ModeWrapper,
+
+    /// Cache for on-demand [`HintBinding`] to [`KeyBinding`] conversion.
+    #[serde(skip)]
+    cache: OnceCell<KeyBinding>,
+}
+
+impl HintBinding {
+    /// Get the key binding for a hint.
+    pub fn key_binding(&self, hint: &Rc<Hint>) -> &KeyBinding {
+        self.cache.get_or_init(|| KeyBinding {
+            trigger: self.key.clone(),
+            mods: self.mods.0,
+            mode: self.mode.mode,
+            notmode: self.mode.not_mode,
+            action: Action::Hint(hint.clone()),
+        })
+    }
 }
 
 /// Hint mouse highlighting.

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -441,7 +441,7 @@ impl<'de> Deserialize<'de> for HintContent {
 }
 
 /// Binding for triggering a keyboard hint.
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct HintBinding {
     pub key: BindingKey,
@@ -468,7 +468,7 @@ impl HintBinding {
     }
 }
 
-impl Debug for HintBinding {
+impl fmt::Debug for HintBinding {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("HintBinding")
             .field("key", &self.key)

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -468,6 +468,16 @@ impl HintBinding {
     }
 }
 
+impl Debug for HintBinding {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HintBinding")
+            .field("key", &self.key)
+            .field("mods", &self.mods)
+            .field("mode", &self.mode)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Hint mouse highlighting.
 #[derive(ConfigDeserialize, Default, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HintMouse {


### PR DESCRIPTION
This fixes an issue where changes made to the bindings of a hint through IPC were completely ignored, since the hint key bindings were only generated on config load without regeneration on IPC config override.

While it would be possible to just filter out remove hint key bindings based on their action and then repopulate them on IPC config reload, this solution would be quite hacky.

To have a better distinction between traditional and hint key bindings, the two have been entirely separated and hint bindings are just converted to key bindings on demand. This allows easily replacing the entire hint array without any post-processing, making it simpler to maintain for future changes.

Closes #8568.