### PR TITLE
[Tabs] Adds support of in-window tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ which is closed with the `F - wontfix` label.
 <img width="1000" alt="alacritty tabs" src="https://github.com/user-attachments/assets/1abb3b24-19a7-417d-a277-98652552d3cf" />
 </p>
 
+## Example Tabs Config
+
+```toml
+[tabs]
+tab_bar_edge = "top"
+tab_bar_style = "slant"
+tab_powerline_style = "slanted"
+tab_bar_min_tabs = 1
+tab_switch_strategy = "previous"
+tab_title_template = "{title}"
+active_tab_foreground = "#1e1e2e"
+active_tab_background = "#cba6f7"
+active_tab_font_style = "italic"
+inactive_tab_foreground = "#cdd6f4"
+inactive_tab_background = "#0b0b12"
+inactive_tab_font_style = "normal"
+tab_bar_background = "#11111b"
+mouse = { enabled = true, hover = true }
+
+[keyboard]
+bindings = [
+  { key = "T", mods = "Super", action = "CreateNewTab" },
+  { key = "Right", mods = "Super", action = "SelectNextTab" },
+  { key = "Left", mods = "Super", action = "SelectPreviousTab" },
+  { key = "Tab", mods = "Super", action = "SelectNextTab" },
+  { key = "Tab", mods = "Super|Shift", action = "SelectPreviousTab" },
+  { key = "W", mods = "Super", action = "CloseTab" },
+  { key = ".", mods = "Super", action = "MoveTabForward" },
+  { key = ",", mods = "Super", action = "MoveTabBackward" },
+  { key = "T", mods = "Super|Alt", action = "SetTabTitle" },
+]
+```
+
 ## About
 
 Alacritty is a modern terminal emulator that comes with sensible defaults, but

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 <h1 align="center">Alacritty - A fast, cross-platform, OpenGL terminal emulator</h1>
 
+## This Fork
+
+This repository is a fork of Alacritty that adds in-window tabs, including a
+configurable tab bar, tab actions, and custom tab titles, similar to Kitty's
+tab workflow.
+
+Upstream Alacritty has historically declined adding tabs by design; see
+[Tabs support in the terminal (#3129)](https://github.com/alacritty/alacritty/issues/3129),
+which is closed with the `F - wontfix` label.
+
 <p align="center">
   <img alt="Alacritty - A fast, cross-platform, OpenGL terminal emulator"
        src="https://raw.githubusercontent.com/alacritty/alacritty/master/extra/promo/alacritty-readme.png">
@@ -101,9 +111,9 @@ usecases.
 
 Alacritty has many great features, but not every feature from every other
 terminal. This could be for a number of reasons, but sometimes it's just not a
-good fit for Alacritty. This means you won't find things like tabs or splits
-(which are best left to a window manager or [terminal multiplexer][tmux]) nor
-niceties like a GUI config editor.
+good fit for Alacritty. This means you won't find things like splits (which are
+best left to a window manager or [terminal multiplexer][tmux]) nor niceties
+like a GUI config editor.
 
 [tmux]: https://github.com/tmux/tmux
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Upstream Alacritty has historically declined adding tabs by design; see
 which is closed with the `F - wontfix` label.
 
 <p align="center">
-  <img alt="Alacritty - A fast, cross-platform, OpenGL terminal emulator"
-       src="https://raw.githubusercontent.com/alacritty/alacritty/master/extra/promo/alacritty-readme.png">
+<img width="1000" alt="alacritty tabs" src="https://github.com/user-attachments/assets/1abb3b24-19a7-417d-a277-98652552d3cf" />
 </p>
 
 ## About

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -181,6 +181,9 @@ pub enum Action {
     /// Spawn a new instance of Alacritty.
     SpawnNewInstance,
 
+    /// Close the active tab.
+    CloseTab,
+
     /// Select next tab.
     SelectNextTab,
 
@@ -216,6 +219,15 @@ pub enum Action {
 
     /// Select the last tab.
     SelectLastTab,
+
+    /// Move the active tab forward.
+    MoveTabForward,
+
+    /// Move the active tab backward.
+    MoveTabBackward,
+
+    /// Set a custom title for the active tab.
+    SetTabTitle,
 
     /// Create a new Alacritty window.
     CreateNewWindow,
@@ -558,6 +570,15 @@ fn common_keybindings() -> Vec<KeyBinding> {
         "-",    ModifiersState::CONTROL;                                                                 Action::DecreaseFontSize;
         "+" => KeyLocation::Numpad, ModifiersState::CONTROL;                                             Action::IncreaseFontSize;
         "-" => KeyLocation::Numpad, ModifiersState::CONTROL;                                             Action::DecreaseFontSize;
+        ArrowRight, ModifiersState::CONTROL | ModifiersState::SHIFT;                                     Action::SelectNextTab;
+        Tab,        ModifiersState::CONTROL;                                                             Action::SelectNextTab;
+        ArrowLeft,  ModifiersState::CONTROL | ModifiersState::SHIFT;                                     Action::SelectPreviousTab;
+        Tab,        ModifiersState::CONTROL | ModifiersState::SHIFT;                                     Action::SelectPreviousTab;
+        "t",        ModifiersState::CONTROL | ModifiersState::SHIFT;                                     Action::CreateNewTab;
+        "w",        ModifiersState::CONTROL | ModifiersState::SHIFT;                                     Action::CloseTab;
+        ".",        ModifiersState::CONTROL | ModifiersState::SHIFT;                                     Action::MoveTabForward;
+        ",",        ModifiersState::CONTROL | ModifiersState::SHIFT;                                     Action::MoveTabBackward;
+        "t",        ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT;              Action::SetTabTitle;
     )
 }
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -20,6 +20,7 @@ pub mod monitor;
 pub mod scrolling;
 pub mod selection;
 pub mod serde_utils;
+pub mod tabs;
 pub mod terminal;
 pub mod ui_config;
 pub mod window;

--- a/alacritty/src/config/tabs.rs
+++ b/alacritty/src/config/tabs.rs
@@ -1,0 +1,117 @@
+use serde::Serialize;
+
+use alacritty_config_derive::ConfigDeserialize;
+
+use crate::display::color::Rgb;
+
+#[derive(ConfigDeserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct Tabs {
+    pub tab_bar_edge: TabBarEdge,
+    pub tab_bar_style: TabBarStyle,
+    pub tab_powerline_style: TabPowerlineStyle,
+    pub tab_bar_min_tabs: usize,
+    pub tab_switch_strategy: TabSwitchStrategy,
+    pub tab_separator: String,
+    pub tab_title_template: String,
+    pub active_tab_title_template: Option<String>,
+    pub tab_title_max_length: usize,
+    pub active_tab_foreground: Option<Rgb>,
+    pub active_tab_background: Option<Rgb>,
+    pub active_tab_font_style: TabFontStyle,
+    pub inactive_tab_foreground: Option<Rgb>,
+    pub inactive_tab_background: Option<Rgb>,
+    pub inactive_tab_font_style: TabFontStyle,
+    pub tab_bar_background: Option<Rgb>,
+    pub mouse: TabMouse,
+}
+
+impl Tabs {
+    #[inline]
+    pub fn display_tab_bar(&self, tab_count: usize) -> bool {
+        self.tab_bar_style != TabBarStyle::Hidden && tab_count >= self.tab_bar_min_tabs
+    }
+}
+
+impl Default for Tabs {
+    fn default() -> Self {
+        Self {
+            tab_bar_edge: Default::default(),
+            tab_bar_style: Default::default(),
+            tab_powerline_style: Default::default(),
+            tab_bar_min_tabs: 2,
+            tab_switch_strategy: Default::default(),
+            tab_separator: String::from(" | "),
+            tab_title_template: String::from("{title}"),
+            active_tab_title_template: None,
+            tab_title_max_length: 0,
+            active_tab_foreground: None,
+            active_tab_background: None,
+            active_tab_font_style: Default::default(),
+            inactive_tab_foreground: None,
+            inactive_tab_background: None,
+            inactive_tab_font_style: Default::default(),
+            tab_bar_background: None,
+            mouse: Default::default(),
+        }
+    }
+}
+
+#[derive(ConfigDeserialize, Serialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TabBarEdge {
+    Top,
+    #[default]
+    Bottom,
+}
+
+#[derive(ConfigDeserialize, Serialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TabBarStyle {
+    Hidden,
+    Separator,
+    Slant,
+    #[default]
+    Powerline,
+    Fade,
+}
+
+#[derive(ConfigDeserialize, Serialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TabPowerlineStyle {
+    #[default]
+    Angled,
+    Slanted,
+    Round,
+}
+
+#[derive(ConfigDeserialize, Serialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TabSwitchStrategy {
+    #[default]
+    Previous,
+    Left,
+    Right,
+    Last,
+}
+
+#[derive(ConfigDeserialize, Serialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TabFontStyle {
+    #[default]
+    Normal,
+    Bold,
+    Italic,
+    BoldItalic,
+}
+
+#[derive(ConfigDeserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TabMouse {
+    pub enabled: bool,
+    pub hover: bool,
+}
+
+impl Default for TabMouse {
+    fn default() -> Self {
+        Self { enabled: true, hover: true }
+    }
+}

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -32,6 +32,7 @@ use crate::config::general::General;
 use crate::config::mouse::Mouse;
 use crate::config::scrolling::Scrolling;
 use crate::config::selection::Selection;
+use crate::config::tabs::Tabs;
 use crate::config::terminal::Terminal;
 use crate::config::window::WindowConfig;
 
