### PR TITLE
Ignore when config file is moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Fixed
 
 - Slowdowns over time on macOS 26
+- Brief error popup when saving the config file with some editors
 
 ## 0.16.0
 

--- a/alacritty/src/config/monitor.rs
+++ b/alacritty/src/config/monitor.rs
@@ -6,6 +6,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use log::{debug, error, warn};
+use notify::event::{ModifyKind, RenameMode};
 use notify::{
     Config, Error as NotifyError, Event as NotifyEvent, EventKind, RecommendedWatcher,
     RecursiveMode, Watcher,
@@ -112,6 +113,11 @@ impl ConfigMonitor {
                 match event {
                     Ok(Ok(event)) => match event.kind {
                         EventKind::Other if event.info() == Some("shutdown") => break,
+                        // Ignore when config file is moved as it's equivalent to deletion.
+                        // Some editors trigger this as they move the file as part of saving.
+                        EventKind::Modify(ModifyKind::Name(
+                            RenameMode::From | RenameMode::Both,
+                        )) => (),
                         EventKind::Any
                         | EventKind::Create(_)
                         | EventKind::Modify(_)


### PR DESCRIPTION
As this is practically the same as deleting the file it should be treated the same and ignored.

Moving a file from somewhere to the config file is not ignored and the config will reload as normal.

This fixes file not found errors when saving the config file in some editors. This doesn't consider the possible race condition where a modify and rename event both exist in the queue.