### PR TITLE
Fix owner check warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 ## 0.18.0-dev
 
+### Fixed
+
+- Spurious "Failed to set new owner of XCB selection" warnings on X11
+
 ## 0.17.0
 
 ### Packaging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,8 +2723,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "x11-clipboard"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
+source = "git+https://github.com/quininer/x11-clipboard.git?rev=19ab2163cf0bd0db607e827a5214571990307866#19ab2163cf0bd0db607e827a5214571990307866"
 dependencies = [
  "libc",
  "x11rb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ incremental = false
 [workspace.dependencies]
 toml = "0.9.11"
 toml_edit = "0.24.0"
+
+# TODO: Validation of fix for #6978. Remove before next release and use released `x11-clipboard`.
+[patch.crates-io]
+x11-clipboard = { git = "https://github.com/quininer/x11-clipboard.git", rev = "19ab2163cf0bd0db607e827a5214571990307866" }


### PR DESCRIPTION
Use a patched version of x11-clipboard that fixes #6978 via https://github.com/quininer/x11-clipboard/pull/53. Use a Git dependency to get some exposure to Alacritty users until we have confidence in the fix and can publish a new version of x11-clipboard. See https://github.com/alacritty/copypasta/pull/85 for additional details.

Closes: #6978