### PR TITLE
Bump MACOSX_DEPLOYMENT_TARGET to 10.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ help: ## Print this help message
 binary: $(TARGET)-native ## Build a release binary
 binary-universal: $(TARGET)-universal ## Build a universal release binary
 $(TARGET)-native:
-	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release
+	MACOSX_DEPLOYMENT_TARGET="10.12" cargo build --release
 $(TARGET)-universal:
-	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=x86_64-apple-darwin
-	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin
+	MACOSX_DEPLOYMENT_TARGET="10.12" cargo build --release --target=x86_64-apple-darwin
+	MACOSX_DEPLOYMENT_TARGET="10.12" cargo build --release --target=aarch64-apple-darwin
 	@lipo target/{x86_64,aarch64}-apple-darwin/release/$(TARGET) -create -output $(APP_BINARY)
 
 app: $(APP_NAME)-native ## Create an Alacritty.app


### PR DESCRIPTION
Fixes

    warning: deployment target in MACOSX_DEPLOYMENT_TARGET was set to 10.11, but the minimum supported by `rustc` is 10.12

See for example the release CI build: https://github.com/alacritty/alacritty/actions/runs/18609525350/job/53065041493#step:7:16