### PR TITLE
Fix typo: install the following packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -145,7 +145,7 @@ Compiles out of the box for 14.2
 
 #### Void Linux
 
-On [Void Linux](https://voidlinux.org), install following packages before
+On [Void Linux](https://voidlinux.org), install the following packages before
 compiling Alacritty:
 
 ```sh


### PR DESCRIPTION
Fix missing article 'the' in INSTALL.md Void Linux section. Changed 'install following packages' to 'install the following packages'.