### PR TITLE
Remove cstr! macro in favor of literal notation

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -181,7 +181,7 @@ impl TerminalOptions {
             if working_directory.is_dir() {
                 pty_config.working_directory = Some(working_directory.to_owned());
             } else {
-                error!("Invalid working directory: {:?}", working_directory);
+                error!("Invalid working directory: {working_directory:?}");
             }
         }
 
@@ -384,7 +384,7 @@ impl ParsedOptions {
                 Err(err) => {
                     error!(
                         target: LOG_TARGET_IPC_CONFIG,
-                        "Unable to override option '{}': {}", option, err
+                        "Unable to override option '{option}': {err}"
                     );
                     self.config_options.swap_remove(i);
                 },

--- a/alacritty/src/clipboard.rs
+++ b/alacritty/src/clipboard.rs
@@ -62,7 +62,7 @@ impl Clipboard {
         };
 
         clipboard.set_contents(text.into()).unwrap_or_else(|err| {
-            warn!("Unable to store text in clipboard: {}", err);
+            warn!("Unable to store text in clipboard: {err}");
         });
     }
 
@@ -74,7 +74,7 @@ impl Clipboard {
 
         match clipboard.get_contents() {
             Err(err) => {
-                debug!("Unable to load text from clipboard: {}", err);
+                debug!("Unable to load text from clipboard: {err}");
                 String::new()
             },
             Ok(text) => text,

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -148,7 +148,7 @@ pub fn load(options: &mut Options) -> UiConfig {
 
 /// Attempt to reload the configuration file.
 pub fn reload(config_path: &Path, options: &mut Options) -> Result<UiConfig> {
-    debug!("Reloading configuration file: {:?}", config_path);
+    debug!("Reloading configuration file: {config_path:?}");
 
     // Load config, propagating errors.
     let mut config = load_from(config_path)?;
@@ -169,11 +169,11 @@ fn load_from(path: &Path) -> Result<UiConfig> {
     match read_config(path) {
         Ok(config) => Ok(config),
         Err(Error::Io(io)) if io.kind() == io::ErrorKind::NotFound => {
-            error!(target: LOG_TARGET_CONFIG, "Unable to load config {:?}: File not found", path);
+            error!(target: LOG_TARGET_CONFIG, "Unable to load config {path:?}: File not found");
             Err(Error::Io(io))
         },
         Err(err) => {
-            error!(target: LOG_TARGET_CONFIG, "Unable to load config {:?}: {}", path, err);
+            error!(target: LOG_TARGET_CONFIG, "Unable to load config {path:?}: {err}");
             Err(err)
         },
     }
@@ -268,7 +268,7 @@ fn load_imports(
                 continue;
             },
             Err(err) => {
-                error!(target: LOG_TARGET_CONFIG, "Unable to import config {:?}: {}", path, err)
+                error!(target: LOG_TARGET_CONFIG, "Unable to import config {path:?}: {err}")
             },
         }
     }

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -63,7 +63,7 @@ impl ConfigMonitor {
         ) {
             Ok(watcher) => watcher,
             Err(err) => {
-                error!("Unable to watch config file: {}", err);
+                error!("Unable to watch config file: {err}");
                 return None;
             },
         };
@@ -84,7 +84,7 @@ impl ConfigMonitor {
             // Watch all configuration file directories.
             for parent in &parents {
                 if let Err(err) = watcher.watch(parent, RecursiveMode::NonRecursive) {
-                    debug!("Unable to watch config directory {:?}: {}", parent, err);
+                    debug!("Unable to watch config directory {parent:?}: {err}");
                 }
             }
 
@@ -135,10 +135,10 @@ impl ConfigMonitor {
                         }
                     },
                     Ok(Err(err)) => {
-                        debug!("Config watcher errors: {:?}", err);
+                        debug!("Config watcher errors: {err:?}");
                     },
                     Err(err) => {
-                        debug!("Config watcher channel dropped unexpectedly: {}", err);
+                        debug!("Config watcher channel dropped unexpectedly: {err}");
                         break;
                     },
                 };

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -205,7 +205,7 @@ where
         match Binding::<T>::deserialize(value) {
             Ok(binding) => bindings.push(binding),
             Err(err) => {
-                error!(target: LOG_TARGET_CONFIG, "Config error: {}; ignoring binding", err);
+                error!(target: LOG_TARGET_CONFIG, "Config error: {err}; ignoring binding");
             },
         }
     }
@@ -410,7 +410,7 @@ impl<'de> Deserialize<'de> for HintContent {
                             Err(err) => {
                                 error!(
                                     target: LOG_TARGET_CONFIG,
-                                    "Config error: hint's regex: {}", err
+                                    "Config error: hint's regex: {err}"
                                 );
                             },
                         },
@@ -419,7 +419,7 @@ impl<'de> Deserialize<'de> for HintContent {
                             Err(err) => {
                                 error!(
                                     target: LOG_TARGET_CONFIG,
-                                    "Config error: hint's hyperlinks: {}", err
+                                    "Config error: hint's hyperlinks: {err}"
                                 );
                             },
                         },

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -110,10 +110,7 @@ impl WindowConfig {
             warn!(
                 target: LOG_TARGET_CONFIG,
                 "Both `lines` and `columns` must be non-zero for `window.dimensions` to take \
-                 effect. Configured value of `{}` is 0 while that of `{}` is {}",
-                zero_key,
-                non_zero_key,
-                non_zero_value,
+                 effect. Configured value of `{zero_key}` is 0 while that of `{non_zero_key}` is {non_zero_value}",
             );
 
             None
@@ -255,7 +252,7 @@ impl<'de> Deserialize<'de> for Class {
                             Err(err) => {
                                 error!(
                                     target: LOG_TARGET_CONFIG,
-                                    "Config error: class.instance: {}", err
+                                    "Config error: class.instance: {err}"
                                 );
                             },
                         },
@@ -264,7 +261,7 @@ impl<'de> Deserialize<'de> for Class {
                             Err(err) => {
                                 error!(
                                     target: LOG_TARGET_CONFIG,
-                                    "Config error: class.instance: {}", err
+                                    "Config error: class.instance: {err}"
                                 );
                             },
                         },

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -458,7 +458,7 @@ impl Display {
             config.window.dynamic_padding && config.window.dimensions().is_none(),
         );
 
-        info!("Cell size: {} x {}", cell_width, cell_height);
+        info!("Cell size: {cell_width} x {cell_height}");
         info!("Padding: {} x {}", size_info.padding_x(), size_info.padding_y());
         info!("Width: {}, Height: {}", size_info.width(), size_info.height());
 
@@ -511,7 +511,7 @@ impl Display {
 
         // Disable vsync.
         if let Err(err) = surface.set_swap_interval(&context, SwapInterval::DontWait) {
-            info!("Failed to disable vsync: {}", err);
+            info!("Failed to disable vsync: {err}");
         }
 
         Ok(Self {
@@ -618,7 +618,7 @@ impl Display {
             (surface, context) => surface.swap_buffers(context),
         };
         if let Err(err) = res {
-            debug!("error calling swap_buffers: {}", err);
+            debug!("error calling swap_buffers: {err}");
         }
     }
 
@@ -674,7 +674,7 @@ impl Display {
             cell_width = cell_dimensions.0;
             cell_height = cell_dimensions.1;
 
-            info!("Cell size: {} x {}", cell_width, cell_height);
+            info!("Cell size: {cell_width} x {cell_height}");
 
             // Mark entire terminal as damaged since glyph size could change without cell size
             // changes.

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -198,7 +198,7 @@ impl Window {
         use_srgb_color_space(&window);
 
         let scale_factor = window.scale_factor();
-        log::info!("Window scale factor: {}", scale_factor);
+        log::info!("Window scale factor: {scale_factor}");
         let is_x11 = matches!(window.window_handle().unwrap().as_raw(), RawWindowHandle::Xlib(_));
 
         Ok(Self {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -384,7 +384,7 @@ impl ApplicationHandler<Event> for Processor {
                         event_loop.exit();
                     }
                 } else if let Err(err) = self.create_window(event_loop, options) {
-                    error!("Could not open window: {:?}", err);
+                    error!("Could not open window: {err:?}");
                 }
             },
             // Process events affecting all windows.
@@ -507,7 +507,7 @@ impl ApplicationHandler<Event> for Processor {
 
         // SAFETY: The clipboard must be dropped before the event loop, so use the nop clipboard
         // as a safe placeholder.
-        mem::swap(&mut self.clipboard, &mut Clipboard::new_nop());
+        self.clipboard = Clipboard::new_nop();
     }
 }
 
@@ -905,7 +905,7 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         let result = spawn_daemon(program, args);
 
         match result {
-            Ok(_) => debug!("Launched {} with args {:?}", program, args),
+            Ok(_) => debug!("Launched {program} with args {args:?}"),
             Err(err) => warn!("Unable to launch {program} with args {args:?}: {err}"),
         }
     }

--- a/alacritty/src/ipc.rs
+++ b/alacritty/src/ipc.rs
@@ -58,7 +58,7 @@ pub fn spawn_ipc_socket(
             let message: SocketMessage = match serde_json::from_str(&data) {
                 Ok(message) => message,
                 Err(err) => {
-                    warn!("Failed to convert data from socket: {}", err);
+                    warn!("Failed to convert data from socket: {err}");
                     continue;
                 },
             };

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -187,7 +187,7 @@ fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
             Ok(path) => Some(path),
             Err(err) if options.daemon => return Err(err.into()),
             Err(err) => {
-                log::warn!("Unable to create socket: {:?}", err);
+                log::warn!("Unable to create socket: {err:?}");
                 None
             },
         }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -33,14 +33,6 @@ pub use text::{GlyphCache, LoaderApi};
 use shader::ShaderVersion;
 use text::{Gles2Renderer, Glsl3Renderer, TextRenderer};
 
-macro_rules! cstr {
-    ($s:literal) => {
-        // This can be optimized into an no-op with pre-allocated NUL-terminated bytes.
-        unsafe { std::ffi::CStr::from_ptr(concat!($s, "\0").as_ptr().cast()) }
-    };
-}
-pub(crate) use cstr;
-
 /// Whether the OpenGL functions have been loaded.
 pub static GL_FUNS_LOADED: AtomicBool = AtomicBool::new(false);
 
@@ -303,7 +295,7 @@ impl Renderer {
                 _ => "invalid",
             };
 
-            info!("GPU reset ({})", reason);
+            info!("GPU reset ({reason})");
 
             true
         }
@@ -404,5 +396,5 @@ extern "system" fn gl_debug_log(
     _: *mut std::os::raw::c_void,
 ) {
     let msg = unsafe { CStr::from_ptr(msg).to_string_lossy() };
-    debug!("[gl_render] {}", msg);
+    debug!("[gl_render] {msg}");
 }

--- a/alacritty/src/renderer/rects.rs
+++ b/alacritty/src/renderer/rects.rs
@@ -12,10 +12,9 @@ use alacritty_terminal::term::cell::Flags;
 use crate::display::color::Rgb;
 use crate::display::content::RenderableCell;
 use crate::display::SizeInfo;
-use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderError, ShaderProgram, ShaderVersion};
-use crate::renderer::{self, cstr};
+use crate::{gl, renderer};
 
 #[derive(Debug, Copy, Clone)]
 pub struct RenderRect {
@@ -447,13 +446,13 @@ impl RectShaderProgram {
         let program = ShaderProgram::new(shader_version, header, RECT_SHADER_V, RECT_SHADER_F)?;
 
         Ok(Self {
-            u_cell_width: program.get_uniform_location(cstr!("cellWidth")).ok(),
-            u_cell_height: program.get_uniform_location(cstr!("cellHeight")).ok(),
-            u_padding_x: program.get_uniform_location(cstr!("paddingX")).ok(),
-            u_padding_y: program.get_uniform_location(cstr!("paddingY")).ok(),
-            u_underline_position: program.get_uniform_location(cstr!("underlinePosition")).ok(),
-            u_underline_thickness: program.get_uniform_location(cstr!("underlineThickness")).ok(),
-            u_undercurl_position: program.get_uniform_location(cstr!("undercurlPosition")).ok(),
+            u_cell_width: program.get_uniform_location(c"cellWidth").ok(),
+            u_cell_height: program.get_uniform_location(c"cellHeight").ok(),
+            u_padding_x: program.get_uniform_location(c"paddingX").ok(),
+            u_padding_y: program.get_uniform_location(c"paddingY").ok(),
+            u_underline_position: program.get_uniform_location(c"underlinePosition").ok(),
+            u_underline_thickness: program.get_uniform_location(c"underlineThickness").ok(),
+            u_undercurl_position: program.get_uniform_location(c"undercurlPosition").ok(),
             program,
         })
     }

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -73,7 +73,7 @@ fn box_drawing(character: char, metrics: &Metrics, offset: &Delta<i8>) -> Raster
             y_end += y_offset;
 
             let k = y_end / x_end;
-            let f_x = |x: f32, h: f32| -> f32 { -1. * k * x + h + y_offset };
+            let f_x = |x: f32, h: f32| -> f32 { -k * x + h + y_offset };
             let g_x = |x: f32, h: f32| -> f32 { k * x + h + y_offset };
 
             let from_x = 0.;

--- a/alacritty/src/renderer/text/gles2.rs
+++ b/alacritty/src/renderer/text/gles2.rs
@@ -11,7 +11,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderProgram, ShaderVersion};
-use crate::renderer::{cstr, Error, GlExtensions};
+use crate::renderer::{Error, GlExtensions};
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
@@ -482,8 +482,8 @@ impl TextShaderProgram {
         let program = ShaderProgram::new(shader_version, None, TEXT_SHADER_V, fragment_shader)?;
 
         Ok(Self {
-            u_projection: program.get_uniform_location(cstr!("projection"))?,
-            u_rendering_pass: program.get_uniform_location(cstr!("renderingPass"))?,
+            u_projection: program.get_uniform_location(c"projection")?,
+            u_rendering_pass: program.get_uniform_location(c"renderingPass")?,
             program,
         })
     }

--- a/alacritty/src/renderer/text/glsl3.rs
+++ b/alacritty/src/renderer/text/glsl3.rs
@@ -11,7 +11,7 @@ use crate::display::SizeInfo;
 use crate::gl;
 use crate::gl::types::*;
 use crate::renderer::shader::{ShaderProgram, ShaderVersion};
-use crate::renderer::{cstr, Error};
+use crate::renderer::Error;
 
 use super::atlas::{Atlas, ATLAS_SIZE};
 use super::{
@@ -426,9 +426,9 @@ impl TextShaderProgram {
     pub fn new(shader_version: ShaderVersion) -> Result<TextShaderProgram, Error> {
         let program = ShaderProgram::new(shader_version, None, TEXT_SHADER_V, TEXT_SHADER_F)?;
         Ok(Self {
-            u_projection: program.get_uniform_location(cstr!("projection"))?,
-            u_cell_dim: program.get_uniform_location(cstr!("cellDim"))?,
-            u_rendering_pass: program.get_uniform_location(cstr!("renderingPass"))?,
+            u_projection: program.get_uniform_location(c"projection")?,
+            u_cell_dim: program.get_uniform_location(c"cellDim")?,
+            u_rendering_pass: program.get_uniform_location(c"renderingPass")?,
             program,
         })
     }

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -170,7 +170,7 @@ impl GlyphCache {
         match rasterizer.load_font(description, size) {
             Ok(font) => Ok(font),
             Err(err) => {
-                error!("{}", err);
+                error!("{err}");
 
                 let fallback_desc =
                     Self::make_desc(Font::default().normal(), Slant::Normal, Weight::Normal);

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -212,7 +212,7 @@ where
 
             // Register TTY through EventedRW interface.
             if let Err(err) = unsafe { self.pty.register(&self.poll, interest, poll_opts) } {
-                error!("Event loop registration error: {}", err);
+                error!("Event loop registration error: {err}");
                 return (self, state);
             }
 
@@ -235,7 +235,7 @@ where
                     match err.kind() {
                         ErrorKind::Interrupted => continue,
                         _ => {
-                            error!("Event loop polling error: {}", err);
+                            error!("Event loop polling error: {err}");
                             break 'event_loop;
                         },
                     }
@@ -289,14 +289,14 @@ where
                                         continue;
                                     }
 
-                                    error!("Error reading from PTY in event loop: {}", err);
+                                    error!("Error reading from PTY in event loop: {err}");
                                     break 'event_loop;
                                 }
                             }
 
                             if event.writable {
                                 if let Err(err) = self.pty_write(&mut state) {
-                                    error!("Error writing to PTY in event loop: {}", err);
+                                    error!("Error writing to PTY in event loop: {err}");
                                     break 'event_loop;
                                 }
                             }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -664,7 +664,7 @@ impl<T> Term<T> {
             return;
         }
 
-        debug!("New num_cols is {} and num_lines is {}", num_cols, num_lines);
+        debug!("New num_cols is {num_cols} and num_lines is {num_lines}");
 
         // Move vi mode cursor with the content.
         let history_size = self.history_size();
@@ -740,7 +740,7 @@ impl<T> Term<T> {
     /// Expects origin to be in scroll range.
     #[inline]
     fn scroll_down_relative(&mut self, origin: Line, mut lines: usize) {
-        trace!("Scrolling down relative: origin={}, lines={}", origin, lines);
+        trace!("Scrolling down relative: origin={origin}, lines={lines}");
 
         lines = cmp::min(lines, (self.scroll_region.end - self.scroll_region.start).0 as usize);
         lines = cmp::min(lines, (self.scroll_region.end - origin).0 as usize);
@@ -768,7 +768,7 @@ impl<T> Term<T> {
     /// Expects origin to be in scroll range.
     #[inline]
     fn scroll_up_relative(&mut self, origin: Line, mut lines: usize) {
-        trace!("Scrolling up relative: origin={}, lines={}", origin, lines);
+        trace!("Scrolling up relative: origin={origin}, lines={lines}");
 
         lines = cmp::min(lines, (self.scroll_region.end - self.scroll_region.start).0 as usize);
 
@@ -1157,7 +1157,7 @@ impl<T: EventListener> Handler for Term<T> {
         let line = Line(line);
         let col = Column(col);
 
-        trace!("Going to: line={}, col={}", line, col);
+        trace!("Going to: line={line}, col={col}");
         let (y_offset, max_y) = if self.mode.contains(TermMode::ORIGIN) {
             (self.scroll_region.start, self.scroll_region.end - 1)
         } else {
@@ -1173,13 +1173,13 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn goto_line(&mut self, line: i32) {
-        trace!("Going to line: {}", line);
+        trace!("Going to line: {line}");
         self.goto(line, self.grid.cursor.point.column.0)
     }
 
     #[inline]
     fn goto_col(&mut self, col: usize) {
-        trace!("Going to column: {}", col);
+        trace!("Going to column: {col}");
         self.goto(self.grid.cursor.point.line.0, col)
     }
 
@@ -1213,7 +1213,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_up(&mut self, lines: usize) {
-        trace!("Moving up: {}", lines);
+        trace!("Moving up: {lines}");
 
         let line = self.grid.cursor.point.line - lines;
         let column = self.grid.cursor.point.column;
@@ -1222,7 +1222,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_down(&mut self, lines: usize) {
-        trace!("Moving down: {}", lines);
+        trace!("Moving down: {lines}");
 
         let line = self.grid.cursor.point.line + lines;
         let column = self.grid.cursor.point.column;
@@ -1231,7 +1231,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_forward(&mut self, cols: usize) {
-        trace!("Moving forward: {}", cols);
+        trace!("Moving forward: {cols}");
         let last_column = cmp::min(self.grid.cursor.point.column + cols, self.last_column());
 
         let cursor_line = self.grid.cursor.point.line.0 as usize;
@@ -1243,7 +1243,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_backward(&mut self, cols: usize) {
-        trace!("Moving backward: {}", cols);
+        trace!("Moving backward: {cols}");
         let column = self.grid.cursor.point.column.saturating_sub(cols);
 
         let cursor_line = self.grid.cursor.point.line.0 as usize;
@@ -1295,8 +1295,8 @@ impl<T: EventListener> Handler for Term<T> {
         if self.keyboard_mode_stack.len() >= KEYBOARD_MODE_STACK_MAX_DEPTH {
             let removed = self.title_stack.remove(0);
             trace!(
-                "Removing '{:?}' from bottom of keyboard mode stack that exceeds its maximum depth",
-                removed
+                "Removing '{removed:?}' from bottom of keyboard mode stack that exceeds its \
+                 maximum depth"
             );
         }
 
@@ -1330,7 +1330,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn device_status(&mut self, arg: usize) {
-        trace!("Reporting device status: {}", arg);
+        trace!("Reporting device status: {arg}");
         match arg {
             5 => {
                 let text = String::from("\x1b[0n");
@@ -1341,13 +1341,13 @@ impl<T: EventListener> Handler for Term<T> {
                 let text = format!("\x1b[{};{}R", pos.line + 1, pos.column + 1);
                 self.event_proxy.send_event(Event::PtyWrite(text));
             },
-            _ => debug!("unknown device status query: {}", arg),
+            _ => debug!("unknown device status query: {arg}"),
         };
     }
 
     #[inline]
     fn move_down_and_cr(&mut self, lines: usize) {
-        trace!("Moving down and cr: {}", lines);
+        trace!("Moving down and cr: {lines}");
 
         let line = self.grid.cursor.point.line + lines;
         self.goto(line.0, 0)
@@ -1355,7 +1355,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_up_and_cr(&mut self, lines: usize) {
-        trace!("Moving up and cr: {}", lines);
+        trace!("Moving up and cr: {lines}");
 
         let line = self.grid.cursor.point.line - lines;
         self.goto(line.0, 0)
@@ -1495,7 +1495,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn insert_blank_lines(&mut self, lines: usize) {
-        trace!("Inserting blank {} lines", lines);
+        trace!("Inserting blank {lines} lines");
 
         let origin = self.grid.cursor.point.line;
         if self.scroll_region.contains(&origin) {
@@ -1508,7 +1508,7 @@ impl<T: EventListener> Handler for Term<T> {
         let origin = self.grid.cursor.point.line;
         let lines = cmp::min(self.screen_lines() - origin.0 as usize, lines);
 
-        trace!("Deleting {} lines", lines);
+        trace!("Deleting {lines} lines");
 
         if lines > 0 && self.scroll_region.contains(&origin) {
             self.scroll_up_relative(origin, lines);
@@ -1565,7 +1565,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_backward_tabs(&mut self, count: u16) {
-        trace!("Moving backward {} tabs", count);
+        trace!("Moving backward {count} tabs");
 
         let old_col = self.grid.cursor.point.column.0;
         for _ in 0..count {
@@ -1590,7 +1590,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn move_forward_tabs(&mut self, count: u16) {
-        trace!("Moving forward {} tabs", count);
+        trace!("Moving forward {count} tabs");
 
         let num_cols = self.columns();
         let old_col = self.grid.cursor.point.column.0;
@@ -1633,7 +1633,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn clear_line(&mut self, mode: ansi::LineClearMode) {
-        trace!("Clearing line: {:?}", mode);
+        trace!("Clearing line: {mode:?}");
 
         let cursor = &self.grid.cursor;
         let bg = cursor.template.bg;
@@ -1660,7 +1660,7 @@ impl<T: EventListener> Handler for Term<T> {
     /// Set the indexed color value.
     #[inline]
     fn set_color(&mut self, index: usize, color: Rgb) {
-        trace!("Setting color[{}] = {:?}", index, color);
+        trace!("Setting color[{index}] = {color:?}");
 
         // Damage terminal if the color changed and it's not the cursor.
         if index != NamedColor::Cursor as usize && self.colors[index] != Some(color) {
@@ -1673,7 +1673,7 @@ impl<T: EventListener> Handler for Term<T> {
     /// Respond to a color query escape sequence.
     #[inline]
     fn dynamic_color_sequence(&mut self, prefix: String, index: usize, terminator: &str) {
-        trace!("Requested write of escape sequence for color code {}: color[{}]", prefix, index);
+        trace!("Requested write of escape sequence for color code {prefix}: color[{index}]");
 
         let terminator = terminator.to_owned();
         self.event_proxy.send_event(Event::ColorRequest(
@@ -1690,7 +1690,7 @@ impl<T: EventListener> Handler for Term<T> {
     /// Reset the indexed color to original value.
     #[inline]
     fn reset_color(&mut self, index: usize) {
-        trace!("Resetting color[{}]", index);
+        trace!("Resetting color[{index}]");
 
         // Damage terminal if the color changed and it's not the cursor.
         if index != NamedColor::Cursor as usize && self.colors[index].is_some() {
@@ -1748,7 +1748,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn clear_screen(&mut self, mode: ansi::ClearMode) {
-        trace!("Clearing screen: {:?}", mode);
+        trace!("Clearing screen: {mode:?}");
         let bg = self.grid.cursor.template.bg;
 
         let screen_lines = self.screen_lines();
@@ -1819,7 +1819,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn clear_tabs(&mut self, mode: ansi::TabulationClearMode) {
-        trace!("Clearing tabs: {:?}", mode);
+        trace!("Clearing tabs: {mode:?}");
         match mode {
             ansi::TabulationClearMode::Current => {
                 self.tabs[self.grid.cursor.point.column] = false;
@@ -1872,14 +1872,14 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn set_hyperlink(&mut self, hyperlink: Option<Hyperlink>) {
-        trace!("Setting hyperlink: {:?}", hyperlink);
+        trace!("Setting hyperlink: {hyperlink:?}");
         self.grid.cursor.template.set_hyperlink(hyperlink.map(|e| e.into()));
     }
 
     /// Set a terminal attribute.
     #[inline]
     fn terminal_attribute(&mut self, attr: Attr) {
-        trace!("Setting attribute: {:?}", attr);
+        trace!("Setting attribute: {attr:?}");
         let cursor = &mut self.grid.cursor;
         match attr {
             Attr::Foreground(color) => cursor.template.fg = color,
@@ -1925,7 +1925,7 @@ impl<T: EventListener> Handler for Term<T> {
             Attr::Strike => cursor.template.flags.insert(Flags::STRIKEOUT),
             Attr::CancelStrike => cursor.template.flags.remove(Flags::STRIKEOUT),
             _ => {
-                debug!("Term got unhandled attr: {:?}", attr);
+                debug!("Term got unhandled attr: {attr:?}");
             },
         }
     }
@@ -1935,12 +1935,12 @@ impl<T: EventListener> Handler for Term<T> {
         let mode = match mode {
             PrivateMode::Named(mode) => mode,
             PrivateMode::Unknown(mode) => {
-                debug!("Ignoring unknown mode {} in set_private_mode", mode);
+                debug!("Ignoring unknown mode {mode} in set_private_mode");
                 return;
             },
         };
 
-        trace!("Setting private mode: {:?}", mode);
+        trace!("Setting private mode: {mode:?}");
         match mode {
             NamedPrivateMode::UrgencyHints => self.mode.insert(TermMode::URGENCY_HINTS),
             NamedPrivateMode::SwapScreenAndSetRestoreCursor => {
@@ -1995,12 +1995,12 @@ impl<T: EventListener> Handler for Term<T> {
         let mode = match mode {
             PrivateMode::Named(mode) => mode,
             PrivateMode::Unknown(mode) => {
-                debug!("Ignoring unknown mode {} in unset_private_mode", mode);
+                debug!("Ignoring unknown mode {mode} in unset_private_mode");
                 return;
             },
         };
 
-        trace!("Unsetting private mode: {:?}", mode);
+        trace!("Unsetting private mode: {mode:?}");
         match mode {
             NamedPrivateMode::UrgencyHints => self.mode.remove(TermMode::URGENCY_HINTS),
             NamedPrivateMode::SwapScreenAndSetRestoreCursor => {
@@ -2096,12 +2096,12 @@ impl<T: EventListener> Handler for Term<T> {
         let mode = match mode {
             ansi::Mode::Named(mode) => mode,
             ansi::Mode::Unknown(mode) => {
-                debug!("Ignoring unknown mode {} in set_mode", mode);
+                debug!("Ignoring unknown mode {mode} in set_mode");
                 return;
             },
         };
 
-        trace!("Setting public mode: {:?}", mode);
+        trace!("Setting public mode: {mode:?}");
         match mode {
             NamedMode::Insert => self.mode.insert(TermMode::INSERT),
             NamedMode::LineFeedNewLine => self.mode.insert(TermMode::LINE_FEED_NEW_LINE),
@@ -2113,12 +2113,12 @@ impl<T: EventListener> Handler for Term<T> {
         let mode = match mode {
             ansi::Mode::Named(mode) => mode,
             ansi::Mode::Unknown(mode) => {
-                debug!("Ignoring unknown mode {} in unset_mode", mode);
+                debug!("Ignoring unknown mode {mode} in unset_mode");
                 return;
             },
         };
 
-        trace!("Setting public mode: {:?}", mode);
+        trace!("Setting public mode: {mode:?}");
         match mode {
             NamedMode::Insert => {
                 self.mode.remove(TermMode::INSERT);
@@ -2154,7 +2154,7 @@ impl<T: EventListener> Handler for Term<T> {
         let bottom = bottom.unwrap_or_else(|| self.screen_lines());
 
         if top >= bottom {
-            debug!("Invalid scrolling region: ({};{})", top, bottom);
+            debug!("Invalid scrolling region: ({top};{bottom})");
             return;
         }
 
@@ -2165,7 +2165,7 @@ impl<T: EventListener> Handler for Term<T> {
         let start = Line(top as i32 - 1);
         let end = Line(bottom as i32);
 
-        trace!("Setting scrolling region: ({};{})", start, end);
+        trace!("Setting scrolling region: ({start};{end})");
 
         let screen_lines = Line(self.screen_lines() as i32);
         self.scroll_region.start = cmp::min(start, screen_lines);
@@ -2187,19 +2187,19 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn configure_charset(&mut self, index: CharsetIndex, charset: StandardCharset) {
-        trace!("Configuring charset {:?} as {:?}", index, charset);
+        trace!("Configuring charset {index:?} as {charset:?}");
         self.grid.cursor.charsets[index] = charset;
     }
 
     #[inline]
     fn set_active_charset(&mut self, index: CharsetIndex) {
-        trace!("Setting active charset {:?}", index);
+        trace!("Setting active charset {index:?}");
         self.active_charset = index;
     }
 
     #[inline]
     fn set_cursor_style(&mut self, style: Option<CursorStyle>) {
-        trace!("Setting cursor style {:?}", style);
+        trace!("Setting cursor style {style:?}");
         self.cursor_style = style;
 
         // Notify UI about blinking changes.
@@ -2208,7 +2208,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn set_cursor_shape(&mut self, shape: CursorShape) {
-        trace!("Setting cursor shape {:?}", shape);
+        trace!("Setting cursor shape {shape:?}");
 
         let style = self.cursor_style.get_or_insert(self.config.default_cursor_style);
         style.shape = shape;
@@ -2216,7 +2216,7 @@ impl<T: EventListener> Handler for Term<T> {
 
     #[inline]
     fn set_title(&mut self, title: Option<String>) {
-        trace!("Setting title to '{:?}'", title);
+        trace!("Setting title to '{title:?}'");
 
         self.title.clone_from(&title);
 
@@ -2235,8 +2235,7 @@ impl<T: EventListener> Handler for Term<T> {
         if self.title_stack.len() >= TITLE_STACK_MAX_DEPTH {
             let removed = self.title_stack.remove(0);
             trace!(
-                "Removing '{:?}' from bottom of title stack that exceeds its maximum depth",
-                removed
+                "Removing '{removed:?}' from bottom of title stack that exceeds its maximum depth"
             );
         }
 
@@ -2248,7 +2247,7 @@ impl<T: EventListener> Handler for Term<T> {
         trace!("Attempting to pop title from stack...");
 
         if let Some(popped) = self.title_stack.pop() {
-            trace!("Title '{:?}' popped from stack", popped);
+            trace!("Title '{popped:?}' popped from stack");
             self.set_title(popped);
         }
     }

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -383,7 +383,7 @@ impl EventedPty for Pty {
         let mut buf = [0u8; 1];
         if let Err(err) = self.signals.read(&mut buf) {
             if err.kind() != ErrorKind::WouldBlock {
-                error!("Error reading from signal pipe: {}", err);
+                error!("Error reading from signal pipe: {err}");
             }
             return None;
         }
@@ -391,7 +391,7 @@ impl EventedPty for Pty {
         // Match on the child process.
         match self.child.try_wait() {
             Err(err) => {
-                error!("Error checking child process termination: {}", err);
+                error!("Error checking child process termination: {err}");
                 None
             },
             Ok(None) => None,


### PR DESCRIPTION
Also apply clippy changes while at it.

Closes #8002.