@@ -62,6 +63,9 @@ pub struct UiConfig {
 
     /// Window configuration.
     pub window: WindowConfig,
+
+    /// Tab bar configuration.
+    pub tabs: Tabs,
 
     /// Mouse configuration.
     pub mouse: Mouse,

--- a/alacritty/src/display/damage.rs
+++ b/alacritty/src/display/damage.rs
@@ -226,7 +226,7 @@ impl<'a> RenderDamageIterator<'a> {
     #[inline]
     fn rect_for_line(&self, line_damage: LineDamageBounds) -> Rect {
         let size_info = &self.size_info;
-        let y_top = size_info.height() - size_info.padding_y();
+        let y_top = size_info.height() - size_info.padding_bottom_y();
         let x = size_info.padding_x() + line_damage.left as u32 * size_info.cell_width();
         let y = y_top - (line_damage.line + 1) as u32 * size_info.cell_height();
         let width = (line_damage.right - line_damage.left + 1) as u32 * size_info.cell_width();

--- a/alacritty/src/display/hint.rs
+++ b/alacritty/src/display/hint.rs
@@ -13,8 +13,8 @@ use alacritty_terminal::term::cell::Hyperlink;
 use alacritty_terminal::term::search::{Match, RegexIter, RegexSearch};
 use alacritty_terminal::term::{Term, TermMode};
 
-use crate::config::UiConfig;
 use crate::config::ui_config::{Hint, HintAction};
+use crate::config::UiConfig;
 
 /// Maximum number of linewraps followed outside of the viewport during search highlighting.
 pub const MAX_SEARCH_LINES: usize = 100;

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -32,28 +32,29 @@ use alacritty_terminal::index::{Column, Direction, Line, Point};
 use alacritty_terminal::selection::Selection;
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::{
-    self, LineDamageBounds, MIN_COLUMNS, MIN_SCREEN_LINES, Term, TermDamage, TermMode,
+    self, LineDamageBounds, Term, TermDamage, TermMode, MIN_COLUMNS, MIN_SCREEN_LINES,
 };
 use alacritty_terminal::vte::ansi::{CursorShape, NamedColor};
 
-use crate::config::UiConfig;
 use crate::config::debug::RendererPreference;
 use crate::config::font::Font;
+use crate::config::tabs::{TabBarEdge, TabBarStyle, TabFontStyle, TabPowerlineStyle};
 use crate::config::window::Dimensions;
 #[cfg(not(windows))]
 use crate::config::window::StartupMode;
+use crate::config::UiConfig;
 use crate::display::bell::VisualBell;
 use crate::display::color::{List, Rgb};
 use crate::display::content::{RenderableContent, RenderableCursor};
 use crate::display::cursor::IntoRects;
-use crate::display::damage::{DamageTracker, damage_y_to_viewport_y};
+use crate::display::damage::{damage_y_to_viewport_y, DamageTracker};
 use crate::display::hint::{HintMatch, HintState};
 use crate::display::meter::Meter;
 use crate::display::window::Window;
 use crate::event::{Event, EventType, Mouse, SearchState};
 use crate::message_bar::{MessageBuffer, MessageType};
 use crate::renderer::rects::{RenderLine, RenderLines, RenderRect};
-use crate::renderer::{self, GlyphCache, Renderer, platform};
+use crate::renderer::{self, platform, GlyphCache, Renderer};
 use crate::scheduler::{Scheduler, TimerId, Topic};
 use crate::string::{ShortenDirection, StrShortener};
 
@@ -161,6 +162,9 @@ pub struct SizeInfo<T = f32> {
     /// Vertical window padding.
     padding_y: T,
 
+    /// Bottom window padding.
+    padding_bottom_y: T,
+
     /// Number of lines in the viewport.
     screen_lines: usize,
 
@@ -177,8 +181,9 @@ impl From<SizeInfo<f32>> for SizeInfo<u32> {
             cell_height: size_info.cell_height as u32,
             padding_x: size_info.padding_x as u32,
             padding_y: size_info.padding_y as u32,
+            padding_bottom_y: size_info.padding_bottom_y as u32,
             screen_lines: size_info.screen_lines,
-            columns: size_info.screen_lines,
+            columns: size_info.columns,
         }
     }
 }
@@ -224,6 +229,11 @@ impl<T: Clone + Copy> SizeInfo<T> {
     pub fn padding_y(&self) -> T {
         self.padding_y
     }
+
+    #[inline]
+    pub fn padding_bottom_y(&self) -> T {
+        self.padding_bottom_y
+    }
 }
 
 impl SizeInfo<f32> {
@@ -255,6 +265,7 @@ impl SizeInfo<f32> {
             cell_height,
             padding_x: padding_x.floor(),
             padding_y: padding_y.floor(),
+            padding_bottom_y: padding_y.floor(),
             screen_lines,
             columns,
         }
@@ -263,6 +274,11 @@ impl SizeInfo<f32> {
     #[inline]
     pub fn reserve_lines(&mut self, count: usize) {
         self.screen_lines = cmp::max(self.screen_lines.saturating_sub(count), MIN_SCREEN_LINES);
+    }
+
+    #[inline]
+    pub fn add_top_padding(&mut self, padding: f32) {
+        self.padding_y += padding;
     }
 
     /// Check if coordinates are inside the terminal grid.
@@ -387,6 +403,7 @@ pub struct Display {
 
     // Mouse point position when highlighting hints.
     hint_mouse_point: Option<Point>,
+    tab_hit_boxes: Vec<TabHitBox>,
 
     renderer: ManuallyDrop<Renderer>,
     renderer_preference: Option<RendererPreference>,
@@ -397,6 +414,15 @@ pub struct Display {
 
     glyph_cache: GlyphCache,
     meter: Meter,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TabHitBox {
+    index: usize,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
 }
 
 impl Display {
@@ -535,6 +561,7 @@ impl Display {
             vi_highlighted_hint: Default::default(),
             highlighted_hint: Default::default(),
             hint_mouse_point: Default::default(),
+            tab_hit_boxes: Default::default(),
             pending_update: Default::default(),
             cursor_hidden: Default::default(),
             meter: Default::default(),
@@ -655,6 +682,9 @@ impl Display {
         message_buffer: &MessageBuffer,
         search_state: &mut SearchState,
         config: &UiConfig,
+        tab_bar_lines: usize,
+        top_tab_bar_lines: usize,
+        tab_title_editor_lines: usize,
     ) where
         T: EventListener,
     {
@@ -703,7 +733,10 @@ impl Display {
         let search_active = search_state.history_index.is_some();
         let message_bar_lines = message_buffer.message().map_or(0, |m| m.text(&new_size).len());
         let search_lines = usize::from(search_active);
-        new_size.reserve_lines(message_bar_lines + search_lines);
+        new_size.reserve_lines(
+            message_bar_lines + search_lines + tab_bar_lines + tab_title_editor_lines,
+        );
+        new_size.add_top_padding(top_tab_bar_lines as f32 * new_size.cell_height());
 
         // Update resize increments.
         if config.window.resize_increments {
@@ -779,6 +812,8 @@ impl Display {
         message_buffer: &MessageBuffer,
         config: &UiConfig,
         search_state: &mut SearchState,
+        tab_titles: &[(String, bool)],
+        tab_title_editor: Option<&str>,
     ) {
         // Collect renderable content before the terminal is dropped.
         let mut content = RenderableContent::new(config, self, &terminal, search_state);
@@ -961,8 +996,11 @@ impl Display {
             }
         }
 
+        let tab_title_editor_offset = usize::from(tab_title_editor.is_some());
+
         if let Some(message) = message_buffer.message() {
-            let search_offset = usize::from(search_state.regex().is_some());
+            let search_offset =
+                usize::from(search_state.regex().is_some()) + tab_title_editor_offset;
             let text = message.text(&size_info);
 
             // Create a new rectangle for the background.
@@ -1008,6 +1046,35 @@ impl Display {
             self.renderer.draw_rects(&size_info, &metrics, rects);
         }
 
+        if let Some(tab_title_editor) = tab_title_editor {
+            let line = size_info.screen_lines() + usize::from(search_state.regex().is_some());
+            self.draw_footer_text(
+                config,
+                &format_search_prompt("Tab title: ", tab_title_editor, size_info.columns()),
+                line,
+            );
+            let y = size_info.cell_height().mul_add(line as f32, size_info.padding_y()) as i32;
+            let width = size_info.width() as i32;
+            let height = size_info.cell_height() as i32;
+            self.damage_tracker.frame().add_viewport_rect(&size_info, 0, y, width, height);
+            self.damage_tracker.next_frame().add_viewport_rect(&size_info, 0, y, width, height);
+        }
+
+        self.tab_hit_boxes.clear();
+        if config.tabs.display_tab_bar(tab_titles.len()) {
+            let line = match config.tabs.tab_bar_edge {
+                TabBarEdge::Top => 0,
+                TabBarEdge::Bottom => {
+                    let search_lines =
+                        usize::from(search_state.regex().is_some()) + tab_title_editor_offset;
+                    let message_lines =
+                        message_buffer.message().map_or(0, |m| m.text(&size_info).len());
+                    size_info.screen_lines() + search_lines + message_lines
+                },
+            };
+            self.draw_tab_bar(config, tab_titles, line);
+        }
+
         self.draw_render_timer(config);
 
         // Draw hyperlink uri preview.
@@ -1051,6 +1118,14 @@ impl Display {
         self.damage_tracker.debug = config.debug.highlight_damage;
         self.visual_bell.update_config(&config.bell);
         self.colors = List::from(&config.colors);
+    }
+
+    pub fn tab_at_position(&self, x: usize, y: usize) -> Option<usize> {
+        self.tab_hit_boxes.iter().find_map(|hit_box| {
+            let inside_x = (hit_box.x..hit_box.x + hit_box.width).contains(&(x as i32));
+            let inside_y = (hit_box.y..hit_box.y + hit_box.height).contains(&(y as i32));
+            (inside_x && inside_y).then_some(hit_box.index)
+        })
     }
 
     /// Update the mouse/vi mode cursor hint highlighting.
@@ -1306,11 +1381,16 @@ impl Display {
     /// Draw current search regex.
     #[inline(never)]
     fn draw_search(&mut self, config: &UiConfig, text: &str) {
+        self.draw_footer_text(config, text, self.size_info.screen_lines());
+    }
+
+    #[inline(never)]
+    fn draw_footer_text(&mut self, config: &UiConfig, text: &str, line: usize) {
         // Assure text length is at least num_cols.
         let num_cols = self.size_info.columns();
         let text = format!("{text:<num_cols$}");
 
-        let point = Point::new(self.size_info.screen_lines(), Column(0));
+        let point = Point::new(line, Column(0));
 
         let fg = config.colors.footer_bar_foreground();
         let bg = config.colors.footer_bar_background();
@@ -1323,6 +1403,341 @@ impl Display {
             &self.size_info,
             &mut self.glyph_cache,
         );
+    }
+
+    fn draw_string_with_flags(
+        &mut self,
+        point: Point<usize>,
+        fg: Rgb,
+        bg: Rgb,
+        bg_alpha: f32,
+        text: &str,
+        size_info: &SizeInfo,
+        flags: Flags,
+    ) -> usize {
+        let mut cells = Vec::with_capacity(text.chars().count());
+        let mut column = point.column.0;
+
+        for character in text.chars() {
+            let width = character.width().unwrap_or(1);
+            let cell_flags = if width == 2 { flags | Flags::WIDE_CHAR } else { flags };
+
+            cells.push(crate::display::content::RenderableCell {
+                point: Point::new(point.line, Column(column)),
+                character,
+                extra: None,
+                flags: cell_flags,
+                bg_alpha,
+                fg,
+                bg,
+                underline: fg,
+            });
+
+            column += width;
+        }
+
+        self.renderer.draw_cells(size_info, &mut self.glyph_cache, cells.into_iter());
+        column - point.column.0
+    }
+
+    #[inline(never)]
+    fn draw_tab_bar(&mut self, config: &UiConfig, tab_titles: &[(String, bool)], line: usize) {
+        let mut size_info = self.size_info;
+        if config.tabs.tab_bar_edge == TabBarEdge::Top {
+            size_info.padding_y -= size_info.cell_height();
+        }
+
+        self.renderer.set_viewport(&size_info);
+
+        let num_cols = self.size_info.columns();
+        let default_bar_bg = config.colors.primary.background * 0.8;
+        let bar_bg = config.tabs.tab_bar_background.unwrap_or(default_bar_bg);
+        let translucent_alpha = tab_bar_background_alpha(config.window_opacity());
+        let rendered_bar_bg = if config.window_opacity() < 1.0 {
+            darken_rgb(bar_bg, 0.5)
+        } else {
+            bar_bg
+        };
+        let visible_bar_bg =
+            blend_rgb(config.colors.primary.background, rendered_bar_bg, translucent_alpha);
+        let active_fg =
+            config.tabs.active_tab_foreground.unwrap_or(config.colors.footer_bar_foreground());
+        let active_bg =
+            config.tabs.active_tab_background.unwrap_or(config.colors.footer_bar_background());
+        let inactive_fg =
+            config.tabs.inactive_tab_foreground.unwrap_or(config.colors.primary.foreground);
+        let default_inactive_bg = if config.window_opacity() < 1.0 {
+            darken_rgb(bar_bg, 0.82)
+        } else {
+            bar_bg
+        };
+        let inactive_bg = config.tabs.inactive_tab_background.unwrap_or(default_inactive_bg);
+
+        let y = size_info.cell_height().mul_add(line as f32, size_info.padding_y()) as i32;
+        let width = size_info.width() as i32;
+        let height = size_info.cell_height() as i32;
+        self.damage_tracker.frame().add_viewport_rect(&size_info, 0, y, width, height);
+        self.damage_tracker.next_frame().add_viewport_rect(&size_info, 0, y, width, height);
+
+        let metrics = self.glyph_cache.font_metrics();
+        let mut rects = vec![RenderRect::new(
+            0.,
+            y as f32,
+            width as f32,
+            height as f32,
+            rendered_bar_bg,
+            translucent_alpha,
+        )];
+
+        if config.tabs.tab_bar_style == TabBarStyle::Slant {
+            let mut column = 0usize;
+
+            for (index, (title, active)) in tab_titles.iter().enumerate() {
+                if column >= num_cols {
+                    break;
+                }
+
+                let tab_bg = if *active {
+                    active_bg
+                } else {
+                    inactive_bg
+                };
+                let rendered_tab_bg = if *active {
+                    tab_bg
+                } else {
+                    blend_rgb(config.colors.primary.background, tab_bg, translucent_alpha)
+                };
+                let next_bg = tab_titles
+                    .get(index + 1)
+                    .map(|(_, active)| {
+                        if *active {
+                            active_bg
+                        } else {
+                            blend_rgb(config.colors.primary.background, inactive_bg, translucent_alpha)
+                        }
+                    })
+                    .unwrap_or(visible_bar_bg);
+                let needs_separator = rendered_tab_bg != next_bg;
+                let reserve = usize::from(needs_separator);
+                let visible: String = StrShortener::new(
+                    &format!(" {title} "),
+                    num_cols.saturating_sub(column + reserve),
+                    ShortenDirection::Right,
+                    Some(SHORTENER),
+                )
+                .collect();
+                let width_cells: usize =
+                    visible.chars().map(|character| character.width().unwrap_or(1)).sum();
+
+                if width_cells == 0 {
+                    break;
+                }
+
+                let body_x = size_info.padding_x() + size_info.cell_width() * column as f32;
+                let body_width = size_info.cell_width() * width_cells as f32;
+                rects.push(RenderRect::new(
+                    body_x,
+                    y as f32,
+                    body_width,
+                    height as f32,
+                    rendered_tab_bg,
+                    1.0,
+                ));
+
+                if needs_separator {
+                    let separator_x = body_x + body_width;
+                    add_slanted_separator_rects(
+                        &mut rects,
+                        separator_x,
+                        y as f32,
+                        size_info.cell_width(),
+                        height as f32,
+                        rendered_tab_bg,
+                        next_bg,
+                    );
+                }
+
+                self.tab_hit_boxes.push(TabHitBox {
+                    index,
+                    x: body_x as i32,
+                    y,
+                    width: (size_info.cell_width() * (width_cells + reserve) as f32) as i32,
+                    height,
+                });
+
+                column += width_cells + reserve;
+            }
+
+            self.renderer.draw_rects(&size_info, &metrics, rects);
+
+            let mut column = 0usize;
+            for (index, (title, active)) in tab_titles.iter().enumerate() {
+                if column >= num_cols {
+                    break;
+                }
+
+                let (tab_fg, tab_bg, font_style) = if *active {
+                    (active_fg, active_bg, config.tabs.active_tab_font_style)
+                } else {
+                    (inactive_fg, inactive_bg, config.tabs.inactive_tab_font_style)
+                };
+                let rendered_tab_bg = if *active {
+                    tab_bg
+                } else {
+                    blend_rgb(config.colors.primary.background, tab_bg, translucent_alpha)
+                };
+                let next_bg = tab_titles
+                    .get(index + 1)
+                    .map(|(_, active)| {
+                        if *active {
+                            active_bg
+                        } else {
+                            blend_rgb(config.colors.primary.background, inactive_bg, translucent_alpha)
+                        }
+                    })
+                    .unwrap_or(visible_bar_bg);
+                let reserve = usize::from(rendered_tab_bg != next_bg);
+                let visible: String = StrShortener::new(
+                    &format!(" {title} "),
+                    num_cols.saturating_sub(column + reserve),
+                    ShortenDirection::Right,
+                    Some(SHORTENER),
+                )
+                .collect();
+                let width_cells: usize =
+                    visible.chars().map(|character| character.width().unwrap_or(1)).sum();
+
+                if width_cells == 0 {
+                    break;
+                }
+
+                self.draw_string_with_flags(
+                    Point::new(line, Column(column)),
+                    tab_fg,
+                    rendered_tab_bg,
+                    0.0,
+                    &visible,
+                    &size_info,
+                    tab_font_flags(font_style),
+                );
+                column += width_cells + reserve;
+            }
+
+            self.renderer.set_viewport(&self.size_info);
+            return;
+        }
+
+        self.renderer.draw_rects(&size_info, &metrics, rects);
+        let mut column = 0usize;
+        for (index, (title, active)) in tab_titles.iter().enumerate() {
+            if column >= num_cols {
+                break;
+            }
+
+            let title = if config.tabs.tab_title_max_length == 0 {
+                title.clone()
+            } else {
+                StrShortener::new(
+                    title,
+                    config.tabs.tab_title_max_length,
+                    ShortenDirection::Right,
+                    Some(SHORTENER),
+                )
+                .collect()
+            };
+            let label = format!(" {title} ");
+            let reserve = match config.tabs.tab_bar_style {
+                TabBarStyle::Powerline => 1,
+                TabBarStyle::Hidden => 0,
+                TabBarStyle::Separator | TabBarStyle::Fade => {
+                    if index + 1 < tab_titles.len() {
+                        config.tabs.tab_separator.chars().count()
+                    } else {
+                        0
+                    }
+                },
+                TabBarStyle::Slant => 0,
+            };
+            let visible: String = StrShortener::new(
+                &label,
+                num_cols.saturating_sub(column + reserve),
+                ShortenDirection::Right,
+                Some(SHORTENER),
+            )
+            .collect();
+
+            let (tab_fg, tab_bg, font_style) = if *active {
+                (active_fg, active_bg, config.tabs.active_tab_font_style)
+            } else {
+                (inactive_fg, inactive_bg, config.tabs.inactive_tab_font_style)
+            };
+            let width_cells: usize =
+                visible.chars().map(|character| character.width().unwrap_or(1)).sum();
+            let hit_box_column = column;
+            let bg_alpha = if *active {
+                1.0
+            } else if tab_bg == bar_bg {
+                0.0
+            } else {
+                translucent_alpha
+            };
+
+            column += self.draw_string_with_flags(
+                Point::new(line, Column(column)),
+                tab_fg,
+                tab_bg,
+                bg_alpha,
+                &visible,
+                &size_info,
+                tab_font_flags(font_style),
+            );
+
+            let separator_width = match config.tabs.tab_bar_style {
+                TabBarStyle::Powerline => {
+                    let next_bg = tab_titles
+                        .get(index + 1)
+                        .map(|(_, active)| if *active { active_bg } else { inactive_bg })
+                        .unwrap_or(bar_bg);
+                    let separator = if index + 1 < tab_titles.len() {
+                        powerline_separator(config.tabs.tab_powerline_style)
+                    } else {
+                        trailing_powerline_separator(config.tabs.tab_powerline_style)
+                    }
+                    .to_string();
+                    self.draw_string_with_flags(
+                        Point::new(line, Column(column)),
+                        tab_bg,
+                        next_bg,
+                        if next_bg == bar_bg { translucent_alpha } else { 1.0 },
+                        &separator,
+                        &size_info,
+                        Flags::empty(),
+                    )
+                },
+                TabBarStyle::Separator | TabBarStyle::Fade if index + 1 < tab_titles.len() => self
+                    .draw_string_with_flags(
+                        Point::new(line, Column(column)),
+                        inactive_fg,
+                        bar_bg,
+                        translucent_alpha,
+                        &config.tabs.tab_separator,
+                        &size_info,
+                        Flags::empty(),
+                    ),
+                _ => 0,
+            };
+            column += separator_width;
+
+            self.tab_hit_boxes.push(TabHitBox {
+                index,
+                x: (size_info.padding_x() + size_info.cell_width() * hit_box_column as f32) as i32,
+                y,
+                width: (size_info.cell_width() * (width_cells + separator_width) as f32) as i32,
+                height,
+            });
+        }
+
+        self.renderer.set_viewport(&self.size_info);
     }
 
     /// Draw render timer.
@@ -1456,6 +1871,138 @@ impl Display {
 
         scheduler.schedule(event, swap_timeout, false, timer_id);
     }
+}
+
+fn tab_font_flags(style: TabFontStyle) -> Flags {
+    match style {
+        TabFontStyle::Normal => Flags::empty(),
+        TabFontStyle::Bold => Flags::BOLD,
+        TabFontStyle::Italic => Flags::ITALIC,
+        TabFontStyle::BoldItalic => Flags::BOLD_ITALIC,
+    }
+}
+
+fn powerline_separator(style: TabPowerlineStyle) -> char {
+    match style {
+        TabPowerlineStyle::Angled => '\u{e0b0}',
+        TabPowerlineStyle::Slanted => '\u{e0bc}',
+        TabPowerlineStyle::Round => '\u{e0b4}',
+    }
+}
+
+fn trailing_powerline_separator(style: TabPowerlineStyle) -> char {
+    match style {
+        TabPowerlineStyle::Angled => '\u{e0b0}',
+        TabPowerlineStyle::Slanted => '\u{e0be}',
+        TabPowerlineStyle::Round => '\u{e0b4}',
+    }
+}
+
+fn tab_bar_background_alpha(window_opacity: f32) -> f32 {
+    if window_opacity >= 1.0 {
+        1.0
+    } else {
+        (window_opacity * 0.35).clamp(0.08, 0.35)
+    }
+}
+
+fn blend_rgb(lhs: Rgb, rhs: Rgb, factor: f32) -> Rgb {
+    let factor = factor.clamp(0.0, 1.0);
+    let inv = 1.0 - factor;
+    let (lr, lg, lb) = lhs.as_tuple();
+    let (rr, rg, rb) = rhs.as_tuple();
+
+    Rgb::new(
+        (lr as f32 * inv + rr as f32 * factor).round() as u8,
+        (lg as f32 * inv + rg as f32 * factor).round() as u8,
+        (lb as f32 * inv + rb as f32 * factor).round() as u8,
+    )
+}
+
+fn darken_rgb(color: Rgb, factor: f32) -> Rgb {
+    let factor = factor.clamp(0.0, 1.0);
+    let (r, g, b) = color.as_tuple();
+    Rgb::new(
+        (r as f32 * factor).round() as u8,
+        (g as f32 * factor).round() as u8,
+        (b as f32 * factor).round() as u8,
+    )
+}
+
+fn add_slanted_separator_rects(
+    rects: &mut Vec<RenderRect>,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    left_color: Rgb,
+    right_color: Rgb,
+) {
+    let strip_count = ((height * 2.0).round() as i32).max(1);
+    let strip_height = height / strip_count as f32;
+
+    for strip in 0..strip_count {
+        let progress = (strip as f32 + 0.5) / strip_count as f32;
+        let boundary = x + (1.0 - progress) * width;
+        add_antialiased_strip(rects, x, y + strip as f32 * strip_height, boundary, strip_height, left_color);
+        add_antialiased_strip(
+            rects,
+            boundary,
+            y + strip as f32 * strip_height,
+            x + width,
+            strip_height,
+            right_color,
+        );
+    }
+}
+
+fn add_antialiased_strip(
+    rects: &mut Vec<RenderRect>,
+    left: f32,
+    y: f32,
+    right: f32,
+    height: f32,
+    color: Rgb,
+) {
+    if right <= left || height <= 0.0 {
+        return;
+    }
+
+    let left_floor = left.floor();
+    let right_floor = right.floor();
+    let left_partial = left.fract() > f32::EPSILON;
+    let right_partial = right.fract() > f32::EPSILON;
+
+    if left_floor == right_floor {
+        rects.push(RenderRect::new(left_floor, y, 1.0, height, color, (right - left).clamp(0.0, 1.0)));
+        return;
+    }
+
+    if left_partial {
+        rects.push(RenderRect::new(
+            left_floor,
+            y,
+            1.0,
+            height,
+            color,
+            (left_floor + 1.0 - left).clamp(0.0, 1.0),
+        ));
+    }
+
+    let full_start = if left_partial { left_floor + 1.0 } else { left_floor };
+    let full_end = right_floor;
+    if full_end > full_start {
+        rects.push(RenderRect::new(full_start, y, full_end - full_start, height, color, 1.0));
+    }
+
+    if right_partial {
+        rects.push(RenderRect::new(right_floor, y, 1.0, height, color, right.fract()));
+    }
+}
+
+fn format_search_prompt(label: &str, value: &str, max_width: usize) -> String {
+    let text = format!("{label}{value}_");
+    format!("{text:<max_width$}")
 }
 
 impl Drop for Display {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -343,10 +343,8 @@ impl ApplicationHandler<Event> for Processor {
             (EventType::ConfigReload(path), _) => {
                 // Clear config logs from message bar for all terminals.
                 for window_context in self.windows.values_mut() {
-                    if !window_context.message_buffer.is_empty() {
-                        window_context.message_buffer.remove_target(LOG_TARGET_CONFIG);
-                        window_context.display.pending_update.dirty = true;
-                    }
+                    window_context.clear_config_messages(LOG_TARGET_CONFIG);
+                    window_context.display.pending_update.dirty = true;
                 }
 
                 // Load config and update each terminal.
@@ -408,35 +406,35 @@ impl ApplicationHandler<Event> for Processor {
             },
             (EventType::Terminal(TerminalEvent::Wakeup), Some(window_id)) => {
                 if let Some(window_context) = self.windows.get_mut(window_id) {
-                    window_context.dirty = true;
-                    if window_context.display.window.has_frame {
+                    window_context.handle_tab_wakeup(event.tab_id);
+                    if window_context.dirty && window_context.display.window.has_frame {
                         window_context.display.window.request_redraw();
                     }
                 }
             },
             (EventType::Terminal(TerminalEvent::Exit), Some(window_id)) => {
-                // Remove the closed terminal.
-                let window_context = match self.windows.entry(*window_id) {
-                    // Don't exit when terminal exits if user asked to hold the window.
-                    Entry::Occupied(window_context)
-                        if !window_context.get().display.window.hold =>
-                    {
-                        window_context.remove()
-                    },
-                    _ => return,
+                let close_window = match self.windows.get_mut(window_id) {
+                    Some(window_context) => window_context.handle_tab_exit(event.tab_id),
+                    None => false,
                 };
 
-                // Unschedule pending events.
-                self.scheduler.unschedule_window(window_context.id());
+                if close_window {
+                    let window_context = match self.windows.entry(*window_id) {
+                        Entry::Occupied(window_context) => window_context.remove(),
+                        Entry::Vacant(_) => return,
+                    };
 
-                // Shutdown if no more terminals are open.
-                if self.windows.is_empty() && !self.cli_options.daemon {
-                    // Write ref tests of last window to disk.
-                    if self.config.debug.ref_test {
-                        window_context.write_ref_test_results();
+                    // Unschedule pending events.
+                    self.scheduler.unschedule_window(window_context.id());
+
+                    // Shutdown if no more terminals are open.
+                    if self.windows.is_empty() && !self.cli_options.daemon {
+                        if self.config.debug.ref_test {
+                            window_context.write_ref_test_results();
+                        }
+
+                        event_loop.exit();
                     }
-
-                    event_loop.exit();
                 }
             },
             // NOTE: This event bypasses batching to minimize input latency.
@@ -520,15 +518,26 @@ impl ApplicationHandler<Event> for Processor {
 #[derive(Debug, Clone)]
 pub struct Event {
     /// Limit event to a specific window.
-    window_id: Option<WindowId>,
+    pub(crate) window_id: Option<WindowId>,
+
+    /// Limit event to a specific tab inside the window.
+    pub(crate) tab_id: Option<TabId>,
 
     /// Event payload.
-    payload: EventType,
+    pub(crate) payload: EventType,
 }
 
 impl Event {
     pub fn new<I: Into<Option<WindowId>>>(payload: EventType, window_id: I) -> Self {
-        Self { window_id: window_id.into(), payload }
+        Self { window_id: window_id.into(), tab_id: None, payload }
+    }
+
+    pub fn with_tab<I: Into<Option<WindowId>>>(
+        payload: EventType,
+        window_id: I,
+        tab_id: TabId,
+    ) -> Self {
+        Self { window_id: window_id.into(), tab_id: Some(tab_id), payload }
     }
 }
 
@@ -546,6 +555,7 @@ pub enum EventType {
     Message(Message),
     Scroll(Scroll),
     CreateWindow(WindowOptions),
+    Tab(TabAction),
     #[cfg(unix)]
     IpcConfig(IpcConfig),
     #[cfg(unix)]
@@ -562,6 +572,26 @@ impl From<TerminalEvent> for EventType {
     fn from(event: TerminalEvent) -> Self {
         Self::Terminal(event)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TabId(pub u64);
+
+#[derive(Debug, Clone)]
+pub enum TabAction {
+    Create,
+    Close,
+    SelectNext,
+    SelectPrevious,
+    Select(usize),
+    SelectLast,
+    MoveForward,
+    MoveBackward,
+    SetTitle,
+    ConfirmTitle,
+    CancelTitle,
+    TitleInput(char),
+    TitlePopWord,
 }
 
 /// Regex search state.
@@ -663,6 +693,11 @@ impl Default for InlineSearchState {
 pub struct ActionContext<'a, N, T> {
     pub notifier: &'a mut N,
     pub terminal: &'a mut Term<T>,
+    pub tab_terminal_title: &'a mut Option<String>,
+    pub tab_detected_title: &'a str,
+    pub tab_custom_title: &'a mut Option<String>,
+    pub tab_title_editor_active: bool,
+    pub is_active_tab: bool,
     pub clipboard: &'a mut Clipboard,
     pub mouse: &'a mut Mouse,
     pub touch: &'a mut TouchPurpose,
@@ -879,6 +914,103 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         }
 
         self.spawn_daemon(&alacritty, &args);
+    }
+
+    fn create_new_tab(&mut self) {
+        let _ = self
+            .event_proxy
+            .send_event(Event::new(EventType::Tab(TabAction::Create), self.display.window.id()));
+    }
+
+    fn close_tab(&mut self) {
+        let _ = self
+            .event_proxy
+            .send_event(Event::new(EventType::Tab(TabAction::Close), self.display.window.id()));
+    }
+
+    fn select_next_tab(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::SelectNext),
+            self.display.window.id(),
+        ));
+    }
+
+    fn select_previous_tab(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::SelectPrevious),
+            self.display.window.id(),
+        ));
+    }
+
+    fn select_tab_at_index(&mut self, index: usize) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::Select(index)),
+            self.display.window.id(),
+        ));
+    }
+
+    fn select_last_tab(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::SelectLast),
+            self.display.window.id(),
+        ));
+    }
+
+    fn move_tab_forward(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::MoveForward),
+            self.display.window.id(),
+        ));
+    }
+
+    fn move_tab_backward(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::MoveBackward),
+            self.display.window.id(),
+        ));
+    }
+
+    fn set_tab_title(&mut self) {
+        let _ = self
+            .event_proxy
+            .send_event(Event::new(EventType::Tab(TabAction::SetTitle), self.display.window.id()));
+    }
+
+    fn tab_at_mouse(&mut self) -> Option<usize> {
+        let mouse = &*self.mouse;
+        self.display.tab_at_position(mouse.x, mouse.y)
+    }
+
+    fn tab_title_editor_active(&self) -> bool {
+        self.tab_title_editor_active
+    }
+
+    fn confirm_tab_title(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::ConfirmTitle),
+            self.display.window.id(),
+        ));
+    }
+
+    fn cancel_tab_title(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::CancelTitle),
+            self.display.window.id(),
+        ));
+    }
+
+    fn tab_title_input(&mut self, c: char) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::TitleInput(c)),
+            self.display.window.id(),
+        ));
+    }
+
+    fn tab_title_pop_word(&mut self) {
+        let _ = self.event_proxy.send_event(Event::new(
+            EventType::Tab(TabAction::TitlePopWord),
+            self.display.window.id(),
+        ));
     }
 
     #[cfg(not(windows))]
