### PR TITLE
avoid scroll on vertical shrink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Fixed
 
 - Spurious "Failed to set new owner of XCB selection" warnings on X11
+- Alternate screen flickering during vertical resize
 
 ## 0.17.0
 

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -82,14 +82,12 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
     {
         // Scroll up to keep content inside the window.
         let required_scrolling = (self.cursor.point.line.0 as usize + 1).saturating_sub(target);
-        if required_scrolling > 0 {
+        if required_scrolling > 0 && self.max_scroll_limit > 0 {
             self.scroll_up(&(Line(0)..Line(self.lines as i32)), required_scrolling);
-
-            // Clamp cursors to the new viewport size.
-            self.cursor.point.line = min(self.cursor.point.line, Line(target as i32 - 1));
         }
 
-        // Clamp saved cursor, since only primary cursor is scrolled into viewport.
+        // Clamp cursors to the new viewport size.
+        self.cursor.point.line = min(self.cursor.point.line, Line(target as i32 - 1));
         self.saved_cursor.point.line = min(self.saved_cursor.point.line, Line(target as i32 - 1));
 
         self.raw.rotate((self.lines - target) as isize);

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -20,7 +20,7 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
         let template = mem::take(&mut self.cursor.template);
 
         match self.lines.cmp(&lines) {
-            Ordering::Less => self.grow_lines(lines),
+            Ordering::Less => self.grow_lines(lines, reflow),
             Ordering::Greater => self.shrink_lines(lines, reflow),
             Ordering::Equal => (),
         }
@@ -40,7 +40,7 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
     /// Alacritty keeps the cursor at the bottom of the terminal as long as there
     /// is scrollback available. Once scrollback is exhausted, new lines are
     /// simply added to the bottom of the screen.
-    fn grow_lines<D>(&mut self, target: usize)
+    fn grow_lines<D>(&mut self, target: usize, reflow: bool)
     where
         T: ResetDiscriminant<D>,
         D: PartialEq,
@@ -51,7 +51,7 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
         self.raw.grow_visible_lines(target);
         self.lines = target;
 
-        let history_size = self.history_size();
+        let history_size = if reflow { self.history_size() } else { 0 };
         let from_history = min(history_size, lines_added);
 
         // Move existing lines up for every line that couldn't be pulled from history.
@@ -80,7 +80,8 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
         T: ResetDiscriminant<D>,
         D: PartialEq,
     {
-        // On the alt screen the app redraws after SIGWINCH
+        // If the cursor is at the bottom in the primary screen, scroll up the content together
+        // with the cursor.
         let required_scrolling = (self.cursor.point.line.0 as usize + 1).saturating_sub(target);
         if required_scrolling > 0 && reflow {
             self.scroll_up(&(Line(0)..Line(self.lines as i32)), required_scrolling);

--- a/alacritty_terminal/src/grid/resize.rs
+++ b/alacritty_terminal/src/grid/resize.rs
@@ -21,7 +21,7 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
 
         match self.lines.cmp(&lines) {
             Ordering::Less => self.grow_lines(lines),
-            Ordering::Greater => self.shrink_lines(lines),
+            Ordering::Greater => self.shrink_lines(lines, reflow),
             Ordering::Equal => (),
         }
 
@@ -75,14 +75,14 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
     /// of the terminal window.
     ///
     /// Alacritty takes the same approach.
-    fn shrink_lines<D>(&mut self, target: usize)
+    fn shrink_lines<D>(&mut self, target: usize, reflow: bool)
     where
         T: ResetDiscriminant<D>,
         D: PartialEq,
     {
-        // Scroll up to keep content inside the window.
+        // On the alt screen the app redraws after SIGWINCH
         let required_scrolling = (self.cursor.point.line.0 as usize + 1).saturating_sub(target);
-        if required_scrolling > 0 && self.max_scroll_limit > 0 {
+        if required_scrolling > 0 && reflow {
             self.scroll_up(&(Line(0)..Line(self.lines as i32)), required_scrolling);
         }
 


### PR DESCRIPTION
When an alt-screen application like htop, less or vim has its cursor on the last row and the window is vertically shrunk, shrink_lines calls scroll_up to keep the cursor visible. This shifts the entire viewport upward by the resize delta. The alt screen has no scrollback, so the top rows are lost. Alacritty then draws this shifted state for one frame before the application receives SIGWINCH and redraws itself. The user sees this as a flicker where content briefly jumps upward.