### PR TITLE
Fix Left mouse button bindings being silently ignored

### DIFF
--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -1018,7 +1018,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 ElementState::Pressed => {
                     // Process bindings before mouse press to ensure they operate on the
                     // existing selection rather than the new selection that will be started.
-                    // Only process bindings when they would normally be processed in on_mouse_press.
+                    // Only process bindings when they would normally be processed in
+                    // on_mouse_press.
                     if self.ctx.modifiers().state().shift_key() || !self.ctx.mouse_mode() {
                         self.process_mouse_bindings(button);
                     }

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -1016,9 +1016,15 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         } else {
             match state {
                 ElementState::Pressed => {
-                    // Process mouse press before bindings to update the `click_state`.
+                    // Process bindings before mouse press to ensure they operate on the
+                    // existing selection rather than the new selection that will be started.
+                    // Only process bindings when they would normally be processed in on_mouse_press.
+                    if self.ctx.modifiers().state().shift_key() || !self.ctx.mouse_mode() {
+                        self.process_mouse_bindings(button);
+                    }
+
+                    // Process mouse press to update click state and handle selection.
                     self.on_mouse_press(button);
-                    self.process_mouse_bindings(button);
                 },
                 ElementState::Released => self.on_mouse_release(button),
             }


### PR DESCRIPTION
This PR fixes GitHub issue #8473 where mouse bindings with mouse = "Left" were silently ignored.

  Problem
  The issue was in the order of operations in the mouse_input function. Previously, mouse press handling (including Left mouse button selection handling) occurred before mouse binding processing. This caused bindings like Copy and
  ExpandSelection to operate on newly started selections rather than the existing ones, making them appear to be silently ignored.

  For example, when a user pressed Alt+Left to copy a selection:
   1. The existing selection was cleared and a new one started (in on_left_click)
   2. The Copy binding executed, but copied the new empty selection

  Solution
  Changed the order of operations to process mouse bindings before mouse press handling, ensuring that Left mouse button bindings operate on the existing selection as users expect. This change only affects the order when bindings would
  normally be processed (not in mouse mode without Shift).

  Technical Details
   - Modified mouse_input function in alacritty/src/input/mod.rs
   - Added conditional binding processing before on_mouse_press call
   - Maintains all existing behavior for mouse mode and other conditions
   - Backward compatible with no breaking changes

  Testing
   - All existing tests pass
   - Code follows Alacritty's formatting standards
   - Fix verified with cargo test and cargo fmt

  Fixes #8473
  
 Hope this lands okay. It's my first go at contributing to an open source repo, so yeah.