### PR TITLE
Fix OpenGL robustness crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Brief error popup when saving the config file with some editors
 
+## 0.16.1
+
+### Fixed
+
+- Crashes on GPUs with partial robustness support
+
 ## 0.16.0
 
 ### Packaging

--- a/alacritty/src/renderer/platform.rs
+++ b/alacritty/src/renderer/platform.rs
@@ -4,9 +4,9 @@ use std::num::NonZeroU32;
 
 use glutin::config::{ColorBufferType, Config, ConfigTemplateBuilder, GetGlConfig};
 use glutin::context::{
-    ContextApi, ContextAttributesBuilder, GlProfile, NotCurrentContext, Robustness, Version,
+    ContextApi, ContextAttributesBuilder, GlProfile, NotCurrentContext, Version,
 };
-use glutin::display::{Display, DisplayApiPreference, DisplayFeatures, GetGlDisplay};
+use glutin::display::{Display, DisplayApiPreference, GetGlDisplay};
 use glutin::error::Result as GlutinResult;
 use glutin::prelude::*;
 use glutin::surface::{Surface, SurfaceAttributesBuilder, WindowSurface};
@@ -110,12 +110,7 @@ pub fn create_gl_context(
     raw_window_handle: Option<RawWindowHandle>,
 ) -> GlutinResult<NotCurrentContext> {
     let debug = log::max_level() >= LevelFilter::Debug;
-    let mut builder = ContextAttributesBuilder::new().with_debug(debug);
-
-    // Try to enable robustness.
-    if gl_display.supported_features().contains(DisplayFeatures::CONTEXT_ROBUSTNESS) {
-        builder = builder.with_robustness(Robustness::RobustLoseContextOnReset);
-    }
+    let builder = ContextAttributesBuilder::new().with_debug(debug);
 
     let mut profiles = [
         builder


### PR DESCRIPTION
This disables the OpenGL context's robustness feature since some GPUs that advertise robustness support do not support sufficient capabilities for our implementation.

Closes #8713.