### PR TITLE
Fixes RTL zero-width character rendering

### DIFF
--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -255,12 +255,15 @@ impl GlyphCache {
         glyph.top += i32::from(self.glyph_offset.y);
         glyph.top -= self.metrics.descent as i32;
 
-        // The metrics of zero-width characters are based on rendering
-        // the character after the current cell, with the anchor at the
-        // right side of the preceding character. Since we render the
-        // zero-width characters inside the preceding character, the
-        // anchor has been moved to the right by one cell.
-        if glyph.character.width() == Some(0) {
+        // The metrics of most zero-width characters are based on
+        // rendering the character after the current cell, with the
+        // anchor at the right side of the preceding character. Since
+        // we render the zero-width characters inside the preceding
+        // character, the anchor has been moved to the right by one
+        // cell. Chars that don't adhere to this are excluded.
+        if glyph.character.width() == Some(0)
+            && !('\u{590}'..'\u{900}').contains(&glyph.character)
+        {
             glyph.left += self.metrics.average_advance as i32;
         }
 


### PR DESCRIPTION
Changing glyph lbearing messes with Right-to-Left zero-width characters. Their metrics work differently. To illustrate:
Before change:
![pull-before1](https://github.com/user-attachments/assets/180db442-f782-4077-be85-88f34aed2abb).
After change:
![pull-after1](https://github.com/user-attachments/assets/3a66db8a-03b6-4aa8-b4b9-837c223f627a).
For those unfamiliar with these languages, the first image is a pain to read, with vowels misplaced and potentially obscured by nearby text. This is not a font issue. It happens because RTL implies that the 'forward-facing' glyph edge is on the left, which is where our anchor is anyway, so we shouldn't be adjusting it. The given range excludes RTL scripts that have diacritics. There are also blocks like 'Arabic Presentation', but their diacritics aren't zero-width. Note that an extra unicode dependency would just add more complexity, so the char range seems like the way to go.