### PR TITLE
Remove unused `stroke` attributes from SVG logos

### DIFF
--- a/extra/logo/alacritty-simple.svg
+++ b/extra/logo/alacritty-simple.svg
@@ -299,7 +299,7 @@
          inkscape:connector-curvature="0"
          id="path5336"
          d="m 43.09342,-32.960595 h 9.81316 l 21.729148,53.92852 H 65.523505 L 48,-20.221038 30.476495,20.967925 h -9.112223 z"
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1" /><path
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd" /><path
          transform="matrix(1.3912031,0,0,1.3379446,21.567141,-29.104025)"
          clip-path="url(#clipPath3639)"
          style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter1378)"

--- a/extra/logo/alacritty-term+scanlines.svg
+++ b/extra/logo/alacritty-term+scanlines.svg
@@ -499,7 +499,7 @@
          inkscape:connector-curvature="0"
          id="path5336"
          d="m 44.673625,-23.161141 h 6.65275 L 66.05747,13.39925 H 59.879914 L 48,-14.524464 36.120086,13.39925 H 29.94253 Z"
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1" /><path
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd" /><path
          transform="matrix(0.94315461,0,0,0.90704843,30.080063,-20.546611)"
          clip-path="url(#clipPath3639)"
          style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter1378)"
@@ -521,7 +521,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccc"
          clip-path="none" /><path
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1"
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd"
          d="m 44.673625,-23.161141 h 6.65275 L 66.05747,13.39925 H 59.879914 L 48,-14.524464 36.120086,13.39925 H 29.94253 Z"
          id="path4185"
          inkscape:connector-curvature="0"

--- a/extra/logo/alacritty-term.svg
+++ b/extra/logo/alacritty-term.svg
@@ -432,7 +432,7 @@
          inkscape:connector-curvature="0"
          id="path5336"
          d="m 44.673625,-23.161141 h 6.65275 L 66.05747,13.39925 H 59.879914 L 48,-14.524464 36.120086,13.39925 H 29.94253 Z"
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1" /><path
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd" /><path
          transform="matrix(0.94315461,0,0,0.90704843,30.080063,-20.546611)"
          clip-path="url(#clipPath3639)"
          style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter1378)"

--- a/extra/logo/compat/alacritty-simple.svg
+++ b/extra/logo/compat/alacritty-simple.svg
@@ -308,4 +308,4 @@
          inkscape:connector-curvature="0"
          id="path5336"
          d="m 44.673625,-23.161141 h 6.65275 L 66.05747,13.39925 H 59.879914 L 48,-14.524464 36.120086,13.39925 H 29.94253 Z"
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1" /></g></g></svg>
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd" /></g></g></svg>

--- a/extra/logo/compat/alacritty-term+scanlines.svg
+++ b/extra/logo/compat/alacritty-term+scanlines.svg
@@ -471,7 +471,7 @@
          inkscape:connector-curvature="0"
          id="path5336"
          d="m 44.673625,-23.161141 h 6.65275 L 66.05747,13.39925 H 59.879914 L 48,-14.524464 36.120086,13.39925 H 29.94253 Z"
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1" /></g></g><g
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd" /></g></g><g
      sodipodi:insensitive="true"
      transform="translate(-16,35.820639)"
      style="display:inline"
@@ -486,7 +486,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccc"
          clip-path="none" /><path
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1"
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd"
          d="m 44.673625,-23.161141 h 6.65275 L 66.05747,13.39925 H 59.879914 L 48,-14.524464 36.120086,13.39925 H 29.94253 Z"
          id="path4185"
          inkscape:connector-curvature="0"

--- a/extra/logo/compat/alacritty-term.svg
+++ b/extra/logo/compat/alacritty-term.svg
@@ -441,4 +441,4 @@
          inkscape:connector-curvature="0"
          id="path5336"
          d="m 44.673625,-23.161141 h 6.65275 L 66.05747,13.39925 H 59.879914 L 48,-14.524464 36.120086,13.39925 H 29.94253 Z"
-         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient10962);stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.41420996;stroke-dasharray:none;stroke-opacity:1" /></g></g></svg>
+         style="clip-rule:evenodd;fill:url(#linearGradient11006);fill-opacity:1;fill-rule:evenodd" /></g></g></svg>


### PR DESCRIPTION
This prevents warnings in Qt apps using the QtSvg library when displaying the affected SVG logos. The warning:

```
qt.svg: <input>:LINE:COLUMN: Could not resolve property: #linearGradient10962
```

On Linux, for example, you'll see that warning by opening any of the affected SVGs with [Gwenview](https://apps.kde.org/gwenview/) from the command line. You can also occasionally see it in the system journal when KDE Plasma loads the Alacritty logo for the first time to display it on the taskbar.

That `#linearGradient10962` property does not exist in any of the SVGs, so this removes all references to it in `stroke` attributes.

This also removes other unused `stroke-*` attributes that do not affect the SVGs visually.