### PR TITLE
Introduce new option selection.force_x11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Vi motions `*`, `#`, `{`, and `}`
 - IPC config retrieval using `alacritty msg get-config`
+- Config option `selection.force_x11` to force X11 clipboard backend for text selection
 
 ### Changed
 

--- a/alacritty/src/config/selection.rs
+++ b/alacritty/src/config/selection.rs
@@ -7,6 +7,7 @@ use alacritty_terminal::term::SEMANTIC_ESCAPE_CHARS;
 pub struct Selection {
     pub semantic_escape_chars: String,
     pub save_to_clipboard: bool,
+    pub force_x11: bool,
 }
 
 impl Default for Selection {
@@ -14,6 +15,7 @@ impl Default for Selection {
         Self {
             semantic_escape_chars: SEMANTIC_ESCAPE_CHARS.to_owned(),
             save_to_clipboard: Default::default(),
+            force_x11: Default::default(),
         }
     }
 }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -113,7 +113,12 @@ impl Processor {
 
         // SAFETY: Since this takes a pointer to the winit event loop, it MUST be dropped first,
         // which is done in `loop_exiting`.
-        let clipboard = unsafe { Clipboard::new(event_loop.display_handle().unwrap().as_raw()) };
+        let clipboard = unsafe {
+            Clipboard::new(
+                event_loop.display_handle().unwrap().as_raw(),
+                config.selection.force_x11,
+            )
+        };
 
         // Create a config monitor.
         //

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -540,6 +540,12 @@ This section documents the *[selection]* table of the configuration file.
 
 	Default: _false_
 
+*force_x11* = _true_ | _false_
+
+	When set to _true_, copy selected text using the X11 clipboard backend.
+
+	Default: _false_
+
 # CURSOR
 
 This section documents the *[cursor]* table of the configuration file.


### PR DESCRIPTION
Mouse selection on Wayland compositors like Cosmic does not copy the selected text to certain clipboard managers (e.g., CopyQ), because the selection uses the Wayland clipboard backend, which these managers may not always support.

This change adds the new option `force_x11` to `selection` to force using the X11 clipboard backend even under Wayland. Enabling this option improves compatibility with clipboard managers that rely on X11 clipboard events, ensuring mouse selection is correctly copied and accessible.

Default behavior remains unchanged to avoid breaking setups that rely on the native Wayland clipboard backend.