### PR TITLE
Disable NSAutoFillHeuristicController on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Don't highlight hints on hover when the mouse cursor is hidden
 
+### Fixed
+
+- Slowdowns over time on macOS 26
+
 ## 0.16.0
 
 ### Packaging

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -61,6 +61,7 @@ objc2-foundation = { version = "0.3.1", default-features = false, features = [
     "std",
     "NSString",
     "NSLocale",
+    "NSUserDefaults",
 ] }
 objc2-app-kit = { version = "0.3.1", default-features = false, features = [
     "std",

--- a/alacritty/src/macos/mod.rs
+++ b/alacritty/src/macos/mod.rs
@@ -1,2 +1,16 @@
+use objc2::runtime::AnyObject;
+use objc2_foundation::{NSDictionary, NSString, NSUserDefaults, ns_string};
+
 pub mod locale;
 pub mod proc;
+
+pub fn disable_autofill() {
+    unsafe {
+        NSUserDefaults::standardUserDefaults().registerDefaults(
+            &NSDictionary::<NSString, AnyObject>::from_slices(
+                &[ns_string!("NSAutoFillHeuristicControllerEnabled")],
+                &[ns_string!("NO")],
+            ),
+        );
+    }
+}

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -180,6 +180,9 @@ fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
     #[cfg(target_os = "macos")]
     locale::set_locale_environment();
 
+    #[cfg(target_os = "macos")]
+    macos::disable_autofill();
+
     // Create the IPC socket listener.
     #[cfg(unix)]
     let socket_path = if config.ipc_socket() {


### PR DESCRIPTION
Fixes #8696 

Registers UserDefaults on startup on macOS to prevent NSAutoFillHeuristicController from slowing the terminal down.

Small change, but I'm not entirely sure how to benchmark this, as it's a very hit-or-miss issue. I've tested this for a few days and don't notice the slowdown, and this fix has been verified in other apps - but advice would be appreciated on benchmarking if needed!