### PR TITLE
Add `WriteHistory` action

### DIFF
--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -10,6 +10,8 @@ use std::cmp::{max, min, Ordering};
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fmt::Debug;
+use std::fs::File;
+use std::io::Write;
 use std::marker::PhantomData;
 use std::mem;
 use std::time::{Duration, Instant};
@@ -400,6 +402,13 @@ impl<T: EventListener> Execute<T> for Action {
                 ctx.mark_dirty();
             },
             Action::ClearHistory => ctx.terminal_mut().clear_screen(ClearMode::Saved),
+            Action::WriteHistory(file) => {
+                if let Err(err) = File::create(file)
+                    .and_then(|mut file| write!(file, "{}", ctx.terminal().grid()))
+                {
+                    debug!("Failed to write history to file: {err:?}")
+                }
+            },
             Action::ClearLogNotice => ctx.pop_message(),
             #[cfg(not(target_os = "macos"))]
             Action::CreateNewWindow => ctx.create_new_window(),

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -1,6 +1,7 @@
 //! A specialized 2D grid implementation optimized for use in a terminal.
 
 use std::cmp::{max, min};
+use std::fmt::{Display, Formatter};
 use std::ops::{Bound, Deref, Index, IndexMut, Range, RangeBounds};
 
 #[cfg(feature = "serde")]
@@ -437,6 +438,12 @@ impl<T> Grid<T> {
     pub fn cursor_cell(&mut self) -> &mut T {
         let point = self.cursor.point;
         &mut self[point.line][point.column]
+    }
+}
+
+impl<T: Display + GridCell> Display for Grid<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.raw)
     }
 }
 

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -149,6 +150,12 @@ impl Default for Cell {
             flags: Flags::empty(),
             extra: None,
         }
+    }
+}
+
+impl Display for Cell {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.c)
     }
 }
 


### PR DESCRIPTION
Adds a `WriteHistory` action, which writes the contents of the current display buffer to a file. This can be configured in the TOML file using:
```toml
[keyboard]
bindings = [
  { mods = "Control", key = "O", write_history = "/tmp/alacritty-scrollback" }
]
```

This is useful (to me) to be able to search/select the scrollback buffer using my editor, instead of vi mode.

This does not add escape sequences to the generated file. I have another branch that does that but didn't like the implementation.