### PR TITLE
Set `ALACRITTY_TERM_TITLE` when executing hint commands.

### DIFF
--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -136,10 +136,13 @@ pub trait ActionContext<T: EventListener> {
     fn semantic_word(&self, point: Point) -> String;
     fn on_terminal_input_start(&mut self) {}
     fn paste(&mut self, _text: &str, _bracketed: bool) {}
-    fn spawn_daemon<I, S>(&self, _program: &str, _args: I)
+    fn spawn_daemon<I, J, K, S, V>(&self, _program: &str, _args: I, _envs: J)
     where
         I: IntoIterator<Item = S> + Debug + Copy,
+        J: IntoIterator<Item = (K, V)> + Debug,
+        K: AsRef<OsStr>,
         S: AsRef<OsStr>,
+        V: AsRef<OsStr>,
     {
     }
 }
@@ -168,7 +171,10 @@ impl<T: EventListener> Execute<T> for Action {
     fn execute<A: ActionContext<T>>(&self, ctx: &mut A) {
         match self {
             Action::Esc(s) => ctx.paste(s, false),
-            Action::Command(program) => ctx.spawn_daemon(program.program(), program.args()),
+            Action::Command(program) => {
+                let envs: Vec<(&str, &str)> = vec![];
+                ctx.spawn_daemon(program.program(), program.args(), envs);
+            },
             Action::Hint(hint) => {
                 ctx.display().hint_state.start(hint.clone());
                 ctx.mark_dirty();


### PR DESCRIPTION
This allows the command run to be passed context about which terminal the hint has been run from.

For example in my shell, I set the title of the terminal to:

```
[<user>@<host> <running command> <cwd>]
```

with:

```
chpwd() {
  [[ -t 1 ]] || return
  print -Pn "\e]2;[%n@%m %~]\a"
}
```

so whenever I change directory, the terminal title is changed.

When I click on a hint, that title is sent to the hint command. I then extract the cwd to find out what directory that terminal was in (replacing `~` with `$HOME` because `%~` in the shell above pretty prints `$HOME` as `~`:

```
term_dir=$(echo "$ALACRITTY_TERM_TITLE" | sed -E "s/.* (.*)\]/\\1/g" | sed -E "s|^~|${HOME}|g")
```

With that knowledge, I can then do things like drive different neovims based on `$term_dir/.nvim_server`. Specifically, I have a hint which matches `file:line:col`, so when I click on an error in a backtrace, the right neovim switches to `file` (at `line:col`), even if I have multiple neovims running in different directories across my machine. The script I execute (eliding boring details) looks roughly as follows:

```
term_dir=$(echo "$ALACRITTY_TERM_TITLE" | sed -E "s/.* (.*)\]/\\1/g" | sed -E "s|^~|${HOME}|g")
if [ -e "$term_dir/.nvim_server" ]; then
  cd $term_dir
  path=$(echo "$1" | cut -d ":" -f 1)
  line=$(echo "$1" | cut -d ":" -f 2)
  col=$(echo "$1" | cut -d ":" -f 3)
  nvim --server .nvim_server --remote-tab "${path}"
  nvim --server .nvim_server --remote-send ":call cursor(${line},${col})<CR>"
fi
```