### PR TITLE
implement flatpak packaging support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,26 @@ jobs:
           ./.github/workflows/upload_asset.sh ./extra/completions/_alacritty $GITHUB_TOKEN
           ./.github/workflows/upload_asset.sh ./extra/linux/Alacritty.desktop $GITHUB_TOKEN
           ./.github/workflows/upload_asset.sh ./extra/alacritty.info $GITHUB_TOKEN
+
+  flatpak:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Flatpak and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+      - name: Add Flathub repository
+        run: |
+          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      - name: Install Flatpak SDK and runtime
+        run: |
+          flatpak install --user -y flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          flatpak install --user -y flathub org.freedesktop.Sdk.Extension.rust-stable//25.08
+      - name: Build Flatpak bundle
+        run: make flatpak-bundle
+      - name: Upload Flatpak bundle
+        run: |
+          mv ./Alacritty.flatpak ./Alacritty-${GITHUB_REF##*/}.flatpak
+          ./.github/workflows/upload_asset.sh ./Alacritty-${GITHUB_REF##*/}.flatpak $GITHUB_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 target
+
+# Flatpak build artifacts
+.flatpak-builder
+flatpak-build-dir
+repo
+*.flatpak

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,34 @@ cargo install alacritty
 Note that you will still need to install the dependencies for your OS of choice.
 Please refer to the [Dependencies](#dependencies) section.
 
+# Flatpak Installation
+
+On Linux, Alacritty can be installed as a Flatpak. If a pre-built bundle is
+available from the releases page, you can install it with:
+
+```sh
+flatpak install Alacritty-v0.x.x.flatpak
+```
+
+Or build from source:
+
+```sh
+# Install Flatpak SDK and runtime
+flatpak install flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+flatpak install flathub org.freedesktop.Sdk.Extension.rust-stable//25.08
+
+# Build and install
+make flatpak
+```
+
+To create a distributable bundle:
+
+```sh
+make flatpak-bundle
+```
+
+For more details, see [extra/flatpak/README.md](extra/flatpak/README.md).
+
 # Manual Installation
 
 1. [Prerequisites](#prerequisites)

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,21 @@ install-universal: $(INSTALL)-native ## Mount universal disk image
 $(INSTALL)-%: $(DMG_NAME)-%
 	@open $(DMG_DIR)/$(DMG_NAME)
 
-.PHONY: app binary clean dmg install $(TARGET) $(TARGET)-universal
+.PHONY: app binary clean dmg install $(TARGET) $(TARGET)-universal flatpak flatpak-bundle
 
 clean: ## Remove all build artifacts
 	@cargo clean
+	@rm -rf .flatpak-builder flatpak-build-dir repo
+
+# Flatpak targets (Linux)
+FLATPAK_MANIFEST = $(ASSETS_DIR)/flatpak/org.alacritty.Alacritty.yml
+FLATPAK_BUILD_DIR = flatpak-build-dir
+FLATPAK_REPO = repo
+
+flatpak: ## Build and install Flatpak (Linux)
+	flatpak-builder --user --install --force-clean $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+
+flatpak-bundle: ## Create a Flatpak bundle file (Linux)
+	flatpak-builder --force-clean --repo=$(FLATPAK_REPO) $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+	flatpak build-bundle $(FLATPAK_REPO) Alacritty.flatpak org.alacritty.Alacritty
+	@echo "Created 'Alacritty.flatpak'"

--- a/extra/flatpak/README.md
+++ b/extra/flatpak/README.md
@@ -1,0 +1,77 @@
+# Flatpak Support for Alacritty
+
+This directory contains the files needed to build Alacritty as a Flatpak.
+
+## Prerequisites
+
+Install the Flatpak SDK and runtime:
+
+```sh
+flatpak install flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+flatpak install flathub org.freedesktop.Sdk.Extension.rust-stable//25.08
+```
+
+Install `flatpak-builder`:
+
+```sh
+# Fedora
+sudo dnf install flatpak-builder
+
+# Debian/Ubuntu
+sudo apt install flatpak-builder
+
+# Arch Linux
+sudo pacman -S flatpak-builder
+```
+
+## Building
+
+Build and install locally:
+
+```sh
+make flatpak
+```
+
+Create a distributable bundle:
+
+```sh
+make flatpak-bundle
+```
+
+This creates `Alacritty.flatpak` which can be installed with:
+
+```sh
+flatpak install Alacritty.flatpak
+```
+
+## Running
+
+```sh
+flatpak run org.alacritty.Alacritty
+```
+
+## How It Works
+
+The Flatpak uses [host-spawn](https://github.com/1player/host-spawn) to run
+your shell on the host system with proper PTY allocation. A default config
+at `/app/etc/xdg/alacritty/alacritty.toml` sets host-spawn as the shell program.
+
+User configuration in `~/.config/alacritty/` takes precedence and is shared
+with native installations.
+
+## Permissions
+
+The Flatpak has access to:
+- Full host filesystem (`--filesystem=host`)
+- GPU acceleration (`--device=dri`)
+- Wayland and X11 display servers
+- Network access
+- Flatpak portal for host process spawning
+
+Permissions can be adjusted with `flatpak override`.
+
+## Files
+
+- `org.alacritty.Alacritty.yml` - Flatpak manifest
+- `org.alacritty.Alacritty.desktop` - Desktop entry
+- `org.alacritty.Alacritty.metainfo.xml` - AppStream metadata

--- a/extra/flatpak/org.alacritty.Alacritty.desktop
+++ b/extra/flatpak/org.alacritty.Alacritty.desktop
@@ -1,0 +1,18 @@
+[Desktop Entry]
+Type=Application
+TryExec=alacritty
+Exec=alacritty
+Icon=org.alacritty.Alacritty
+Terminal=false
+Categories=System;TerminalEmulator;
+
+Name=Alacritty
+GenericName=Terminal
+Comment=A fast, cross-platform, OpenGL terminal emulator
+StartupNotify=true
+StartupWMClass=Alacritty
+Actions=New;
+
+[Desktop Action New]
+Name=New Terminal
+Exec=alacritty

--- a/extra/flatpak/org.alacritty.Alacritty.metainfo.xml
+++ b/extra/flatpak/org.alacritty.Alacritty.metainfo.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: MIT -->
+<component type="desktop-application">
+  <id>org.alacritty.Alacritty</id>
+
+  <developer id="org.alacritty">
+    <name>Alacritty Contributors</name>
+  </developer>
+
+  <name>Alacritty</name>
+
+  <project_license>Apache-2.0</project_license>
+  <metadata_license>MIT</metadata_license>
+
+  <summary>A fast, cross-platform, OpenGL terminal emulator</summary>
+  <description>
+    <p>
+      Alacritty is a modern terminal emulator that comes with sensible defaults,
+      but allows for extensive configuration. By integrating with other
+      applications, rather than reimplementing their functionality, it manages
+      to provide a flexible set of features with high performance.
+    </p>
+    <ul>
+      <li>GPU-accelerated rendering</li>
+      <li>Native Wayland and X11 support</li>
+      <li>Vi mode for keyboard-driven navigation</li>
+      <li>Configurable key bindings</li>
+      <li>True color support</li>
+      <li>Scrollback buffer</li>
+    </ul>
+  </description>
+
+  <categories>
+    <category>TerminalEmulator</category>
+  </categories>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/alacritty/alacritty/master/extra/promo/alacritty-readme.png</image>
+      <caption>Alacritty terminal with neovim</caption>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://alacritty.org</url>
+  <url type="bugtracker">https://github.com/alacritty/alacritty/issues</url>
+  <url type="vcs-browser">https://github.com/alacritty/alacritty</url>
+
+  <launchable type="desktop-id">org.alacritty.Alacritty.desktop</launchable>
+
+  <provides>
+    <binary>alacritty</binary>
+  </provides>
+
+  <content_rating type="oars-1.1" />
+</component>

--- a/extra/flatpak/org.alacritty.Alacritty.yml
+++ b/extra/flatpak/org.alacritty.Alacritty.yml
@@ -1,0 +1,70 @@
+app-id: org.alacritty.Alacritty
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+command: alacritty
+finish-args:
+  - --allow=devel
+  - --device=dri
+  - --filesystem=host
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --talk-name=org.freedesktop.Flatpak
+  - --env=XDG_CONFIG_DIRS=/app/etc/xdg:/etc/xdg
+modules:
+  - name: host-spawn
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 host-spawn-x86_64 /app/bin/host-spawn
+    sources:
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/v1.6.2/host-spawn-x86_64
+        sha256: 077bc09a087292447ba17cfe2156a93f71bf56c4c6be8e38d3abe65c1240f34c
+    only-arches:
+      - x86_64
+
+  - name: host-spawn-aarch64
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 host-spawn-aarch64 /app/bin/host-spawn
+    sources:
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/v1.6.2/host-spawn-aarch64
+        sha256: 8b30215b0b6b66c8c34a3e22d372dd39020295cd0904608bc2c5f5ecff829e5f
+    only-arches:
+      - aarch64
+
+  - name: alacritty
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin
+      env:
+        CARGO_HOME: /run/build/alacritty/cargo
+      build-args:
+        - --share=network
+    sources:
+      - type: dir
+        path: ../../
+    build-commands:
+      - cargo build --release
+      - install -Dm755 target/release/alacritty -t /app/bin/
+      - install -Dm644 extra/flatpak/org.alacritty.Alacritty.desktop /app/share/applications/org.alacritty.Alacritty.desktop
+      - install -Dm644 extra/logo/alacritty-term.svg /app/share/icons/hicolor/scalable/apps/org.alacritty.Alacritty.svg
+      - install -Dm644 extra/flatpak/org.alacritty.Alacritty.metainfo.xml /app/share/metainfo/org.alacritty.Alacritty.metainfo.xml
+      - mkdir -p /app/share/terminfo
+      - tic -o /app/share/terminfo extra/alacritty.info
+      - install -Dm644 extra/completions/_alacritty /app/share/zsh/site-functions/_alacritty
+      - install -Dm644 extra/completions/alacritty.bash /app/share/bash-completion/completions/alacritty
+      - install -Dm644 extra/completions/alacritty.fish /app/share/fish/vendor_completions.d/alacritty.fish
+      - mkdir -p /app/etc/xdg/alacritty
+      - |
+        cat > /app/etc/xdg/alacritty/alacritty.toml << 'EOF'
+        # Flatpak default configuration
+        # Uses host-spawn to run shell on the host system
+        [terminal]
+        shell = { program = "/app/bin/host-spawn" }
+        EOF


### PR DESCRIPTION
This pull request provides simple flatpak packaging support. If you have the official "flatpak-builder" installed on your Linux system, all you need to do is run the following command to locally build and install Alacritty as flatpak:
```bash
make flatpak
```
If you accept this change, I am willing to maintain the flatpak packaging and take care of submitting and maintaining it on Flathub as well while giving the official Alacritty maintainer full maintainer access to all Flathub repositories. I can also take care of the process of getting the Alacritty flatpak marked as "verified" on Flathub.