### PR TITLE
docs: fix README feature overview wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Join [`#alacritty`] on libera.chat if you have questions or looking for a quick 
 
 ## Features
 
-You can find an overview over the features available in Alacritty [here](./docs/features.md).
+You can find an overview of the features available in Alacritty [here](./docs/features.md).
 
 ## Further information
 


### PR DESCRIPTION
## Summary
- fix the README wording for the features overview link
- keep the change limited to one docs file with no behavior impact

## Related issue
- N/A

## Guideline alignment
- Minimal docs-only change following the repo contribution guidance: https://github.com/alacritty/alacritty/blob/master/CONTRIBUTING.md

## Validation/testing
- Not run; README-only change
