### PR TITLE
Always round window corners on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - `Enter`,`Tab`, `Backspace` not disambiguated with `shift` in kitty keyboard's disambiguate mode
 - Hint bindings not respecting IPC overrides
 - Search matching a wrapping fullwidth character in the last column
+- The window having square corners on Windows 11 when decorations are disabled
 
 ## 0.15.1
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -2,6 +2,8 @@
 use winit::platform::startup_notify::{
     self, EventLoopExtStartupNotify, WindowAttributesExtStartupNotify,
 };
+#[cfg(windows)]
+use winit::platform::windows::{CornerPreference, WindowExtWindows};
 #[cfg(not(any(target_os = "macos", windows)))]
 use winit::window::ActivationToken;
 
@@ -193,6 +195,9 @@ impl Window {
 
         // Set initial transparency hint.
         window.set_transparent(config.window_opacity() < 1.);
+
+        #[cfg(windows)]
+        window.set_corner_preference(CornerPreference::Round);
 
         #[cfg(target_os = "macos")]
         use_srgb_color_space(&window);


### PR DESCRIPTION
When decorations are disabled on Windows 11, it will not round the corners of the window unless you explicitly tell it to.

This provides a workaround for that by always forcing rounded corners on Windows.

I don't have a machine with Windows 10 to test this on, so I'm not sure how this behaves there.