### PR TITLE
Add size_hint to GridIterator

### DIFF
--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -639,7 +639,7 @@ impl<T> BidirectionalIterator for GridIterator<'_, T> {
         let last_column = self.grid.last_column();
 
         // Stop once we've reached the end of the grid.
-        if self.point == Point::new(topmost_line, Column(0)) {
+        if self.point <= Point::new(topmost_line, Column(0)) {
             return None;
         }
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -608,6 +608,27 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
 
         Some(Indexed { cell: &self.grid[self.point], point: self.point })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.point >= self.end {
+            return (0, Some(0));
+        }
+
+        let size = if self.point.line == self.end.line {
+            self.end.column.saturating_sub(self.point.column.0)
+        } else {
+            let first_line = self.grid.columns.saturating_sub(self.point.column.0);
+
+            // How many lines in total separate start from end?
+            let total_lines = (self.end.line - self.point.line).0 as usize;
+            let middle_lines = total_lines.saturating_sub(1);
+
+            let last_line = self.end.column;
+            first_line + middle_lines * self.grid.columns + last_line.0
+        };
+
+        (size, Some(size))
+    }
 }
 
 /// Bidirectional iterator.

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -599,7 +599,7 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
         }
 
         match self.point {
-            Point { column, .. } if column == self.grid.last_column() => {
+            Point { column, .. } if column >= self.grid.last_column() => {
                 self.point.column = Column(0);
                 self.point.line += 1;
             },
@@ -617,13 +617,11 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
         let size = if self.point.line == self.end.line {
             (self.end.column - self.point.column).0
         } else {
-            let cols_on_first_line = self.grid.columns.saturating_sub(self.point.column.0);
-
-            // Lines between self.point and self.end, excluding first and last line
+            let cols_on_first_line = self.grid.columns.saturating_sub(self.point.column.0 + 1);
             let middle_lines = (self.end.line - self.point.line).0 as usize - 1;
+            let cols_on_last_line = self.end.column + 1;
 
-            let last_line = self.end.column;
-            cols_on_first_line + middle_lines * self.grid.columns + last_line.0
+            cols_on_first_line + middle_lines * self.grid.columns + cols_on_last_line.0
         };
 
         (size, Some(size))

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -601,7 +601,7 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
         match self.point {
             Point { column, .. } if column == self.grid.last_column() => {
                 self.point.column = Column(0);
-                self.point.line += Line(1);
+                self.point.line += 1;
             },
             _ => self.point.column += Column(1),
         }
@@ -649,7 +649,7 @@ impl<T> BidirectionalIterator for GridIterator<'_, T> {
         match self.point {
             Point { column: Column(0), .. } => {
                 self.point.column = last_column;
-                self.point.line -= Line(1);
+                self.point.line -= 1;
             },
             _ => self.point.column -= Column(1),
         }

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -601,7 +601,7 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
         match self.point {
             Point { column, .. } if column == self.grid.last_column() => {
                 self.point.column = Column(0);
-                self.point.line += 1;
+                self.point.line += Line(1);
             },
             _ => self.point.column += Column(1),
         }
@@ -649,7 +649,7 @@ impl<T> BidirectionalIterator for GridIterator<'_, T> {
         match self.point {
             Point { column: Column(0), .. } => {
                 self.point.column = last_column;
-                self.point.line -= 1;
+                self.point.line -= Line(1);
             },
             _ => self.point.column -= Column(1),
         }

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -617,13 +617,13 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
         let size = if self.point.line == self.end.line {
             (self.end.column - self.point.column).0
         } else {
-            let first_line = self.grid.columns.saturating_sub(self.point.column.0);
+            let cols_on_first_line = self.grid.columns.saturating_sub(self.point.column.0);
 
             // Lines between self.point and self.end, excluding first and last line
             let middle_lines = (self.end.line - self.point.line).0 as usize - 1;
 
             let last_line = self.end.column;
-            first_line + middle_lines * self.grid.columns + last_line.0
+            cols_on_first_line + middle_lines * self.grid.columns + last_line.0
         };
 
         (size, Some(size))

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -615,13 +615,12 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
         }
 
         let size = if self.point.line == self.end.line {
-            self.end.column.saturating_sub(self.point.column.0)
+            (self.end.column - self.point.column).0
         } else {
             let first_line = self.grid.columns.saturating_sub(self.point.column.0);
 
-            // How many lines in total separate start from end?
-            let total_lines = (self.end.line - self.point.line).0 as usize;
-            let middle_lines = total_lines.saturating_sub(1);
+            // Lines between self.point and self.end, excluding first and last line
+            let middle_lines = (self.end.line - self.point.line).0 as usize - 1;
 
             let last_line = self.end.column;
             first_line + middle_lines * self.grid.columns + last_line.0

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -355,6 +355,7 @@ fn accurate_size_hint() {
     size_hint_matches_count(grid.iter_from(Point::new(Line(0), Column(0))));
     size_hint_matches_count(grid.iter_from(Point::new(Line(2), Column(3))));
     size_hint_matches_count(grid.iter_from(Point::new(Line(4), Column(4))));
+    size_hint_matches_count(grid.iter_from(Point::new(Line(4), Column(2))));
     size_hint_matches_count(grid.iter_from(Point::new(Line(10), Column(10))));
     size_hint_matches_count(grid.iter_from(Point::new(Line(2), Column(10))));
 

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -348,6 +348,30 @@ fn shrink_reflow_disabled() {
     assert_eq!(grid[Line(0)][Column(1)], cell('2'));
 }
 
+#[test]
+fn accurate_size_hint() {
+    let grid = Grid::<Cell>::new(5, 5, 2);
+
+    size_hint_matches_count(grid.iter_from(Point::new(Line(0), Column(0))));
+    size_hint_matches_count(grid.iter_from(Point::new(Line(2), Column(3))));
+    size_hint_matches_count(grid.iter_from(Point::new(Line(4), Column(4))));
+
+    let mut iterator = grid.iter_from(Point::new(Line(3), Column(1)));
+    iterator.next();
+    iterator.next();
+    size_hint_matches_count(iterator);
+
+    size_hint_matches_count(grid.display_iter());
+}
+
+fn size_hint_matches_count<T>(iter: impl Iterator<Item = T>) {
+    let iterator = iter.into_iter();
+    let (lower, upper) = iterator.size_hint();
+    let count = iterator.count();
+    assert_eq!(lower, count);
+    assert_eq!(upper, Some(count));
+}
+
 // https://github.com/rust-lang/rust-clippy/pull/6375
 #[allow(clippy::all)]
 fn cell(c: char) -> Cell {

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -355,6 +355,8 @@ fn accurate_size_hint() {
     size_hint_matches_count(grid.iter_from(Point::new(Line(0), Column(0))));
     size_hint_matches_count(grid.iter_from(Point::new(Line(2), Column(3))));
     size_hint_matches_count(grid.iter_from(Point::new(Line(4), Column(4))));
+    size_hint_matches_count(grid.iter_from(Point::new(Line(10), Column(10))));
+    size_hint_matches_count(grid.iter_from(Point::new(Line(2), Column(10))));
 
     let mut iterator = grid.iter_from(Point::new(Line(3), Column(1)));
     iterator.next();


### PR DESCRIPTION
Closes #8621 

Adds a manual implementation of `size_hint` for `GridIterator`. The most noticeable benefit will be the enabling pre-allocation when using `collect()` on the `GridIterator`. Also includes a tiny style fix to keep usage of `Line` consistent.