### PR TITLE
Fix: alacritty windows flicker when starting in Maximized mode (startup_mode: Maximized) in Windows

### DIFF
--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -488,6 +488,7 @@ impl Display {
         }
 
         window.set_visible(true);
+        window.set_maximized(config.window.maximized());
 
         // Always focus new windows, even if no Alacritty window is currently focused.
         #[cfg(target_os = "macos")]

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -180,7 +180,6 @@ impl Window {
             .with_visible(false)
             .with_transparent(true)
             .with_blur(config.window.blur)
-            .with_maximized(config.window.maximized())
             .with_fullscreen(config.window.fullscreen())
             .with_window_level(config.window.level.into());
 


### PR DESCRIPTION
![PixPin_2025-10-31_11-53-13](https://github.com/user-attachments/assets/30d90bde-7559-4e62-beaf-481291ca70dd)
