### PR TITLE
Edited zypper command to include gcc-c++

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -136,7 +136,7 @@ a `zypper` command that should install all of them. If something is
 still found to be missing, please open an issue.
 
 ```sh
-zypper install cmake freetype-devel fontconfig-devel libxcb-devel libxkbcommon-devel
+zypper install cmake freetype-devel fontconfig-devel libxcb-devel libxkbcommon-devel gcc-c++
 ```
 
 #### Slackware


### PR DESCRIPTION
Without gcc-c++ the build failed with: 
warning: freetype-sys@0.20.1: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `c++` installed? error: failed to run custom build command for `freetype-sys v0.20.1`