@@ -1866,15 +1998,30 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                 },
                 EventType::Terminal(event) => match event {
                     TerminalEvent::Title(title) => {
-                        if !self.ctx.preserve_title && self.ctx.config.window.dynamic_title {
+                        *self.ctx.tab_terminal_title = Some(title.clone());
+                        if self.ctx.is_active_tab
+                            && self.ctx.tab_custom_title.is_none()
+                            && !self.ctx.preserve_title
+                            && self.ctx.config.window.dynamic_title
+                        {
                             self.ctx.window().set_title(title);
                         }
+                        *self.ctx.dirty = true;
                     },
                     TerminalEvent::ResetTitle => {
+                        *self.ctx.tab_terminal_title = None;
                         let window_config = &self.ctx.config.window;
-                        if !self.ctx.preserve_title && window_config.dynamic_title {
-                            self.ctx.display.window.set_title(window_config.identity.title.clone());
+                        if self.ctx.is_active_tab
+                            && self.ctx.tab_custom_title.is_none()
+                            && !self.ctx.preserve_title
+                            && window_config.dynamic_title
+                        {
+                            self.ctx
+                                .display
+                                .window
+                                .set_title(self.ctx.tab_detected_title.to_owned());
                         }
+                        *self.ctx.dirty = true;
                     },
                     TerminalEvent::Bell => {
                         // Set window urgency hint when window is not focused.
@@ -1930,6 +2077,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                 },
                 #[cfg(unix)]
                 EventType::IpcConfig(_) | EventType::IpcGetConfig(..) | EventType::Shutdown => (),
+                EventType::Tab(_) => (),
                 EventType::Message(_)
                 | EventType::ConfigReload(_)
                 | EventType::CreateWindow(_)
@@ -2073,21 +2221,22 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
 pub struct EventProxy {
     proxy: EventLoopProxy<Event>,
     window_id: WindowId,
+    tab_id: TabId,
 }
 
 impl EventProxy {
-    pub fn new(proxy: EventLoopProxy<Event>, window_id: WindowId) -> Self {
-        Self { proxy, window_id }
+    pub fn new(proxy: EventLoopProxy<Event>, window_id: WindowId, tab_id: TabId) -> Self {
+        Self { proxy, window_id, tab_id }
     }
 
     /// Send an event to the event loop.
     pub fn send_event(&self, event: EventType) {
-        let _ = self.proxy.send_event(Event::new(event, self.window_id));
+        let _ = self.proxy.send_event(Event::with_tab(event, self.window_id, self.tab_id));
     }
 }
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: TerminalEvent) {
-        let _ = self.proxy.send_event(Event::new(event.into(), self.window_id));
+        let _ = self.proxy.send_event(Event::with_tab(event.into(), self.window_id, self.tab_id));
     }
 }

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -53,6 +53,25 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             return;
         }
 
+        if self.ctx.tab_title_editor_active() {
+            match key.logical_key.as_ref() {
+                Key::Named(NamedKey::Enter) => self.ctx.confirm_tab_title(),
+                Key::Named(NamedKey::Escape) => self.ctx.cancel_tab_title(),
+                Key::Named(NamedKey::Backspace) => self.ctx.tab_title_input('\x7f'),
+                _ if mods.control_key()
+                    && matches!(key.logical_key.as_ref(), Key::Character("w")) =>
+                {
+                    self.ctx.tab_title_pop_word()
+                },
+                _ => {
+                    for character in text.chars() {
+                        self.ctx.tab_title_input(character);
+                    }
+                },
+            }
+            return;
+        }
+
         // Reset search delay when the user is still typing.
         self.reset_search_delay();
 

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -99,6 +99,25 @@ pub trait ActionContext<T: EventListener> {
     fn terminal(&self) -> &Term<T>;
     fn terminal_mut(&mut self) -> &mut Term<T>;
     fn spawn_new_instance(&mut self) {}
+    fn create_new_tab(&mut self) {}
+    fn close_tab(&mut self) {}
+    fn select_next_tab(&mut self) {}
+    fn select_previous_tab(&mut self) {}
+    fn select_tab_at_index(&mut self, _index: usize) {}
+    fn select_last_tab(&mut self) {}
+    fn move_tab_forward(&mut self) {}
+    fn move_tab_backward(&mut self) {}
+    fn set_tab_title(&mut self) {}
+    fn tab_at_mouse(&mut self) -> Option<usize> {
+        None
+    }
+    fn tab_title_editor_active(&self) -> bool {
+        false
+    }
+    fn confirm_tab_title(&mut self) {}
+    fn cancel_tab_title(&mut self) {}
+    fn tab_title_input(&mut self, _c: char) {}
+    fn tab_title_pop_word(&mut self) {}
     #[cfg(target_os = "macos")]
     fn create_new_window(&mut self, _tabbing_id: Option<String>) {}
     #[cfg(not(target_os = "macos"))]
@@ -405,6 +424,10 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ClearLogNotice => ctx.pop_message(),
             #[cfg(not(target_os = "macos"))]
             Action::CreateNewWindow => ctx.create_new_window(),
+            #[cfg(not(target_os = "macos"))]
+            Action::CreateNewTab => ctx.create_new_tab(),
+            #[cfg(not(target_os = "macos"))]
+            Action::CloseTab => ctx.close_tab(),
             Action::SpawnNewInstance => ctx.spawn_new_instance(),
             #[cfg(target_os = "macos")]
             Action::CreateNewWindow => ctx.create_new_window(None),
@@ -440,6 +463,36 @@ impl<T: EventListener> Execute<T> for Action {
             Action::SelectTab9 => ctx.window().select_tab_at_index(8),
             #[cfg(target_os = "macos")]
             Action::SelectLastTab => ctx.window().select_last_tab(),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectNextTab => ctx.select_next_tab(),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectPreviousTab => ctx.select_previous_tab(),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab1 => ctx.select_tab_at_index(0),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab2 => ctx.select_tab_at_index(1),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab3 => ctx.select_tab_at_index(2),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab4 => ctx.select_tab_at_index(3),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab5 => ctx.select_tab_at_index(4),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab6 => ctx.select_tab_at_index(5),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab7 => ctx.select_tab_at_index(6),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab8 => ctx.select_tab_at_index(7),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectTab9 => ctx.select_tab_at_index(8),
+            #[cfg(not(target_os = "macos"))]
+            Action::SelectLastTab => ctx.select_last_tab(),
+            #[cfg(not(target_os = "macos"))]
+            Action::MoveTabForward => ctx.move_tab_forward(),
+            #[cfg(not(target_os = "macos"))]
+            Action::MoveTabBackward => ctx.move_tab_backward(),
+            #[cfg(not(target_os = "macos"))]
+            Action::SetTabTitle => ctx.set_tab_title(),
             _ => (),
         }
     }
@@ -993,6 +1046,17 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             _ => (),
         }
 
