### PR TITLE
fix(install): Remove Debian/Ubuntu Dependency from INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ to build Alacritty. Here's an apt command that should install all of them. If
 something is still found to be missing, please open an issue.
 
 ```sh
-apt install cmake g++ pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
+apt install cmake g++ pkg-config libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3
 ```
 
 #### Arch Linux


### PR DESCRIPTION
The instructions for installing dependencies in Debian\Ubuntu indicates the package libfreetype6-dev, which doesn't need to be installed. It was removed from INSTALL.md.

Resolves #8115