### PR TITLE
fix(input): handle layout-shifted keys in vi mode search

### DIFF
--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -213,7 +213,17 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 },
             };
 
-            if binding.is_triggered_by(mode, mods, &key) {
+            // For character bindings, only require that the binding's modifiers are
+            // present, ignoring extra modifiers like Shift that may be needed to
+            // produce the character on non-US keyboard layouts. For scancode
+            // bindings, modifiers must match exactly since the binding refers to a
+            // physical key position.
+            let binding_mods = match &binding.trigger {
+                BindingKey::Keycode { key: Key::Character(_), .. } => mods & binding.mods,
+                _ => mods,
+            };
+
+            if binding.is_triggered_by(mode, binding_mods, &key) {
                 // Pass through the key if any of the bindings has the `ReceiveChar` action.
                 *suppress_chars.get_or_insert(true) &= binding.action != Action::ReceiveChar;
 


### PR DESCRIPTION
## Summary

- On non-US keyboard layouts (e.g. Spanish), characters like `/` require Shift+7. The key event carries both the character and a Shift modifier, causing the default vi mode SearchForward binding to fail since it expects no modifiers.
- For character-based key bindings, mask the actual modifiers to only include what the binding declares before calling `is_triggered_by`. This makes layout-necessary modifiers transparent while still enforcing explicitly required ones.
- Scancode bindings continue to use exact modifier matching, since they refer to physical key positions.

## Test plan

- [ ] On a Spanish (or other non-US) keyboard layout, enter vi mode and press `/` (Shift+7) -- should trigger SearchForward
- [ ] On a US keyboard layout, verify `/` still triggers SearchForward (no regression)
- [ ] Verify `?` (Shift+/) still triggers SearchBackward on US layout
- [ ] Verify Ctrl+Shift+V paste binding still works (explicit modifier requirements preserved)
- [ ] Verify scancode-based bindings are unaffected

Fixes #8846