### PR TITLE
Fix hint highlighting when hovering with hidden mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.17.0-dev
 
+### Changed
+
+- Don't highlight hints on hover when the mouse cursor is hidden
+
 ## 0.16.0
 
 ### Packaging

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -1081,7 +1081,10 @@ impl Display {
         }
 
         // Abort if mouse highlighting conditions are not met.
-        if !mouse.inside_text_area || !term.selection.as_ref().is_none_or(Selection::is_empty) {
+        if !self.window.mouse_visible()
+            || !mouse.inside_text_area
+            || !term.selection.as_ref().is_none_or(Selection::is_empty)
+        {
             if self.highlighted_hint.take().is_some() {
                 self.damage_tracker.frame().mark_fully_damaged();
                 dirty = true;

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -277,6 +277,11 @@ impl Window {
         }
     }
 
+    #[inline]
+    pub fn mouse_visible(&self) -> bool {
+        self.mouse_visible
+    }
+
     #[cfg(not(any(target_os = "macos", windows)))]
     pub fn get_platform_window(
         identity: &Identity,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1208,8 +1208,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
 
         // Hide mouse cursor.
-        if self.config.mouse.hide_when_typing {
+        if self.config.mouse.hide_when_typing && self.display.window.mouse_visible() {
             self.display.window.set_mouse_visible(false);
+
+            // Request hint highlights update, since the mouse may have been hovering a hint.
+            self.mouse.hint_highlight_dirty = true
         }
     }
 


### PR DESCRIPTION
When the mouse cursor was hidden with `hide_when_typing` enabled, hints could still be highlighted under the hidden cursor. This typically occurred when a hint moved underneath the stationary, hidden cursor.

This fix ensures hints are not highlighted by the mouse cursor while it's hidden.