### PR TITLE
Adding hint substitution (Hint capture group interpolation before command)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.17.0-dev
 
+### Added
+
+- Substitution operation on regex terminal hints brefore command or action invocation
+
 ### Changed
 
 - Don't highlight hints on hover when the mouse cursor is hidden

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "parking_lot",
  "png",
+ "regex-automata",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2"
 log = { version = "0.4", features = ["std", "serde"] }
 notify = "8.0.0"
 parking_lot = "0.12.0"
+regex-automata = "0.4.3"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.25"

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -267,6 +267,7 @@ impl Default for Hints {
             enabled: vec![Rc::new(Hint {
                 content,
                 action,
+                substitution: None,
                 persist: false,
                 post_processing: true,
                 mouse: Some(HintMouse { enabled: true, mods: Default::default() }),
@@ -355,6 +356,10 @@ pub struct Hint {
     /// Regex for finding matches.
     #[serde(flatten)]
     pub content: HintContent,
+
+    /// Optional regex substitution on the string before executing action.
+    #[serde(default)]
+    pub substitution: Option<String>,
 
     /// Action executed when this hint is triggered.
     #[serde(flatten)]
@@ -511,6 +516,14 @@ impl LazyRegex {
         F: FnMut(&mut RegexSearch) -> T,
     {
         self.0.borrow_mut().compiled().map(f)
+    }
+
+    pub fn get_text(&self) -> String {
+        match &*self.0.borrow() {
+            LazyRegexVariant::Compiled(value, _) => String::from(value),
+            LazyRegexVariant::Pattern(value) => String::from(value),
+            LazyRegexVariant::Uncompilable(value) => String::from(value),
+        }
     }
 }
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1232,10 +1232,12 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
 
         let hint_bounds = hint.bounds();
-        let text = match hint.text(self.terminal) {
+        let raw_text = match hint.text(self.terminal) {
             Some(text) => text,
             None => return,
         };
+
+        let text = hint.substitute_text(raw_text);
 
         match &hint.action() {
             // Launch an external program.

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -673,7 +673,7 @@ terminal and pipe it to other applications.
 
 	Default: _"jfkdls;ahgurieowpq"_
 
-*enabled* = [{ *<regex>*, *<hyperlinks>*, *<post_processing>*, *<persist>*, *<action>*, *<command>*, *<binding>*, *<mouse>* },]
+*enabled* = [{ *<regex>*, *<hyperlinks>*, *<post_processing>*, *<persist>*, *<action>*, *<command>*, *<substitution>*, *<binding>*, *<mouse>* },]
 
 Array with all available hints.
 
@@ -716,6 +716,11 @@ _action_ or a _command_.
 		the _binding_.
 
 		The hint's text is always attached as the last argument.
+
+	*substitution* = _"<string>"_
+
+		Process the command by running a string interpolation operation on the hint
+		before attaching it to the command or action.
 
 	*binding* = { key = _"<string>"_, mods = _"<string>"_, mode = _"<string>"_ }
 


### PR DESCRIPTION
Substitution is an optional hint parameter that if specified uses the given string and interpolates it with the raw text, essentially performing a regex replace operation before handing it over to the command.