### PR TITLE
Fix non-async-signal-safety in `pre_exec`

### DIFF
--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -1,10 +1,11 @@
 //! TTY related functionality.
 
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io::{Error, ErrorKind, Read, Result};
 use std::mem::MaybeUninit;
 use std::os::fd::OwnedFd;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
@@ -41,7 +42,7 @@ macro_rules! die {
 }
 
 /// Really only needed on BSD, but should be fine elsewhere.
-fn set_controlling_terminal(fd: c_int) {
+fn set_controlling_terminal(fd: c_int) -> Result<()> {
     let res = unsafe {
         // TIOSCTTY changes based on platform and the `ioctl` call is different
         // based on architecture (32/64). So a generic cast is used to make sure
@@ -51,9 +52,7 @@ fn set_controlling_terminal(fd: c_int) {
         libc::ioctl(fd, TIOCSCTTY as _, 0)
     };
 
-    if res < 0 {
-        die!("ioctl TIOCSCTTY failed: {}", Error::last_os_error());
-    }
+    if res == 0 { Ok(()) } else { Err(Error::last_os_error()) }
 }
 
 #[derive(Debug)]
@@ -241,21 +240,25 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
     builder.env_remove("XDG_ACTIVATION_TOKEN");
     builder.env_remove("DESKTOP_STARTUP_ID");
 
-    let working_directory = config.working_directory.clone();
+    let working_directory = config
+        .working_directory
+        .as_ref()
+        .and_then(|path| CString::new(path.as_os_str().as_bytes()).ok());
+
     unsafe {
         builder.pre_exec(move || {
             // Create a new process group.
             let err = libc::setsid();
             if err == -1 {
-                return Err(Error::other("Failed to set session id"));
+                return Err(Error::last_os_error());
             }
 
             // Set working directory, ignoring invalid paths.
             if let Some(working_directory) = working_directory.as_ref() {
-                let _ = env::set_current_dir(working_directory);
+                libc::chdir(working_directory.as_ptr());
             }
 
-            set_controlling_terminal(slave_fd);
+            set_controlling_terminal(slave_fd)?;
 
             // No longer need slave/master fds.
             libc::close(slave_fd);


### PR DESCRIPTION
My proposed fix for #8751, with a couple additions. This resolves all the issues with async signal safety that I could find, specifically:

- `fork`(2) not being async-signal-safe due to invoking `pthread_atfork` handlers; replaced with a syscall.
- `die!` invoking the logger; replaced with an error code.
- `env::set_current_dir` allocating; replaced with `Command::current_dir`.
- `Error::other` allocating; replaced with an error code.

Closes #8751.