### PR TITLE
feat: Add --no-preserve-title option

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -214,6 +214,10 @@ pub struct WindowIdentity {
     /// Defines window class/app_id on X11/Wayland [default: Alacritty].
     #[clap(long, value_name = "general> | <general>,<instance", value_parser = parse_class)]
     pub class: Option<Class>,
+
+    /// Don't preserve window title when --class or --title is specified
+    #[clap(long)]
+    pub no_preserve_title: bool,
 }
 
 impl WindowIdentity {

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -172,7 +172,8 @@ impl WindowContext {
         let mut pty_config = config.pty_config();
         options.terminal_options.override_pty_config(&mut pty_config);
 
-        let preserve_title = options.window_identity.title.is_some();
+        let preserve_title =
+            options.window_identity.title.is_some() && !options.window_identity.no_preserve_title;
 
         info!(
             "PTY dimensions: {:?} x {:?}",

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -32,6 +32,7 @@ _alacritty() {
 '(-q)*-v[Increases the level of verbosity (the max level is -vvv)]' \
 '--daemon[Do not spawn an initial window]' \
 '--hold[Remain open after child process exit]' \
+'--no-preserve-title[Don'\''t preserve window title when --class or --title is specified]' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -72,6 +73,7 @@ _arguments "${_arguments_options[@]}" : \
 '*-o+[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION:_default' \
 '*--option=[Override configuration file options \[example\: '\''cursor.style="Beam"'\''\]]:OPTION:_default' \
 '--hold[Remain open after child process exit]' \
+'--no-preserve-title[Don'\''t preserve window title when --class or --title is specified]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0

--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -74,7 +74,7 @@ _alacritty() {
 
     case "${cmd}" in
         alacritty)
-            opts="-q -v -e -T -o -h -V --print-events --ref-test --embed --config-file --socket --daemon --working-directory --hold --command --title --class --option --help --version msg migrate help"
+            opts="-q -v -e -T -o -h -V --print-events --ref-test --embed --config-file --socket --daemon --working-directory --hold --command --title --class --no-preserve-title --option --help --version msg migrate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -373,7 +373,7 @@ _alacritty() {
             return 0
             ;;
         alacritty__msg__create__window)
-            opts="-e -T -o -h --working-directory --hold --command --title --class --option --help"
+            opts="-e -T -o -h --working-directory --hold --command --title --class --no-preserve-title --option --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_alacritty_global_optspecs
-	string join \n print-events ref-test embed= config-file= socket= q v daemon working-directory= hold e/command= T/title= class= o/option= h/help V/version
+	string join \n print-events ref-test embed= config-file= socket= q v daemon working-directory= hold e/command= T/title= class= no-preserve-title o/option= h/help V/version
 end
 
 function __fish_alacritty_needs_command
@@ -38,6 +38,7 @@ complete -c alacritty -n "__fish_alacritty_needs_command" -s q -d 'Reduces the l
 complete -c alacritty -n "__fish_alacritty_needs_command" -s v -d 'Increases the level of verbosity (the max level is -vvv)'
 complete -c alacritty -n "__fish_alacritty_needs_command" -l daemon -d 'Do not spawn an initial window'
 complete -c alacritty -n "__fish_alacritty_needs_command" -l hold -d 'Remain open after child process exit'
+complete -c alacritty -n "__fish_alacritty_needs_command" -l no-preserve-title -d 'Don\'t preserve window title when --class or --title is specified'
 complete -c alacritty -n "__fish_alacritty_needs_command" -s h -l help -d 'Print help'
 complete -c alacritty -n "__fish_alacritty_needs_command" -s V -l version -d 'Print version'
 complete -c alacritty -n "__fish_alacritty_needs_command" -f -a "msg" -d 'Send a message to the Alacritty socket'
@@ -55,6 +56,7 @@ complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen
 complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen_subcommand_from create-window" -l class -d 'Defines window class/app_id on X11/Wayland [default: Alacritty]' -r
 complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen_subcommand_from create-window" -s o -l option -d 'Override configuration file options [example: \'cursor.style="Beam"\']' -r
 complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen_subcommand_from create-window" -l hold -d 'Remain open after child process exit'
+complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen_subcommand_from create-window" -l no-preserve-title -d 'Don\'t preserve window title when --class or --title is specified'
 complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen_subcommand_from create-window" -s h -l help -d 'Print help'
 complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen_subcommand_from config" -s w -l window-id -d 'Window ID for the new config' -r
 complete -c alacritty -n "__fish_alacritty_using_subcommand msg; and __fish_seen_subcommand_from config" -s r -l reset -d 'Clear all runtime configuration changes'


### PR DESCRIPTION
Specifying window identity using cli results in `WindowContext::preserve_title` to be set to true. This is annoying in setups that use window title/class to move around windows to different workspaces/tags. 

This patch adds an `--no-preserve-title` option to cli arguments, that allows the user to use `--class` or `--title` and also allow title overrides.