+        if state == ElementState::Pressed
+            && button == MouseButton::Left
+            && self.ctx.config().tabs.mouse.enabled
+        {
+            if let Some(tab_index) = self.ctx.tab_at_mouse() {
+                self.ctx.select_tab_at_index(tab_index);
+                self.ctx.window().set_mouse_cursor(CursorIcon::Pointer);
+                return;
+            }
+        }
+
         // Skip normal mouse events if the message bar has been clicked.
         if self.message_bar_cursor_state() == Some(CursorIcon::Pointer)
             && state == ElementState::Pressed
@@ -1097,6 +1161,16 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         let display_offset = self.ctx.terminal().grid().display_offset();
         let point = self.ctx.mouse().point(&self.ctx.size_info(), display_offset);
         let hyperlink = self.ctx.terminal().grid()[point].hyperlink();
+
+        if self.ctx.config().tabs.mouse.enabled {
+            if self.ctx.tab_at_mouse().is_some() {
+                return if self.ctx.config().tabs.mouse.hover {
+                    CursorIcon::Pointer
+                } else {
+                    CursorIcon::Default
+                };
+            }
+        }
 
         // Function to check if mouse is on top of a hint.
         let hint_highlighted = |hint: &HintMatch| hint.should_highlight(point, hyperlink.as_ref());

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -332,9 +332,9 @@ impl Renderer {
         unsafe {
             gl::Viewport(
                 size.padding_x() as i32,
-                size.padding_y() as i32,
+                size.padding_bottom_y() as i32,
                 size.width() as i32 - 2 * size.padding_x() as i32,
-                size.height() as i32 - 2 * size.padding_y() as i32,
+                size.height() as i32 - size.padding_y() as i32 - size.padding_bottom_y() as i32,
             );
         }
     }

