### PR TITLE
Revert "Ignore touch gestures for enabling IME"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Changed
 
 - Don't highlight hints on hover when the mouse cursor is hidden
-- Require explicit tap to enable IME with touch input
 
 ### Fixed
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -119,9 +119,6 @@ pub struct Window {
 
     is_x11: bool,
     current_mouse_cursor: CursorIcon,
-    text_input_active: bool,
-    pointer_focused: bool,
-    touch_focused: bool,
     mouse_visible: bool,
 }
 
@@ -205,18 +202,15 @@ impl Window {
         let is_x11 = matches!(window.window_handle().unwrap().as_raw(), RawWindowHandle::Xlib(_));
 
         Ok(Self {
-            current_mouse_cursor,
-            scale_factor,
-            is_x11,
-            window,
             hold: options.terminal_options.hold,
             requested_redraw: false,
-            text_input_active: true,
             title: identity.title,
+            current_mouse_cursor,
             mouse_visible: true,
             has_frame: true,
-            pointer_focused: Default::default(),
-            touch_focused: Default::default(),
+            scale_factor,
+            window,
+            is_x11,
         })
     }
 
@@ -439,39 +433,11 @@ impl Window {
         self.window.set_simple_fullscreen(simple_fullscreen);
     }
 
-    /// Set whether plain-text input is currently possible.
-    pub fn set_text_input_active(&mut self, active: bool) {
-        if self.text_input_active != active {
-            self.text_input_active = active;
-            self.update_ime_allowed();
-        }
-    }
-
-    /// Set whether the pointer is currently within the window.
-    pub fn set_pointer_focus(&mut self, focused: bool) {
-        if self.touch_focused != focused {
-            self.touch_focused = focused;
-            self.update_ime_allowed();
-        }
-    }
-
-    /// Set whether a touch action has focused the window.
-    pub fn set_touch_focus(&mut self, focused: bool) {
-        if self.touch_focused != focused {
-            self.touch_focused = focused;
-            self.update_ime_allowed();
-        }
-    }
-
-    /// Update whether IME should be offered.
-    fn update_ime_allowed(&mut self) {
+    pub fn set_ime_allowed(&self, allowed: bool) {
         // Skip runtime IME manipulation on X11 since it breaks some IMEs.
-        if self.is_x11 {
-            return;
+        if !self.is_x11 {
+            self.window.set_ime_allowed(allowed);
         }
-
-        let allowed = self.text_input_active && (self.touch_focused || self.pointer_focused);
-        self.window.set_ime_allowed(allowed);
     }
 
     /// Adjust the IME editor position according to the new location of the cursor.

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -29,7 +29,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         if key.state == ElementState::Released {
             if self.ctx.inline_search_state().char_pending {
-                self.ctx.window().set_text_input_active(true);
+                self.ctx.window().set_ime_allowed(true);
             }
             self.key_release(key, mode, mods);
             return;

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -933,9 +933,6 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 self.mouse_moved(start_location);
                 self.mouse_input(ElementState::Pressed, MouseButton::Left);
                 self.mouse_input(ElementState::Released, MouseButton::Left);
-
-                // Set touch focus, enabling IME.
-                self.ctx.window().set_touch_focus(true);
             },
             // Transition zoom to pending state once a finger was released.
             TouchPurpose::Zoom(zoom) => {


### PR DESCRIPTION
Pointer events shouldn't disable IME in any way, however without them touch doesn't really work in the current implementation, so revert it for now to make review of the proper patch for touch easier.

This reverts commit 1399545f48f3a7ec558377a7b935b9a94482d22b.