### PR TITLE
Allow disabling IME on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Changed
 
 - Don't highlight hints on hover when the mouse cursor is hidden
+- IME is disabled in Vi mode on X11
 
 ### Fixed
 

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -434,10 +434,7 @@ impl Window {
     }
 
     pub fn set_ime_allowed(&self, allowed: bool) {
-        // Skip runtime IME manipulation on X11 since it breaks some IMEs.
-        if !self.is_x11 {
-            self.window.set_ime_allowed(allowed);
-        }
+        self.window.set_ime_allowed(allowed);
     }
 
     /// Adjust the IME editor position according to the new location of the cursor.


### PR DESCRIPTION
Previously IME was forced on X11 due to disable/enable not really working on it. However, the new IME logic in winit had this issue fixed for a while.