### PR TITLE
Add macOS dock menu with window list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Fixed invalid logo SVG attributes
 
+### Added
+
+- macOS dock menu showing all open windows for quick switching
+
 ### Changed
 
 - Don't highlight hints on hover when the mouse cursor is hidden

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -69,6 +69,9 @@ objc2-app-kit = { version = "0.3.1", default-features = false, features = [
     "NSResponder",
     "NSView",
     "NSWindow",
+    "NSApplication",
+    "NSMenu",
+    "NSMenuItem",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/alacritty/src/macos/mod.rs
+++ b/alacritty/src/macos/mod.rs
@@ -14,3 +14,108 @@ pub fn disable_autofill() {
         );
     }
 }
+
+// Implement dock menu using Objective-C runtime.
+pub fn setup_dock_menu() {
+    use objc2::ffi::sel_registerName;
+    use objc2::ffi::{class_addMethod, object_getClass};
+    use objc2::{class, msg_send};
+    use std::ffi::CString;
+
+    unsafe {
+        // Get NSApplication.
+        let ns_app_class = class!(NSApplication);
+        let app: *mut AnyObject = msg_send![ns_app_class, sharedApplication];
+
+        // Get the current delegate (set by Winit).
+        let delegate: *mut AnyObject = msg_send![app, delegate];
+
+        if delegate.is_null() {
+            return;
+        }
+
+        // Get the class of the existing delegate.
+        let delegate_class = object_getClass(delegate.cast());
+
+        // Add applicationDockMenu: method to the existing delegate class.
+        let method_name = CString::new("applicationDockMenu:").unwrap();
+        let sel = sel_registerName(method_name.as_ptr()).expect("Failed to register selector");
+
+        // Method signature: id (self, SEL, id).
+        let types = CString::new("@@:@").unwrap();
+
+        class_addMethod(
+            delegate_class.cast_mut(),
+            sel,
+            std::mem::transmute::<*const (), unsafe extern "C-unwind" fn()>(
+                application_dock_menu_impl as *const (),
+            ),
+            types.as_ptr(),
+        );
+    }
+}
+
+// C function that implements applicationDockMenu: delegate method.
+extern "C" fn application_dock_menu_impl(
+    _self: *mut AnyObject,
+    _cmd: *const std::os::raw::c_void,
+    _app: *mut AnyObject,
+) -> *mut AnyObject {
+    use objc2::{class, msg_send, sel};
+
+    unsafe {
+        // Get NSApplication to access windows.
+        let ns_app_class = class!(NSApplication);
+        let app: *mut AnyObject = msg_send![ns_app_class, sharedApplication];
+
+        // Create menu.
+        let ns_menu_class = class!(NSMenu);
+        let menu: *mut AnyObject = msg_send![ns_menu_class, alloc];
+        let menu: *mut AnyObject = msg_send![menu, init];
+
+        // Get windows array.
+        let windows: *mut AnyObject = msg_send![app, windows];
+        let count: usize = msg_send![windows, count];
+
+        // Add each window to menu.
+        for i in 0..count {
+            let window: *mut AnyObject = msg_send![windows, objectAtIndex: i];
+            let title: *mut AnyObject = msg_send![window, title];
+
+            // Check if title is not empty.
+            let length: usize = msg_send![title, length];
+            if length > 0 {
+                // Create menu item.
+                let ns_menu_item_class = class!(NSMenuItem);
+                let item: *mut AnyObject = msg_send![ns_menu_item_class, alloc];
+                let item: *mut AnyObject = msg_send![item, init];
+
+                let _: () = msg_send![item, setTitle: title];
+                let _: () = msg_send![item, setTarget: window];
+
+                let selector = sel!(makeKeyAndOrderFront:);
+                let _: () = msg_send![item, setAction: selector];
+
+                let _: () = msg_send![menu, addItem: item];
+            }
+        }
+
+        // Add separator if we have windows.
+        if count > 0 {
+            let separator_class = class!(NSMenuItem);
+            let separator: *mut AnyObject = msg_send![separator_class, separatorItem];
+            let _: () = msg_send![menu, addItem: separator];
+        }
+
+        // Add "New Window" item.
+        let ns_menu_item_class = class!(NSMenuItem);
+        let new_item: *mut AnyObject = msg_send![ns_menu_item_class, alloc];
+        let new_item: *mut AnyObject = msg_send![new_item, init];
+
+        let new_window_title = ns_string!("New Window");
+        let _: () = msg_send![new_item, setTitle: new_window_title];
+        let _: () = msg_send![menu, addItem: new_item];
+
+        menu
+    }
+}

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -183,6 +183,9 @@ fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
     #[cfg(target_os = "macos")]
     macos::disable_autofill();
 
+    #[cfg(target_os = "macos")]
+    macos::setup_dock_menu();
+
     // Create the IPC socket listener.
     #[cfg(unix)]
     let socket_path = if config.ipc_socket() {


### PR DESCRIPTION
## Summary

Adds macOS dock menu functionality showing all open Alacritty windows, similar to Terminal.app and iTerm2.

After seeing Omachy OS using Alacritty and learning it supports macOS, I decided to switch from the default Mac terminal. Combined with zellij, it's been a great experience - thanks for the excellent work on this project!

The only feature I've been missing is the dock menu to switch between Alacritty windows and see how many I have open. I created this patch which has been working well for me.

<img width="287" height="335" alt="Screenshot 2025-12-16 at 22 24 20" src="https://github.com/user-attachments/assets/94bff208-c737-4f6c-85db-d629639c7cad" />

## Implementation

Uses Objective-C runtime to dynamically add `applicationDockMenu:` to Winit's existing NSApplicationDelegate:

- `class_addMethod` injects the delegate method at runtime
- Works with Winit without modifying or replacing its delegate
- Lists windows via `NSApplication.sharedApplication.windows`
- Uses `makeKeyAndOrderFront:` action for window switching

## Maintenance Considerations

I understand this may not be desirable due to maintenance burden for macOS-specific features. If this doesn't fit the project's goals, I've created a Homebrew tap that automatically applies this patch for each Alacritty release:

**Interim solution:** https://github.com/NorfeldtKnowit/homebrew-alacritty-macos-dock-patched

The tap has automated workflows that:
- Detect new Alacritty releases every 6 hours
- Test patch compatibility
- Build and validate
- Auto-update the formula

This gives users the option without adding maintenance burden to the core project.

## Testing

- [x] Opens multiple windows (Cmd+N)
- [x] Right-click dock icon shows all windows
- [x] Clicking window title brings it to front
- [x] Works with existing Winit delegate

## Related Issues

- #6346 - Group windows in dock (closed, but this adds different functionality)
- #6157 - Window grouping (closed, CreateNewWindow exists)

---

This PR adds dock *menu* functionality (right-click to see windows), which is separate from window *grouping* under a single dock icon.