### PR TITLE
Add window.title_format option for dynamic title customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.18.0-dev
 
+### Changed
+
+- Support `{}` placeholder in `window.title` for dynamic title customization
+
 ## 0.17.0
 
 ### Packaging

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -450,4 +450,46 @@ window = "Hello""#
         let toml = yaml_to_toml(contents);
         assert!(toml.is_empty());
     }
+
+    fn window_config_with_title(title: &str) -> window::WindowConfig {
+        let mut config = window::WindowConfig::default();
+        config.identity.title = title.to_owned();
+        config
+    }
+
+    #[test]
+    fn formatted_title_with_placeholder() {
+        let config = window_config_with_title("Alacritty - {}");
+        assert_eq!(config.formatted_title("vim"), "Alacritty - vim");
+    }
+
+    #[test]
+    fn formatted_title_without_placeholder_uses_dynamic() {
+        let config = window_config_with_title("Alacritty");
+        assert_eq!(config.formatted_title("vim"), "vim");
+    }
+
+    #[test]
+    fn formatted_title_with_empty_dynamic() {
+        let config = window_config_with_title("prefix - {} - suffix");
+        assert_eq!(config.formatted_title(""), "prefix -  - suffix");
+    }
+
+    #[test]
+    fn formatted_title_with_multiple_placeholders() {
+        let config = window_config_with_title("{} - {} - end");
+        assert_eq!(config.formatted_title("vim"), "vim - vim - end");
+    }
+
+    #[test]
+    fn default_title_strips_placeholder() {
+        let config = window_config_with_title("Alacritty - {}");
+        assert_eq!(config.default_title(), "Alacritty - ");
+    }
+
+    #[test]
+    fn default_title_without_placeholder() {
+        let config = window_config_with_title("Alacritty");
+        assert_eq!(config.default_title(), "Alacritty");
+    }
 }

--- a/alacritty/src/config/window.rs
+++ b/alacritty/src/config/window.rs
@@ -90,6 +90,19 @@ impl Default for WindowConfig {
 }
 
 impl WindowConfig {
+    pub fn formatted_title(&self, dynamic_title: &str) -> String {
+        let title = &self.identity.title;
+        if title.contains("{}") {
+            title.replace("{}", dynamic_title)
+        } else {
+            dynamic_title.to_owned()
+        }
+    }
+
+    pub fn default_title(&self) -> String {
+        self.identity.title.replace("{}", "")
+    }
+
     #[inline]
     pub fn dimensions(&self) -> Option<Dimensions> {
         let (lines, columns) = (self.dimensions.lines, self.dimensions.columns);

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -173,8 +173,9 @@ impl Window {
             window_attributes = window_attributes.with_embed_parent_window(parent_window_id);
         }
 
+        let initial_title = config.window.default_title();
         window_attributes = window_attributes
-            .with_title(&identity.title)
+            .with_title(&initial_title)
             .with_theme(config.window.theme())
             .with_visible(false)
             .with_transparent(true)
@@ -206,7 +207,7 @@ impl Window {
         Ok(Self {
             hold: options.terminal_options.hold,
             requested_redraw: false,
-            title: identity.title,
+            title: initial_title,
             current_mouse_cursor,
             mouse_visible: true,
             has_frame: true,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1867,13 +1867,14 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                 EventType::Terminal(event) => match event {
                     TerminalEvent::Title(title) => {
                         if !self.ctx.preserve_title && self.ctx.config.window.dynamic_title {
+                            let title = self.ctx.config.window.formatted_title(&title);
                             self.ctx.window().set_title(title);
                         }
                     },
                     TerminalEvent::ResetTitle => {
                         let window_config = &self.ctx.config.window;
                         if !self.ctx.preserve_title && window_config.dynamic_title {
-                            self.ctx.display.window.set_title(window_config.identity.title.clone());
+                            self.ctx.display.window.set_title(window_config.default_title());
                         }
                     },
                     TerminalEvent::Bell => {

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -304,9 +304,9 @@ impl WindowContext {
         // │ N  │       N       │              _              ││     Y     │
         if !self.preserve_title
             && (!self.config.window.dynamic_title
-                || self.display.window.title() == old_config.window.identity.title)
+                || self.display.window.title() == old_config.window.default_title())
         {
-            self.display.window.set_title(self.config.window.identity.title.clone());
+            self.display.window.set_title(self.config.window.default_title());
         }
 
         let opaque = self.config.window_opacity() >= 1.;

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -159,7 +159,11 @@ This section documents the *[window]* table of the configuration file.
 
 *title* = _"<string>"_
 
-	Window title.
+	Window title. If the string contains _{}_, it acts as a format string
+	where _{}_ is replaced with the dynamic title set by the terminal
+	application.
+
+	Example: _"Alacritty - {}"_
 
 	Default: _"Alacritty"_
 


### PR DESCRIPTION
Support `{}` placeholder in `window.title` for dynamic title customization. When `{}` is present in the title, it's replaced with the title set by the terminal application.

Example configuration:

```toml
[window]
title = "Alacritty - {}"
```

When `{}` is not present, behavior is unchanged — the dynamic title fully replaces the configured title as before.

A quick test:
```
cargo run -- -o 'window.title="Alacritty - {}"'
```

<img width="962" height="542" alt="image" src="https://github.com/user-attachments/assets/90156cce-7820-4fa2-8a58-e787c9b9c833" />