--- a/alacritty/src/renderer/text/mod.rs
+++ b/alacritty/src/renderer/text/mod.rs
@@ -200,10 +200,13 @@ fn update_projection(u_projection: GLint, size: &SizeInfo) {
     let width = size.width();
     let height = size.height();
     let padding_x = size.padding_x();
-    let padding_y = size.padding_y();
+    let padding_top = size.padding_y();
+    let padding_bottom = size.padding_bottom_y();
 
     // Bounds check.
-    if (width as u32) < (2 * padding_x as u32) || (height as u32) < (2 * padding_y as u32) {
+    if (width as u32) < (2 * padding_x as u32)
+        || (height as u32) < ((padding_top + padding_bottom) as u32)
+    {
         return;
     }
 
@@ -211,7 +214,7 @@ fn update_projection(u_projection: GLint, size: &SizeInfo) {
     //   [0, width - 2 * padding_x] to [-1, 1]
     //   [height - 2 * padding_y, 0] to [-1, 1]
     let scale_x = 2. / (width - 2. * padding_x);
-    let scale_y = -2. / (height - 2. * padding_y);
+    let scale_y = -2. / (height - padding_top - padding_bottom);
     let offset_x = -1.;
     let offset_y = 1.;
 

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -6,6 +6,8 @@ use std::io::Write;
 use std::mem;
 #[cfg(not(windows))]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(not(windows))]
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
@@ -33,10 +35,14 @@ use alacritty_terminal::tty;
 use crate::cli::{ParsedOptions, WindowOptions};
 use crate::clipboard::Clipboard;
 use crate::config::UiConfig;
+use crate::config::tabs::{TabBarEdge, TabSwitchStrategy};
+#[cfg(not(windows))]
+use crate::daemon::foreground_process_path;
 use crate::display::Display;
 use crate::display::window::Window;
 use crate::event::{
-    ActionContext, Event, EventProxy, InlineSearchState, Mouse, SearchState, TouchPurpose,
+    ActionContext, Event, EventProxy, EventType, InlineSearchState, Mouse, SearchState, TabAction,
+    TabId, TouchPurpose,
 };
 #[cfg(unix)]
 use crate::logging::LOG_TARGET_IPC_CONFIG;
@@ -44,32 +50,486 @@ use crate::message_bar::MessageBuffer;
 use crate::scheduler::Scheduler;
 use crate::{input, renderer};
 
+#[cfg(not(windows))]
+fn foreground_process_name(master_fd: RawFd, shell_pid: u32) -> Option<String> {
+    let mut pid = unsafe { libc::tcgetpgrp(master_fd) };
+    if pid < 0 {
+        pid = shell_pid as i32;
+    }
+
+    let process_name = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+    let process_name = process_name.trim();
+    (!process_name.is_empty()).then(|| process_name.to_owned())
+}
+
+#[cfg(not(windows))]
+fn process_cwd(pid: u32) -> Option<PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
+}
+
+#[cfg(not(windows))]
+fn format_tab_cwd(path: &Path) -> String {
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
+    if home.as_deref().is_some_and(|home| home == path) {
+        return String::from("~");
+    }
+
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+#[cfg(not(windows))]
+fn is_shell_process(process: &str) -> bool {
+    matches!(process, "bash" | "dash" | "fish" | "nu" | "sh" | "zsh" | "tmux")
+}
+
 /// Event context for one individual Alacritty window.
-pub struct WindowContext {
-    pub message_buffer: MessageBuffer,
-    pub display: Display,
-    pub dirty: bool,
-    event_queue: Vec<WinitEvent<Event>>,
+struct TerminalTab {
+    id: TabId,
     terminal: Arc<FairMutex<Term<EventProxy>>>,
+    notifier: Notifier,
+    terminal_title: Option<String>,
+    detected_title: String,
+    custom_title: Option<String>,
+    message_buffer: MessageBuffer,
     cursor_blink_timed_out: bool,
     prev_bell_cmd: Option<Instant>,
-    modifiers: Modifiers,
     inline_search_state: InlineSearchState,
     search_state: SearchState,
-    notifier: Notifier,
-    mouse: Mouse,
-    touch: TouchPurpose,
-    occluded: bool,
-    preserve_title: bool,
     #[cfg(not(windows))]
     master_fd: RawFd,
     #[cfg(not(windows))]
     shell_pid: u32,
+}
+
+impl TerminalTab {
+    fn new(
+        id: TabId,
+        window_id: WindowId,
+        size_info: crate::display::SizeInfo,
+        config: &UiConfig,
+        options: &WindowOptions,
+        proxy: &EventLoopProxy<Event>,
+    ) -> Result<Self, Box<dyn Error>> {
+        let mut pty_config = config.pty_config();
+        options.terminal_options.override_pty_config(&mut pty_config);
+
+        let event_proxy = EventProxy::new(proxy.clone(), window_id, id);
+
+        let terminal = Term::new(config.term_options(), &size_info, event_proxy.clone());
+        let terminal = Arc::new(FairMutex::new(terminal));
+
+        let pty = tty::new(&pty_config, size_info.into(), window_id.into())?;
+
+        #[cfg(not(windows))]
+        let master_fd = pty.file().as_raw_fd();
+        #[cfg(not(windows))]
+        let shell_pid = pty.child().id();
+
+        let event_loop = PtyEventLoop::new(
+            Arc::clone(&terminal),
+            event_proxy.clone(),
+            pty,
+            pty_config.drain_on_exit,
+            config.debug.ref_test,
+        )?;
+
+        let loop_tx = event_loop.channel();
+        let _io_thread = event_loop.spawn();
+
+        if config.cursor.style().blinking {
+            event_proxy.send_event(TerminalEvent::CursorBlinkingChange.into());
+        }
+
+        Ok(Self {
+            id,
+            terminal,
+            #[cfg(not(windows))]
+            master_fd,
+            #[cfg(not(windows))]
+            shell_pid,
+            notifier: Notifier(loop_tx),
+            terminal_title: None,
+            detected_title: Self::detected_title(
+                #[cfg(not(windows))]
+                master_fd,
+                #[cfg(not(windows))]
+                shell_pid,
+                &config.window.identity.title,
+            ),
+            custom_title: None,
+            cursor_blink_timed_out: false,
+            prev_bell_cmd: None,
+            inline_search_state: Default::default(),
+            message_buffer: Default::default(),
+            search_state: Default::default(),
+        })
+    }
+
+    fn detected_title(
+        #[cfg(not(windows))] master_fd: RawFd,
+        #[cfg(not(windows))] shell_pid: u32,
+        default_title: &str,
+    ) -> String {
+        #[cfg(not(windows))]
+        {
+            let process = foreground_process_name(master_fd, shell_pid);
+            let cwd = foreground_process_path(master_fd, shell_pid)
+                .ok()
+                .map(|path| format_tab_cwd(&path));
+
+            if let Some(process) = process.filter(|process| !is_shell_process(process)) {
+                process
+            } else if let Some(cwd) = cwd {
+                cwd
+            } else {
+                default_title.to_owned()
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            default_title.to_owned()
+        }
+    }
+
+    fn refresh_detected_title(&mut self, config: &UiConfig) -> bool {
+        let detected_title = Self::detected_title(
+            #[cfg(not(windows))]
+            self.master_fd,
+            #[cfg(not(windows))]
+            self.shell_pid,
+            &config.window.identity.title,
+        );
+
+        if self.detected_title == detected_title {
+            false
+        } else {
+            self.detected_title = detected_title;
+            true
+        }
+    }
+
+    fn display_title(&self) -> &str {
+        self.custom_title
+            .as_deref()
+            .or(self.terminal_title.as_deref())
+            .unwrap_or(&self.detected_title)
+    }
+}
+
+struct TabTitleEditor {
+    tab_id: TabId,
+    value: String,
+}
+
+pub struct WindowContext {
+    pub display: Display,
+    pub dirty: bool,
+    event_queue: Vec<WinitEvent<Event>>,
+    tabs: Vec<TerminalTab>,
+    active_tab: usize,
+    next_tab_id: u64,
+    last_active_tab_id: Option<TabId>,
+    tab_title_editor: Option<TabTitleEditor>,
+    focused: bool,
+    modifiers: Modifiers,
+    mouse: Mouse,
+    touch: TouchPurpose,
+    occluded: bool,
+    preserve_title: bool,
     window_config: ParsedOptions,
     config: Rc<UiConfig>,
+    event_proxy: EventLoopProxy<Event>,
 }
 
 impl WindowContext {
+    fn active_tab(&self) -> &TerminalTab {
+        &self.tabs[self.active_tab]
+    }
+
+    fn active_tab_mut(&mut self) -> &mut TerminalTab {
+        &mut self.tabs[self.active_tab]
+    }
+
+    fn tab_index(&self, tab_id: Option<TabId>) -> Option<usize> {
+        match tab_id {
+            Some(tab_id) => self.tabs.iter().position(|tab| tab.id == tab_id),
+            None => Some(self.active_tab),
+        }
+    }
+
+    fn tab_bar_lines(&self) -> usize {
+        usize::from(self.config.tabs.display_tab_bar(self.tabs.len()))
+    }
+
+    fn tab_bar_at_top(&self) -> bool {
+        self.tab_bar_lines() != 0 && self.config.tabs.tab_bar_edge == TabBarEdge::Top
+    }
+
+    fn refresh_window_title(&mut self) {
+        let title = self.active_tab().display_title().to_owned();
+        self.display.window.set_title(title);
+    }
+
+    fn start_tab_title_editor(&mut self) {
+        let tab = self.active_tab();
+        self.tab_title_editor = Some(TabTitleEditor {
+            tab_id: tab.id,
+            value: tab.custom_title.clone().unwrap_or_default(),
+        });
+        self.display.pending_update.dirty = true;
+        self.dirty = true;
+    }
+
+    fn confirm_tab_title_editor(&mut self) {
+        let Some(editor) = self.tab_title_editor.take() else {
+            return;
+        };
+        let Some(index) = self.tabs.iter().position(|tab| tab.id == editor.tab_id) else {
+            return;
+        };
+
+        let title = editor.value.trim().to_owned();
+        self.tabs[index].custom_title = (!title.is_empty()).then_some(title);
+        if index == self.active_tab {
+            self.refresh_window_title();
+        }
+        self.display.pending_update.dirty = true;
+        self.dirty = true;
+    }
+
+    fn cancel_tab_title_editor(&mut self) {
+        if self.tab_title_editor.take().is_some() {
+            self.display.pending_update.dirty = true;
+            self.dirty = true;
+        }
+    }
+
+    fn tab_title_input(&mut self, c: char) {
+        let Some(editor) = self.tab_title_editor.as_mut() else {
+            return;
+        };
+
+        match c {
+            '\x08' | '\x7f' => {
+                let _ = editor.value.pop();
+            },
+            ' '..='~' | '\u{a0}'..='\u{10ffff}' => editor.value.push(c),
+            _ => return,
+        }
+
+        self.display.pending_update.dirty = true;
+        self.dirty = true;
+    }
+
+    fn tab_title_pop_word(&mut self) {
+        let Some(editor) = self.tab_title_editor.as_mut() else {
+            return;
+        };
+
+        editor.value = editor.value.trim_end().to_owned();
+        editor.value.truncate(editor.value.rfind(' ').map_or(0, |index| index + 1));
+        self.display.pending_update.dirty = true;
+        self.dirty = true;
+    }
+
+    fn render_tab_title(&self, index: usize, tab: &TerminalTab, active: bool) -> String {
+        let template =
+            if active { self.config.tabs.active_tab_title_template.as_deref() } else { None }
+                .unwrap_or(&self.config.tabs.tab_title_template);
+
+        let title = tab.display_title();
+        let rendered = template
+            .replace("{title}", title)
+            .replace("{index}", &(index + 1).to_string())
+            .replace("{num_windows}", "1");
+
+        if rendered.is_empty() { title.to_owned() } else { rendered }
+    }
+
+    fn sync_focus(&mut self) {
+        for (index, tab) in self.tabs.iter_mut().enumerate() {
+            let mut terminal = tab.terminal.lock();
+            terminal.is_focused = self.focused && index == self.active_tab;
+        }
+    }
+
+    fn set_active_tab(&mut self, index: usize) {
+        if self.tabs.is_empty() {
+            return;
+        }
+
+        let index = index.min(self.tabs.len() - 1);
+        if self.active_tab == index {
+            return;
+        }
+
+        self.last_active_tab_id = Some(self.tabs[self.active_tab].id);
+        self.active_tab = index;
+        let config = self.config.clone();
+        self.active_tab_mut().refresh_detected_title(&config);
+        self.cancel_tab_title_editor();
+        self.sync_focus();
+        self.refresh_window_title();
+        self.display.damage_tracker.frame().mark_fully_damaged();
+        self.display.damage_tracker.next_frame().mark_fully_damaged();
+        self.display.pending_update.dirty = true;
+        self.dirty = true;
+    }
+
+    fn create_tab(&mut self) -> Result<(), Box<dyn Error>> {
+        let tab_id = TabId(self.next_tab_id);
+        self.next_tab_id += 1;
+
+        let mut options = WindowOptions::default();
+        #[cfg(not(windows))]
+        if let Some(working_directory) = process_cwd(self.active_tab().shell_pid)
+            .filter(|path| path.is_dir())
+            .or_else(|| {
+                foreground_process_path(self.active_tab().master_fd, self.active_tab().shell_pid)
+                    .ok()
+                    .filter(|path| path.is_dir())
+            })
+        {
+            options.terminal_options.working_directory = Some(working_directory);
+        }
+        let tab = match TerminalTab::new(
+            tab_id,
+            self.display.window.id(),
+            self.display.size_info,
+            &self.config,
+            &options,
+            &self.event_proxy,
+        ) {
+            Ok(tab) => tab,
+            Err(err) if options.terminal_options.working_directory.is_some() => {
+                log::warn!(
+                    "Retrying tab creation without inherited working directory after error: {err:?}"
+                );
+                let fallback_options = WindowOptions::default();
+                TerminalTab::new(
+                    tab_id,
+                    self.display.window.id(),
+                    self.display.size_info,
+                    &self.config,
+                    &fallback_options,
+                    &self.event_proxy,
+                )?
+            },
+            Err(err) => return Err(err),
+        };
+
+        self.tabs.push(tab);
+        self.set_active_tab(self.tabs.len() - 1);
+        self.display.damage_tracker.frame().mark_fully_damaged();
+        self.display.damage_tracker.next_frame().mark_fully_damaged();
+        self.display.pending_update.dirty = true;
+        self.dirty = true;
+
+        Ok(())
+    }
+
+    fn close_active_tab(&mut self) {
+        let tab = self.active_tab_mut();
+        tab.terminal.lock().exit();
+    }
+
+    fn move_active_tab(&mut self, delta: isize) {
+        if self.tabs.len() < 2 {
+            return;
+        }
+
+        let old_index = self.active_tab;
+        let new_index = if delta < 0 {
+            old_index.saturating_sub(delta.unsigned_abs())
+        } else {
+            (old_index + delta as usize).min(self.tabs.len() - 1)
+        };
+
+        if new_index == old_index {
+            return;
+        }
+
+        self.tabs.swap(old_index, new_index);
+        self.active_tab = new_index;
+        self.display.damage_tracker.frame().mark_fully_damaged();
+        self.display.damage_tracker.next_frame().mark_fully_damaged();
+        self.dirty = true;
+    }
+
+    pub fn handle_tab_wakeup(&mut self, tab_id: Option<TabId>) {
+        if let Some(index) = self.tab_index(tab_id) {
+            let title_changed = self.tabs[index].refresh_detected_title(&self.config);
+            if index == self.active_tab && title_changed {
+                self.refresh_window_title();
+            }
+        }
+
+        if self.tab_index(tab_id) == Some(self.active_tab) {
+            self.dirty = true;
+        }
+    }
+
+    pub fn handle_tab_exit(&mut self, tab_id: Option<TabId>) -> bool {
+        if self.display.window.hold {
+            return false;
+        }
+
+        let Some(index) = self.tab_index(tab_id) else {
+            return false;
+        };
+        let closing_tab_id = self.tabs[index].id;
+        let next_active_id = match self.config.tabs.tab_switch_strategy {
+            TabSwitchStrategy::Previous => self.last_active_tab_id.filter(|tab_id| {
+                self.tabs.iter().any(|tab| tab.id == *tab_id && tab.id != closing_tab_id)
+            }),
+            TabSwitchStrategy::Left => {
+                index.checked_sub(1).and_then(|index| self.tabs.get(index)).map(|tab| tab.id)
+            },
+            TabSwitchStrategy::Right => self.tabs.get(index + 1).map(|tab| tab.id),
+            TabSwitchStrategy::Last => self.tabs.last().map(|tab| tab.id),
+        };
+
+        self.tabs.remove(index);
+        if self.tab_title_editor.as_ref().is_some_and(|editor| editor.tab_id == closing_tab_id) {
+            self.tab_title_editor = None;
+        }
+
+        if self.tabs.is_empty() {
+            return true;
+        }
+
+        self.active_tab = next_active_id
+            .and_then(|tab_id| self.tabs.iter().position(|tab| tab.id == tab_id))
+            .unwrap_or_else(|| {
+                self.active_tab
+                    .min(self.tabs.len() - 1)
+                    .saturating_sub(usize::from(index < self.active_tab))
+            });
+
+        let config = self.config.clone();
+        self.active_tab_mut().refresh_detected_title(&config);
+
+        self.sync_focus();
+        self.refresh_window_title();
+        self.display.damage_tracker.frame().mark_fully_damaged();
+        self.display.damage_tracker.next_frame().mark_fully_damaged();
+        self.display.pending_update.dirty = true;
+        self.dirty = true;
+
+        false
+    }
+
+    pub fn clear_config_messages(&mut self, target: &str) {
+        for tab in &mut self.tabs {
+            tab.message_buffer.remove_target(target);
+        }
+    }
+
     /// Create initial window context that does bootstrapping the graphics API we're going to use.
     pub fn initial(
         event_loop: &ActiveEventLoop,
@@ -172,9 +632,6 @@ impl WindowContext {
         options: WindowOptions,
         proxy: EventLoopProxy<Event>,
     ) -> Result<Self, Box<dyn Error>> {
-        let mut pty_config = config.pty_config();
-        options.terminal_options.override_pty_config(&mut pty_config);
-
         let preserve_title = options.window_identity.title.is_some();
 
         info!(
@@ -183,77 +640,34 @@ impl WindowContext {
             display.size_info.columns()
         );
 
-        let event_proxy = EventProxy::new(proxy, display.window.id());
-
-        // Create the terminal.
-        //
-        // This object contains all of the state about what's being displayed. It's
-        // wrapped in a clonable mutex since both the I/O loop and display need to
-        // access it.
-        let terminal = Term::new(config.term_options(), &display.size_info, event_proxy.clone());
-        let terminal = Arc::new(FairMutex::new(terminal));
-
-        // Create the PTY.
-        //
-        // The PTY forks a process to run the shell on the slave side of the
-        // pseudoterminal. A file descriptor for the master side is retained for
-        // reading/writing to the shell.
-        let pty = tty::new(&pty_config, display.size_info.into(), display.window.id().into())?;
-
-        #[cfg(not(windows))]
-        let master_fd = pty.file().as_raw_fd();
-        #[cfg(not(windows))]
-        let shell_pid = pty.child().id();
-
-        // Create the pseudoterminal I/O loop.
-        //
-        // PTY I/O is ran on another thread as to not occupy cycles used by the
-        // renderer and input processing. Note that access to the terminal state is
-        // synchronized since the I/O loop updates the state, and the display
-        // consumes it periodically.
-        let event_loop = PtyEventLoop::new(
-            Arc::clone(&terminal),
-            event_proxy.clone(),
-            pty,
-            pty_config.drain_on_exit,
-            config.debug.ref_test,
+        let first_tab = TerminalTab::new(
+            TabId(0),
+            display.window.id(),
+            display.size_info,
+            &config,
+            &options,
+            &proxy,
         )?;
-
-        // The event loop channel allows write requests from the event processor
-        // to be sent to the pty loop and ultimately written to the pty.
-        let loop_tx = event_loop.channel();
-
-        // Kick off the I/O thread.
-        let _io_thread = event_loop.spawn();
-
-        // Start cursor blinking, in case `Focused` isn't sent on startup.
-        if config.cursor.style().blinking {
-            event_proxy.send_event(TerminalEvent::CursorBlinkingChange.into());
-        }
 
         // Create context for the Alacritty window.
         Ok(WindowContext {
             preserve_title,
-            terminal,
             display,
-            #[cfg(not(windows))]
-            master_fd,
-            #[cfg(not(windows))]
-            shell_pid,
             config,
-            notifier: Notifier(loop_tx),
-            cursor_blink_timed_out: Default::default(),
-            prev_bell_cmd: Default::default(),
-            inline_search_state: Default::default(),
-            message_buffer: Default::default(),
             window_config: Default::default(),
-            search_state: Default::default(),
             event_queue: Default::default(),
             modifiers: Default::default(),
             occluded: Default::default(),
             mouse: Default::default(),
             touch: Default::default(),
             dirty: Default::default(),
+            tabs: vec![first_tab],
+            active_tab: 0,
+            next_tab_id: 1,
+            last_active_tab_id: None,
+            tab_title_editor: None,
+            focused: false,
+            event_proxy: proxy,
         })
     }
 
@@ -265,7 +679,9 @@ impl WindowContext {
         self.config = self.window_config.override_config_rc(self.config.clone());
 
         self.display.update_config(&self.config);
-        self.terminal.lock().set_options(self.config.term_options());
+        for tab in &mut self.tabs {
+            tab.terminal.lock().set_options(self.config.term_options());
+        }
 
         // Reload cursor if its thickness has changed.
         if (old_config.cursor.thickness() - self.config.cursor.thickness()).abs() > f32::EPSILON {
@@ -306,7 +722,7 @@ impl WindowContext {
             && (!self.config.window.dynamic_title
                 || self.display.window.title() == old_config.window.identity.title)
         {
-            self.display.window.set_title(self.config.window.identity.title.clone());
+            self.refresh_window_title();
         }
 
         let opaque = self.config.window_opacity() >= 1.;
@@ -326,7 +742,8 @@ impl WindowContext {
         self.display.hint_state.update_alphabet(self.config.hints.alphabet());
 
         // Update cursor blinking.
-        let event = Event::new(TerminalEvent::CursorBlinkingChange.into(), None);
+        let event =
+            Event::new(TerminalEvent::CursorBlinkingChange.into(), self.display.window.id());
         self.event_queue.push(event.into());
 
         self.dirty = true;
@@ -342,7 +759,9 @@ impl WindowContext {
     #[cfg(unix)]
     pub fn reset_window_config(&mut self, config: Rc<UiConfig>) {
         // Clear previous window errors.
-        self.message_buffer.remove_target(LOG_TARGET_IPC_CONFIG);
+        for tab in &mut self.tabs {
+            tab.message_buffer.remove_target(LOG_TARGET_IPC_CONFIG);
+        }
 
         self.window_config.clear();
 
@@ -354,7 +773,9 @@ impl WindowContext {
     #[cfg(unix)]
     pub fn add_window_config(&mut self, config: Rc<UiConfig>, options: &ParsedOptions) {
         // Clear previous window errors.
-        self.message_buffer.remove_target(LOG_TARGET_IPC_CONFIG);
+        for tab in &mut self.tabs {
+            tab.message_buffer.remove_target(LOG_TARGET_IPC_CONFIG);
+        }
 
         self.window_config.extend_from_slice(options);
 
@@ -387,13 +808,27 @@ impl WindowContext {
         }
 
         // Redraw the window.
-        let terminal = self.terminal.lock();
-        self.display.draw(
+        let tab_titles: Vec<_> = self
+            .tabs
+            .iter()
+            .enumerate()
+            .map(|(index, tab)| {
+                let active = index == self.active_tab;
+                (self.render_tab_title(index, tab, active), active)
+            })
+            .collect();
+        let active_tab = self.active_tab;
+        let (display, tabs, config) = (&mut self.display, &mut self.tabs, &self.config);
+        let active_tab = &mut tabs[active_tab];
+        let terminal = active_tab.terminal.lock();
+        display.draw(
             terminal,
             scheduler,
-            &self.message_buffer,
-            &self.config,
-            &mut self.search_state,
+            &active_tab.message_buffer,
+            config,
+            &mut active_tab.search_state,
+            &tab_titles,
+            self.tab_title_editor.as_ref().map(|editor| editor.value.as_str()),
         );
     }
 
@@ -401,7 +836,7 @@ impl WindowContext {
     pub fn handle_event(
         &mut self,
         #[cfg(target_os = "macos")] event_loop: &ActiveEventLoop,
-        event_proxy: &EventLoopProxy<Event>,
+        _event_proxy: &EventLoopProxy<Event>,
         clipboard: &mut Clipboard,
         scheduler: &mut Scheduler,
         event: WinitEvent<Event>,
@@ -422,60 +857,139 @@ impl WindowContext {
             },
         }
 
-        let mut terminal = self.terminal.lock();
+        let old_is_searching = self.active_tab().search_state.history_index.is_some();
+        let queued_events: Vec<_> = self.event_queue.drain(..).collect();
 
-        let old_is_searching = self.search_state.history_index.is_some();
+        for event in queued_events {
+            match &event {
+                WinitEvent::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
+                    self.display.window.hold = false;
+                    for tab in &mut self.tabs {
+                        tab.terminal.lock().exit();
+                    }
+                    continue;
+                },
+                WinitEvent::WindowEvent { event: WindowEvent::Focused(is_focused), .. } => {
+                    self.focused = *is_focused;
+                },
+                WinitEvent::UserEvent(Event { payload: EventType::Tab(action), .. }) => {
+                    match action {
+                        TabAction::Create => {
+                            if let Err(err) = self.create_tab() {
+                                log::error!("Could not create tab: {err:?}");
+                            }
+                        },
+                        TabAction::Close => self.close_active_tab(),
+                        TabAction::SelectNext => {
+                            if !self.tabs.is_empty() {
+                                self.set_active_tab((self.active_tab + 1) % self.tabs.len());
+                            }
+                        },
+                        TabAction::SelectPrevious => {
+                            if !self.tabs.is_empty() {
+                                let next =
+                                    (self.active_tab + self.tabs.len() - 1) % self.tabs.len();
+                                self.set_active_tab(next);
+                            }
+                        },
+                        TabAction::Select(index) => self.set_active_tab(*index),
+                        TabAction::SelectLast => {
+                            if !self.tabs.is_empty() {
+                                self.set_active_tab(self.tabs.len() - 1);
+                            }
+                        },
+                        TabAction::MoveForward => self.move_active_tab(1),
+                        TabAction::MoveBackward => self.move_active_tab(-1),
+                        TabAction::SetTitle => self.start_tab_title_editor(),
+                        TabAction::ConfirmTitle => self.confirm_tab_title_editor(),
+                        TabAction::CancelTitle => self.cancel_tab_title_editor(),
+                        TabAction::TitleInput(c) => self.tab_title_input(*c),
+                        TabAction::TitlePopWord => self.tab_title_pop_word(),
+                    }
+                    continue;
+                },
+                _ => (),
+            }
 
-        let context = ActionContext {
-            cursor_blink_timed_out: &mut self.cursor_blink_timed_out,
-            prev_bell_cmd: &mut self.prev_bell_cmd,
-            message_buffer: &mut self.message_buffer,
-            inline_search_state: &mut self.inline_search_state,
-            search_state: &mut self.search_state,
-            modifiers: &mut self.modifiers,
-            notifier: &mut self.notifier,
-            display: &mut self.display,
-            mouse: &mut self.mouse,
-            touch: &mut self.touch,
-            dirty: &mut self.dirty,
-            occluded: &mut self.occluded,
-            terminal: &mut terminal,
-            #[cfg(not(windows))]
-            master_fd: self.master_fd,
-            #[cfg(not(windows))]
-            shell_pid: self.shell_pid,
-            preserve_title: self.preserve_title,
-            config: &self.config,
-            event_proxy,
-            #[cfg(target_os = "macos")]
-            event_loop,
-            clipboard,
-            scheduler,
-        };
-        let mut processor = input::Processor::new(context);
+            let tab_index = match &event {
+                WinitEvent::UserEvent(Event { tab_id, .. }) => {
+                    self.tab_index(*tab_id).unwrap_or(self.active_tab)
+                },
+                _ => self.active_tab,
+            };
+            let is_active_tab = tab_index == self.active_tab;
+            let tab = &mut self.tabs[tab_index];
+            let mut terminal = tab.terminal.lock();
 
-        for event in self.event_queue.drain(..) {
+            let context = ActionContext {
+                cursor_blink_timed_out: &mut tab.cursor_blink_timed_out,
+                prev_bell_cmd: &mut tab.prev_bell_cmd,
+                message_buffer: &mut tab.message_buffer,
+                inline_search_state: &mut tab.inline_search_state,
+                search_state: &mut tab.search_state,
+                modifiers: &mut self.modifiers,
+                notifier: &mut tab.notifier,
+                display: &mut self.display,
+                mouse: &mut self.mouse,
+                touch: &mut self.touch,
+                dirty: &mut self.dirty,
+                occluded: &mut self.occluded,
+                terminal: &mut terminal,
+                tab_terminal_title: &mut tab.terminal_title,
+                tab_detected_title: &tab.detected_title,
+                tab_custom_title: &mut tab.custom_title,
+                tab_title_editor_active: self.tab_title_editor.is_some(),
+                is_active_tab,
+                #[cfg(not(windows))]
+                master_fd: tab.master_fd,
+                #[cfg(not(windows))]
+                shell_pid: tab.shell_pid,
+                preserve_title: self.preserve_title,
+                config: &self.config,
+                event_proxy: &self.event_proxy,
+                #[cfg(target_os = "macos")]
+                event_loop,
+                clipboard,
+                scheduler,
+            };
+            let mut processor = input::Processor::new(context);
             processor.handle_event(event);
         }
 
+        self.sync_focus();
+
         // Process DisplayUpdate events.
         if self.display.pending_update.dirty {
+            let tab_bar_lines = self.tab_bar_lines();
+            let tab_bar_at_top = usize::from(self.tab_bar_at_top());
+            let tab_title_editor_lines = usize::from(self.tab_title_editor.is_some());
+            let active_index = self.active_tab;
+            let (display, tabs, config) = (&mut self.display, &mut self.tabs, &self.config);
+            let active_tab = &mut tabs[active_index];
+            let mut terminal = active_tab.terminal.lock();
             Self::submit_display_update(
                 &mut terminal,
-                &mut self.display,
-                &mut self.notifier,
-                &self.message_buffer,
-                &mut self.search_state,
+                display,
+                &mut active_tab.notifier,
+                &active_tab.message_buffer,
+                &mut active_tab.search_state,
                 old_is_searching,
-                &self.config,
+                config,
+                tab_bar_lines,
+                tab_bar_at_top,
+                tab_title_editor_lines,
             );
             self.dirty = true;
         }
 
         if self.dirty || self.mouse.hint_highlight_dirty {
-            self.dirty |= self.display.update_highlighted_hints(
+            let active_index = self.active_tab;
+            let (display, tabs, config) = (&mut self.display, &mut self.tabs, &self.config);
+            let active_tab = &mut tabs[active_index];
+            let terminal = active_tab.terminal.lock();
+            self.dirty |= display.update_highlighted_hints(
                 &terminal,
-                &self.config,
+                config,
                 &self.mouse,
                 self.modifiers.state(),
             );
@@ -501,7 +1015,7 @@ impl WindowContext {
     /// Write the ref test results to the disk.
     pub fn write_ref_test_results(&self) {
         // Dump grid state.
-        let mut grid = self.terminal.lock().grid().clone();
+        let mut grid = self.active_tab().terminal.lock().grid().clone();
         grid.initialize_all();
         grid.truncate();
 
@@ -535,6 +1049,9 @@ impl WindowContext {
         search_state: &mut SearchState,
         old_is_searching: bool,
         config: &UiConfig,
+        tab_bar_lines: usize,
+        top_tab_bar_lines: usize,
+        tab_title_editor_lines: usize,
     ) {
         // Compute cursor positions before resize.
         let num_lines = terminal.screen_lines();
@@ -545,7 +1062,16 @@ impl WindowContext {
             search_state.direction == Direction::Left
         };
 
-        display.handle_update(terminal, notifier, message_buffer, search_state, config);
+        display.handle_update(
+            terminal,
+            notifier,
+            message_buffer,
+            search_state,
+            config,
+            tab_bar_lines,
+            top_tab_bar_lines,
+            tab_title_editor_lines,
+        );
 
         let new_is_searching = search_state.history_index.is_some();
         if !old_is_searching && new_is_searching {
@@ -562,7 +1088,8 @@ impl WindowContext {
 
 impl Drop for WindowContext {
     fn drop(&mut self) {
-        // Shutdown the terminal's PTY.
-        let _ = self.notifier.0.send(Msg::Shutdown);
+        for tab in &mut self.tabs {
+            let _ = tab.notifier.0.send(Msg::Shutdown);
+        }
     }
 }

--- a/extra/man/alacritty-bindings.5.scd
+++ b/extra/man/alacritty-bindings.5.scd
@@ -436,6 +436,42 @@ configuration. See *alacritty*(5) for full configuration format documentation.
 :  _"Control"_
 :[
 :  _"DecreaseFontSize"_
+|  _"Right"_
+:  _"Control|Shift"_
+:[
+:  _"SelectNextTab"_
+|  _"Tab"_
+:  _"Control"_
+:[
+:  _"SelectNextTab"_
+|  _"Left"_
+:  _"Control|Shift"_
+:[
+:  _"SelectPreviousTab"_
+|  _"Tab"_
+:  _"Control|Shift"_
+:[
+:  _"SelectPreviousTab"_
+|  _"T"_
+:  _"Control|Shift"_
+:[
+:  _"CreateNewTab"_
+|  _"W"_
+:  _"Control|Shift"_
+:[
+:  _"CloseTab"_
+|  _"."_
+:  _"Control|Shift"_
+:[
+:  _"MoveTabForward"_
+|  _","_
+:  _"Control|Shift"_
+:[
+:  _"MoveTabBackward"_
+|  _"T"_
+:  _"Control|Shift|Alt"_
+:[
+:  _"SetTabTitle"_
 
 ## Windows only
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -625,6 +625,208 @@ Windows: _"powershell"_
 
 	Default: _"OnlyCopy"_
 
+# TABS
+
+This section documents the *[tabs]* table of the configuration file.
+
+Tabs are local to a single Alacritty window. On Linux, BSD, and Windows,
+creating a tab opens a new PTY inside the current window and attempts to reuse
+the active tab's working directory. On macOS, tab actions use the platform's
+native window tabs when available.
+
+The visible title for a tab is resolved in this order:
+
+. Custom tab title set through *SetTabTitle*
+. Terminal-provided title
+. Detected foreground process or working directory fallback
+
+When a custom title is set, it remains static until it is explicitly cleared.
+To restore dynamic titles, open the title editor, submit an empty title, and
+press _Enter_.
+
+While editing a title, _Enter_ confirms it, _Escape_ cancels it, _Backspace_
+deletes the previous character, and _Control|W_ deletes the previous word.
+
+The tab bar is shown only when *tab_bar_style* is not _"hidden"_ and the number
+of open tabs is at least *tab_bar_min_tabs*.
+
+*tab_bar_edge* = _"top"_ | _"bottom"_
+
+	Side of the window used for the tab bar.
+
+	Default: _"bottom"_
+
+*tab_bar_style* = _"hidden"_ | _"separator"_ | _"slant"_ | _"powerline"_ | _"fade"_
+
+	Visual style used to render tabs.
+
+	*Hidden*
+		Disable the tab bar completely.
+	*Separator*
+		Render text tabs separated by *tab_separator*.
+	*Slant*
+		Render slanted tab backgrounds.
+	*Powerline*
+		Render powerline-shaped separators.
+	*Fade*
+		Render text tabs separated by *tab_separator* on top of the bar background.
+
+	Default: _"powerline"_
+
+*tab_powerline_style* = _"angled"_ | _"slanted"_ | _"round"_
+
+	Separator glyph style used by the _"Powerline"_ tab bar style.
+
+	Default: _"angled"_
+
+*tab_bar_min_tabs* = _<integer>_
+
+	Minimum number of tabs required before the tab bar is shown.
+
+	Default: _2_
+
+*tab_switch_strategy* = _"previous"_ | _"left"_ | _"right"_ | _"last"_
+
+	Tab selected after closing the active tab.
+
+	*Previous*
+		Re-select the most recently focused remaining tab.
+	*Left*
+		Select the tab immediately to the left.
+	*Right*
+		Select the tab immediately to the right.
+	*Last*
+		Select the last tab in the tab list.
+
+	Default: _"previous"_
+
+*tab_separator* = _"<string>"_
+
+	Text separator used by the _"Separator"_ and _"Fade"_ styles.
+
+	Default: _" | "_
+
+*tab_title_template* = _"<string>"_
+
+	Template for inactive tab titles.
+
+	Supported placeholders:
+
+	. _{title}_: resolved tab title
+	. _{index}_: 1-based tab index
+	. _{num_windows}_: number of terminal windows in the tab
+
+	Default: _"{title}"_
+
+*active_tab_title_template* = _"<string>"_ | _"None"_
+
+	Optional title template for the active tab. When this is unset, the value of
+	*tab_title_template* is used.
+
+	Default: _"None"_
+
+*tab_title_max_length* = _<integer>_
+
+	Maximum number of cells used for each tab title before truncation. A value of
+	_0_ disables truncation.
+
+	Default: _0_
+
+*active_tab_foreground* = _"#RRGGBB"_ | _"None"_
+
+	Foreground color for the active tab.
+
+	Default: _"None"_
+
+*active_tab_background* = _"#RRGGBB"_ | _"None"_
+
+	Background color for the active tab.
+
+	Default: _"None"_
+
+*active_tab_font_style* = _"normal"_ | _"bold"_ | _"italic"_ | _"bold-italic"_
+
+	Font style used for the active tab title.
+
+	Default: _"normal"_
+
+*inactive_tab_foreground* = _"#RRGGBB"_ | _"None"_
+
+	Foreground color for inactive tabs.
+
+	Default: _"None"_
+
+*inactive_tab_background* = _"#RRGGBB"_ | _"None"_
+
+	Background color for inactive tabs.
+
+	Default: _"None"_
+
+*inactive_tab_font_style* = _"normal"_ | _"bold"_ | _"italic"_ | _"bold-italic"_
+
+	Font style used for inactive tab titles.
+
+	Default: _"normal"_
+
+*tab_bar_background* = _"#RRGGBB"_ | _"None"_
+
+	Background color for the tab bar itself.
+
+	Default: _"None"_
+
+*mouse* = { enabled = _true_ | _false_, hover = _true_ | _false_ }
+
+	Tab bar mouse integration.
+
+	*enabled*
+		Allow selecting tabs by clicking the tab bar.
+
+		Default: _true_
+
+	*hover*
+		Show the pointer cursor while hovering tabs.
+
+		Default: _true_
+
+Example:
+	This example places a slanted tab bar at the top, keeps it visible even with
+	a single tab, uses a purple active tab with italic text, dark inactive tabs,
+	and enables mouse hover/click interaction.
+
+	*[tabs]*++
+tab_bar_edge = _"top"_++
+tab_bar_style = _"slant"_++
+tab_powerline_style = _"slanted"_++
+tab_bar_min_tabs = _1_++
+tab_switch_strategy = _"previous"_++
+tab_title_template = _"{title}"_++
+active_tab_foreground = _"#1e1e2e"_++
+active_tab_background = _"#cba6f7"_++
+active_tab_font_style = _"italic"_++
+inactive_tab_foreground = _"#cdd6f4"_++
+inactive_tab_background = _"#0b0b12"_++
+inactive_tab_font_style = _"normal"_++
+tab_bar_background = _"#11111b"_++
+mouse = { enabled = _true_, hover = _true_ }
+
+	With the _"slant"_ style, *tab_powerline_style* is ignored, so keeping it in
+	the example is harmless but not required.
+
+	Example tab-related key bindings based on the same configuration:
+
+	*[keyboard]*++
+bindings = [++
+	{ key = _"T"_, mods = _"Super"_, action = _"CreateNewTab"_ },++
+	{ key = _"Right"_, mods = _"Super"_, action = _"SelectNextTab"_ },++
+	{ key = _"Left"_, mods = _"Super"_, action = _"SelectPreviousTab"_ },++
+	{ key = _"Tab"_, mods = _"Super"_, action = _"SelectNextTab"_ },++
+	{ key = _"Tab"_, mods = _"Super|Shift"_, action = _"SelectPreviousTab"_ },++
+	{ key = _"W"_, mods = _"Super"_, action = _"CloseTab"_ },++
+	{ key = _"."_, mods = _"Super"_, action = _"MoveTabForward"_ },++
+	{ key = _","_, mods = _"Super"_, action = _"MoveTabBackward"_ },++
+	{ key = _"T"_, mods = _"Super|Alt"_, action = _"SetTabTitle"_ },++
+]
+
 # MOUSE
 
 This section documents the *[mouse]* table of the configuration file.
@@ -841,6 +1043,40 @@ _https://docs.rs/winit/latest/winit/keyboard/enum.Key.html#variant.Dead_
 			Spawn a new instance of Alacritty.
 		*CreateNewWindow*
 			Create a new Alacritty window.
+		*CreateNewTab*
+			Create a new tab in the current window.
+		*CloseTab* # _(Windows, Linux, and BSD only)_
+			Close the active tab.
+		*SelectNextTab*
+			Select the next tab.
+		*SelectPreviousTab*
+			Select the previous tab.
+		*SelectTab1*
+			Select the first tab.
+		*SelectTab2*
+			Select the second tab.
+		*SelectTab3*
+			Select the third tab.
+		*SelectTab4*
+			Select the fourth tab.
+		*SelectTab5*
+			Select the fifth tab.
+		*SelectTab6*
+			Select the sixth tab.
+		*SelectTab7*
+			Select the seventh tab.
+		*SelectTab8*
+			Select the eighth tab.
+		*SelectTab9*
+			Select the ninth tab.
+		*SelectLastTab*
+			Select the last tab.
+		*MoveTabForward* # _(Windows, Linux, and BSD only)_
+			Move the active tab one position forward.
+		*MoveTabBackward* # _(Windows, Linux, and BSD only)_
+			Move the active tab one position backward.
+		*SetTabTitle* # _(Windows, Linux, and BSD only)_
+			Open the custom title editor for the active tab.
 		*ToggleFullscreen*
 			Toggle fullscreen.
 		*ToggleMaximized*
@@ -961,32 +1197,6 @@ _https://docs.rs/winit/latest/winit/keyboard/enum.Key.html#variant.Dead_
 			Enter fullscreen without occupying another space.
 		*HideOtherApplications*
 			Hide all windows other than Alacritty.
-		*CreateNewTab*
-			Create new window in a tab.
-		*SelectNextTab*
-			Select next tab.
-		*SelectPreviousTab*
-			Select previous tab.
-		*SelectTab1*
-			Select the first tab.
-		*SelectTab2*
-			Select the second tab.
-		*SelectTab3*
-			Select the third tab.
-		*SelectTab4*
-			Select the fourth tab.
-		*SelectTab5*
-			Select the fifth tab.
-		*SelectTab6*
-			Select the sixth tab.
-		*SelectTab7*
-			Select the seventh tab.
-		*SelectTab8*
-			Select the eighth tab.
-		*SelectTab9*
-			Select the ninth tab.
-		*SelectLastTab*
-			Select the last tab.
 
 		_Linux/BSD exclusive:_
 


### PR DESCRIPTION
Since we now have Codex in 2026 we don't need to beg authors to add anything.

I just ported tabs from Kitty, including custom titles and keybindings, mouse clickable.
Docs updated, example config attached.

<img width="1516" height="603" alt="Image" src="https://github.com/user-attachments/assets/43f68c12-20f0-4365-97e2-f78dcd9e7348" />

## Example config

```toml
[tabs]
tab_bar_edge = "top"
tab_bar_style = "slant"
tab_powerline_style = "slanted"
tab_bar_min_tabs = 1
tab_switch_strategy = "previous"
tab_title_template = "{title}"
active_tab_foreground = "#1e1e2e"
active_tab_background = "#cba6f7"
active_tab_font_style = "italic"
inactive_tab_foreground = "#cdd6f4"
inactive_tab_background = "#0b0b12"
inactive_tab_font_style = "normal"
tab_bar_background = "#11111b"
mouse = { enabled = true, hover = true }

[keyboard]
bindings = [
  { key = "T", mods = "Super", action = "CreateNewTab" },
  { key = "Right", mods = "Super", action = "SelectNextTab" },
  { key = "Left", mods = "Super", action = "SelectPreviousTab" },
  { key = "Tab", mods = "Super", action = "SelectNextTab" },
  { key = "Tab", mods = "Super|Shift", action = "SelectPreviousTab" },
  { key = "W", mods = "Super", action = "CloseTab" },
  { key = ".", mods = "Super", action = "MoveTabForward" },
  { key = ",", mods = "Super", action = "MoveTabBackward" },
  { key = "T", mods = "Super|Alt", action = "SetTabTitle" },
]
```

P.S. I am not expecting this PR will be really merged, but if so, I can cleanup README changes.
