### PR TITLE
docs: fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ a daily driver.
 
 Precompiled binaries are available from the [GitHub releases page](https://github.com/alacritty/alacritty/releases).
 
-Join [`#alacritty`] on libera.chat if you have questions or looking for a quick help.
+Join [`#alacritty`] on libera.chat if you have questions or are looking for quick help.
 
 [`#alacritty`]: https://web.libera.chat/gamja/?channels=#alacritty
 


### PR DESCRIPTION
## Summary
- Fix grammar in the README sentence about the libera.chat channel.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/alacritty/alacritty/blob/master/CONTRIBUTING.md

## Validation/testing
- Not run (docs change only)