### PR TITLE
Ignore touch gestures for enabling IME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Changed
 
 - Don't highlight hints on hover when the mouse cursor is hidden
+- Require explicit tap to enable IME with touch input
 
 ## 0.16.0
 

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -29,7 +29,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         if key.state == ElementState::Released {
             if self.ctx.inline_search_state().char_pending {
-                self.ctx.window().set_ime_allowed(true);
+                self.ctx.window().set_text_input_active(true);
             }
             self.key_release(key, mode, mods);
             return;

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -933,6 +933,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 self.mouse_moved(start_location);
                 self.mouse_input(ElementState::Pressed, MouseButton::Left);
                 self.mouse_input(ElementState::Released, MouseButton::Left);
+
+                // Set touch focus, enabling IME.
+                self.ctx.window().set_touch_focus(true);
             },
             // Transition zoom to pending state once a finger was released.
             TouchPurpose::Zoom(zoom) => {

--- a/alacritty/src/renderer/text/builtin_font.rs
+++ b/alacritty/src/renderer/text/builtin_font.rs
@@ -895,7 +895,7 @@ impl Canvas {
             *offset += 1.;
         }
 
-        let radius_i = (short_side + stroke_size + 1) / 2;
+        let radius_i = (short_side + stroke_size).div_ceil(2);
         for y in 0..radius_i {
             for x in 0..radius_i {
                 let y = y as f32;


### PR DESCRIPTION
Previously whenever the user would use touch gestures to make selections or scroll the terminal, IME would automatically be enabled due to the focus change and reduce the terminal height. This isn't ideal when the goal is just scanning through the terminal history without making any input.

This patch keeps track of pointer and touch focus and only enables IME when either the pointer is within the window or a tap touch sequence was performed to give the window 'touch focus'.

The initial touch tap sequence used to enable IME is still forwarded to the terminal as a simulated click event, since otherwise touch devices without virtual keyboard would be forced into a confusing additional tap to make it work. This means that virtual keyboard users will not be able to open the virtual keyboard without creating a click event, which should still be preferable to the status quo.

---

I'm not sure if this is ideal for upstreaming, but since all the caveats only affect virtual keyboard users (which are also the ones that would want this patch), I think it should be fine? It does increase the complexity of IME activation a good bit, but in my testing pointer users should be unaffected. Will be running this locally to see if there's any issues.