### PR TITLE
Add terminal arguments for xdg-terminal-exec compatibility

### DIFF
--- a/extra/linux/Alacritty.desktop
+++ b/extra/linux/Alacritty.desktop
@@ -13,6 +13,11 @@ StartupNotify=true
 StartupWMClass=Alacritty
 Actions=New;
 
+X-TerminalArgExec=-e
+X-TerminalArgAppId=--class=
+X-TerminalArgTitle=--title=
+X-TerminalArgDir=--working-directory=
+
 [Desktop Action New]
 Name=New Terminal
 Exec=alacritty


### PR DESCRIPTION
Without the options for `X-TerminalArg*`, you're unable to properly properties when using `xdg-terminal-exec` and can have some generally unpredictable behaviors. This just brings the desktop file in-line with that.