### PR TITLE
macOS: Reset Mach exception ports in PTY child `pre_exec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "home",
  "libc",
  "log",
+ "mach2",
  "miow",
  "parking_lot",
  "piper",
@@ -1037,6 +1038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -32,6 +32,9 @@ rustix-openpty = "0.2.0"
 rustix = { version = "1.0.0", default-features = false, features = ["std"] }
 signal-hook = "0.3.10"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2 = "0.5"
+
 [target.'cfg(windows)'.dependencies]
 piper = "0.2.1"
 miow = "0.6.0"

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -17,6 +17,20 @@ use std::{env, ptr};
 
 use libc::{F_GETFL, F_SETFL, O_NONBLOCK, TIOCSCTTY, c_int, fcntl};
 use log::error;
+#[cfg(target_os = "macos")]
+use mach2::exception_types::{
+    EXC_MASK_ALL, EXCEPTION_DEFAULT, exception_behavior_t, exception_mask_t,
+};
+#[cfg(target_os = "macos")]
+use mach2::kern_return::kern_return_t;
+#[cfg(target_os = "macos")]
+use mach2::mach_types::task_t;
+#[cfg(target_os = "macos")]
+use mach2::port::{MACH_PORT_NULL, mach_port_t};
+#[cfg(target_os = "macos")]
+use mach2::thread_status::{THREAD_STATE_NONE, thread_state_flavor_t};
+#[cfg(target_os = "macos")]
+use mach2::traps::mach_task_self;
 use polling::{Event, PollMode, Poller};
 use rustix_openpty::openpty;
 use rustix_openpty::rustix::termios::Winsize;
@@ -53,6 +67,29 @@ fn set_controlling_terminal(fd: c_int) -> Result<()> {
     };
 
     if res == 0 { Ok(()) } else { Err(Error::last_os_error()) }
+}
+
+#[cfg(target_os = "macos")]
+fn reset_exception_ports() {
+    unsafe extern "C" {
+        fn task_set_exception_ports(
+            task: task_t,
+            exception_mask: exception_mask_t,
+            new_port: mach_port_t,
+            behavior: exception_behavior_t,
+            new_flavor: thread_state_flavor_t,
+        ) -> kern_return_t;
+    }
+
+    unsafe {
+        let _kern_return = task_set_exception_ports(
+            mach_task_self(),
+            EXC_MASK_ALL,
+            MACH_PORT_NULL,
+            EXCEPTION_DEFAULT as exception_behavior_t,
+            THREAD_STATE_NONE,
+        );
+    }
 }
 
 #[derive(Debug)]
@@ -252,6 +289,9 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
             if err == -1 {
                 return Err(Error::last_os_error());
             }
+
+            #[cfg(target_os = "macos")]
+            reset_exception_ports();
 
             // Set working directory, ignoring invalid paths.
             if let Some(working_directory) = working_directory.as_ref() {


### PR DESCRIPTION
On macOS, task exception ports are inherited across `fork`. If a parent process installs exception ports (e.g., for crash reporting), PTY child processes inherit them.

This adds a macOS-only reset in the PTY child `pre_exec` hook so that child processes start with exception ports restored to system defaults (`MACH_PORT_NULL`).

See also:
- https://github.com/zed-industries/zed/issues/36754
- https://github.com/zed-industries/zed/pull/44193
- https://github.com/zed-industries/zed/pull/48877