### PR TITLE
optionally show size info when resizing

### DIFF
--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -65,6 +65,9 @@ pub struct WindowConfig {
 
     /// Window level.
     pub level: WindowLevel,
+
+    /// Show size info for this milliseconds when resizing
+    pub size_info_millis: u32,
 }
 
 impl Default for WindowConfig {
@@ -85,6 +88,7 @@ impl Default for WindowConfig {
             decorations_theme_variant: Default::default(),
             option_as_alt: Default::default(),
             level: Default::default(),
+            size_info_millis: Default::default(),
         }
     }
 }

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -397,6 +397,9 @@ pub struct Display {
 
     glyph_cache: GlyphCache,
     meter: Meter,
+
+    // The last timestamp the size changed.
+    size_info_timestamp: Option<Instant>,
 }
 
 impl Display {
@@ -539,6 +542,7 @@ impl Display {
             cursor_hidden: Default::default(),
             meter: Default::default(),
             ime: Default::default(),
+            size_info_timestamp: None,
         })
     }
 
@@ -722,6 +726,10 @@ impl Display {
 
             // Resize damage tracking.
             self.damage_tracker.resize(new_size.screen_lines(), new_size.columns());
+
+            if config.window.size_info_millis > 0 {
+                self.size_info_timestamp = Some(Instant::now());
+            }
         }
 
         // Check if dimensions have changed.
@@ -959,6 +967,41 @@ impl Display {
 
                 self.draw_ime_preview(point, fg, bg, &mut rects, config);
             }
+        }
+
+        if config.window.size_info_millis > 0
+            && let Some(size_info_timestamp) = self.size_info_timestamp
+        {
+            let lines = self.size_info.screen_lines();
+            let cols = self.size_info.columns();
+            let message_text = lines.to_string() + "x" + &cols.to_string();
+            let message_len = message_text.len();
+            let col = (cols - message_len) / 2;
+            let size_info_timeout = Duration::from_millis(config.window.size_info_millis.into());
+            if size_info_timestamp + size_info_timeout > Instant::now() {
+                let glyph_cache = &mut self.glyph_cache;
+
+                let point = Point::new(lines / 2, Column(col));
+                self.renderer.draw_string(
+                    point,
+                    config.colors.primary.background,
+                    config.colors.bright.green,
+                    message_text.chars(),
+                    &size_info,
+                    glyph_cache,
+                );
+
+                let window_id = self.window.id();
+                let timer_id = TimerId::new(Topic::SizeInfo, window_id);
+                let event = Event::new(EventType::SizeInfo, window_id);
+                scheduler.unschedule(timer_id);
+                scheduler.schedule(event, size_info_timeout, false, timer_id);
+            } else {
+                self.size_info_timestamp = None;
+            }
+
+            let damage = LineDamageBounds::new(lines / 2, col, col + message_len - 1);
+            self.damage_tracker.frame().damage_line(damage);
         }
 
         if let Some(message) = message_buffer.message() {

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -973,7 +973,7 @@ impl Display {
             if let Some(size_info_timestamp) = self.size_info_timestamp {
                 let lines = self.size_info.screen_lines();
                 let cols = self.size_info.columns();
-                let message_text = lines.to_string() + "x" + &cols.to_string();
+                let message_text = cols.to_string() + "x" + &lines.to_string();
                 let message_len = message_text.len();
                 let col = (cols - message_len) / 2;
                 let size_info_timeout =

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -442,6 +442,11 @@ impl ApplicationHandler<Event> for Processor {
                     }
                 }
             },
+            (EventType::SizeInfo, Some(window_id)) => {
+                if let Some(window_context) = self.windows.get_mut(window_id) {
+                    window_context.display.window.request_redraw();
+                }
+            },
             (payload, Some(window_id)) => {
                 if let Some(window_context) = self.windows.get_mut(window_id) {
                     window_context.handle_event(
@@ -547,6 +552,7 @@ pub enum EventType {
     BlinkCursor,
     BlinkCursorTimeout,
     SearchNext,
+    SizeInfo,
     Frame,
 }
 
@@ -1919,6 +1925,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                 | EventType::ConfigReload(_)
                 | EventType::CreateWindow(_)
                 | EventType::Frame => (),
+                EventType::SizeInfo => (),
             },
             WinitEvent::WindowEvent { event, .. } => {
                 match event {

--- a/alacritty/src/scheduler.rs
+++ b/alacritty/src/scheduler.rs
@@ -29,6 +29,7 @@ pub enum Topic {
     BlinkCursor,
     BlinkTimeout,
     Frame,
+    SizeInfo,
 }
 
 /// Event scheduled to be emitted at a specific time.


### PR DESCRIPTION
Introduces window.size_info_millis to the config -> milliseconds to show cols x rows information when resizing

<img width="905" height="582" alt="screenshot" src="https://github.com/user-attachments/assets/f3077054-1861-4d50-980f-b08d8a8a36ba" />

In the old X days this was a feature of gnome-terminal I was missing ever since wayland (due to the fact they used some overlay in the Xorg API). Back the day the info would be shown while the mouse button was held down when resizing. Unfortunately as far I can see, this info is not available in winit (if it is available in wayland at all), so this uses a configurable timeout.