### PR TITLE
Bump png dependency to 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -639,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1510,11 +1510,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.4",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1661,7 +1661,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2387,7 +2387,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -55,7 +55,7 @@ clap_complete = "4.2.3"
 xdg = "3.0.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-png = { version = "0.17.5", default-features = false, optional = true }
+png = { version = "0.18.1", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.1"

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -298,7 +298,7 @@ impl Window {
             let mut decoder = Decoder::new(Cursor::new(WINDOW_ICON));
             decoder.set_transformations(png::Transformations::normalize_to_color8());
             let mut reader = decoder.read_info().expect("invalid embedded icon");
-            let mut buf = vec![0; reader.output_buffer_size()];
+            let mut buf = vec![0; reader.output_buffer_size().expect("invalid embedded icon size")];
             let _ = reader.next_frame(&mut buf);
             Icon::from_rgba(buf, reader.info().width, reader.info().height)
                 .expect("invalid embedded icon format")


### PR DESCRIPTION
The `png` crate was pinned at `0.17.5` in `alacritty/Cargo.toml` since a routine `glutin 0.29.1` bump back in 2022 (commit 7d708d5). Most `png 0.17.x` releases since then have been absorbed automatically through the semver range, but 0.18 requires an explicit source change. It has been stable since 2025-08-29 and is current at 0.18.1.

The one call site (`alacritty/src/display/window.rs`) decodes the compile time embedded window icon on X11. `Cursor<&[u8]>` already satisfies 0.18's new `Seek + BufRead` requirement on `Decoder::new`, so the only code change is handling `Reader::output_buffer_size()` now returning `Option<usize>` instead of `usize`. I matched the existing `.expect("invalid embedded icon")` idiom on the line above. For this embedded input `None` cannot happen.

`png 0.18.1`'s MSRV is `1.73`, well under alacritty's `1.85.0`, so there is no MSRV impact.

### Verification

* `cargo build` (default: wayland + x11): clean
* `cargo build --features x11`: clean
* `cargo build --no-default-features --features wayland` (png not compiled): clean
* `cargo test`: 1 passed, 0 failed
* `cargo clippy --all-targets -- -D warnings`: clean
* `cargo fmt --all --check`: clean

### Lockfile

`cargo update --package png --precise 0.18.1` produced the 18 line lockfile diff: `png 0.17.16` to `0.18.1`, its `bitflags 1.3.2` to `bitflags 2.9.4`, and five unrelated transitive crates (dirs, fastrand, objc2-core-foundation, rustix, tempfile/terminal_size) that pulled newer `windows-sys 0.61.2` during re-resolution. No CHANGELOG entry, matching the pattern of prior "Bump dependencies" commits.
