### PR TITLE
colors: Support system dark mode

### DIFF
--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -75,6 +75,9 @@ pub struct UiConfig {
     /// RGB values for colors.
     pub colors: Colors,
 
+    /// RGB values for colors.
+    pub colors_dark: Colors,
+
     /// Path where config was loaded from.
     #[config(skip)]
     #[serde(skip_serializing)]

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -73,8 +73,17 @@ impl<'a> RenderableContent<'a> {
             None
         };
 
+        let colors = if let Some(theme) = display.window.theme() {
+            match theme {
+                winit::window::Theme::Dark => &display.colors_dark,
+                winit::window::Theme::Light => &display.colors,
+            }
+        } else {
+            &display.colors
+        };
+
         Self {
-            colors: &display.colors,
+            colors,
             size: &display.size_info,
             cursor: RenderableCursor::new_hidden(),
             terminal_content,

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -364,6 +364,9 @@ pub struct Display {
     /// Mapped RGB values for each terminal color.
     pub colors: List,
 
+    /// Mapped RGB values for each terminal color.
+    pub colors_dark: List,
+
     /// State of the keyboard hints.
     pub hint_state: HintState,
 
@@ -521,6 +524,7 @@ impl Display {
             renderer_preference: config.debug.renderer,
             surface: ManuallyDrop::new(surface),
             colors: List::from(&config.colors),
+            colors_dark: List::from(&config.colors_dark),
             frame_timer: FrameTimer::new(),
             raw_window_handle,
             damage_tracker,

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -409,6 +409,10 @@ impl Window {
         self.window.set_theme(theme);
     }
 
+    pub fn theme(&self) -> Option<Theme> {
+        self.window.theme()
+    }
+
     #[cfg(target_os = "macos")]
     pub fn toggle_simple_fullscreen(&self) {
         self.set_simple_fullscreen(!self.window.simple_fullscreen());


### PR DESCRIPTION
Hi!

I know this is a feature @chrisduerr doesn't want. I just don't want to setup a "rube goldberg machine" to simply make alacritty switch themes automatically. It is by far easier for me to maintain this small patch.

Fixes https://github.com/alacritty/alacritty/issues/5999, https://github.com/alacritty/alacritty/issues/7723, https://github.com/alacritty/alacritty/issues/7135, and probably more requests for "following system theme".

This commit adds a new configuration section called "colors_dark" that will be used if the system theme is "dark".

In case the @chrisduerr has changed his mind and would appreciate this feature I would be prepared to fix any feedback.


https://github.com/user-attachments/assets/272aab19-ce8a-4a86-964e-db558916ea3c


example config:

```toml
[font]
size = 10
normal = { family = "Source Code Pro", style = "Regular" }
bold = { family = "Source Code Pro", style = "SemiBold" }
italic = { family = "Source Code Pro", style = "Italic" }
bold_italic = { family = "Source Code Pro", style = "SemiBold Italic" }

[window]
resize_increments = true
opacity = 0.9
blur = true
padding = {x=2,y=2}
dynamic_title = true

# Colors (Gruvbox dark)

# Default colors
[colors_dark.primary]
# hard contrast background = = '#1d2021'
background = '#282828'
# soft contrast background = = '#32302f'
foreground = '#ebdbb2'

# Normal colors
[colors_dark.normal]
black   = '#282828'
red     = '#cc241d'
green   = '#98971a'
yellow  = '#d79921'
blue    = '#458588'
magenta = '#b16286'
cyan    = '#689d6a'
white   = '#a89984'

# Bright colors
[colors_dark.bright]
black   = '#928374'
red     = '#fb4934'
green   = '#b8bb26'
yellow  = '#fabd2f'
blue    = '#83a598'
magenta = '#d3869b'
cyan    = '#8ec07c'
white   = '#ebdbb2'

# Default colors
[colors.primary]
# hard contrast background = = '#f9f5d7'
background = '#fbf1c7'
# soft contrast background = = '#f2e5bc'
foreground = '#3c3836'

# Normal colors
[colors.normal]
black   = '#fbf1c7'
red     = '#cc241d'
green   = '#98971a'
yellow  = '#d79921'
blue    = '#458588'
magenta = '#b16286'
cyan    = '#689d6a'
white   = '#7c6f64'

# Bright colors
[colors.bright]
black   = '#928374'
red     = '#9d0006'
green   = '#79740e'
yellow  = '#b57614'
blue    = '#076678'
magenta = '#8f3f71'
cyan    = '#427b58'
white   = '#3c3836'

```


Regards