### PR TITLE
Update link to TOML spec on alacritty(5) manpage

### DIFF
--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -7,7 +7,7 @@ Alacritty - TOML configuration file format.
 # SYNTAX
 
 Alacritty's configuration file uses the TOML format. The format's specification
-can be found at _https://toml.io/en/v1.0.0_.
+can be found at _https://toml.io/en/v1.1.0_.
 
 # LOCATION
 


### PR DESCRIPTION
Just a minor fix: #8814 missed to update the link to the TOML spec on the alacritty(5) manpage, so make up for that by making it point to the v1.1.0 site.