### PR TITLE
Fix titlebar button reappearance issue in SimpleFullscreen transition

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -71,6 +71,8 @@ objc2-app-kit = { version = "0.3.1", default-features = false, features = [
     "NSResponder",
     "NSView",
     "NSWindow",
+    "NSButton",
+    "NSControl",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -39,6 +39,8 @@ use alacritty_terminal::vte::ansi::{CursorShape, NamedColor};
 use crate::config::UiConfig;
 use crate::config::debug::RendererPreference;
 use crate::config::font::Font;
+#[cfg(target_os = "macos")]
+use crate::config::window::Decorations;
 use crate::config::window::Dimensions;
 #[cfg(not(windows))]
 use crate::config::window::StartupMode;
@@ -498,7 +500,10 @@ impl Display {
         if !_tabbed {
             match config.window.startup_mode {
                 #[cfg(target_os = "macos")]
-                StartupMode::SimpleFullscreen => window.set_simple_fullscreen(true),
+                StartupMode::SimpleFullscreen => window.set_simple_fullscreen(
+                    true,
+                    config.window.decorations == Decorations::Buttonless,
+                ),
                 StartupMode::Maximized if !is_wayland => window.set_maximized(true),
                 _ => (),
             }

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -23,7 +23,7 @@ use std::fmt::{self, Display, Formatter};
 #[cfg(target_os = "macos")]
 use {
     objc2::MainThreadMarker,
-    objc2_app_kit::{NSColorSpace, NSView},
+    objc2_app_kit::{NSColorSpace, NSView, NSWindowButton},
     winit::platform::macos::{OptionAsAlt, WindowAttributesExtMacOS, WindowExtMacOS},
 };
 
@@ -410,8 +410,8 @@ impl Window {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn toggle_simple_fullscreen(&self) {
-        self.set_simple_fullscreen(!self.window.simple_fullscreen());
+    pub fn toggle_simple_fullscreen(&self, buttonless: bool) {
+        self.set_simple_fullscreen(!self.window.simple_fullscreen(), buttonless);
     }
 
     #[cfg(target_os = "macos")]
@@ -431,9 +431,31 @@ impl Window {
         self.window.current_monitor()
     }
 
+    /// Hides titlebar buttons (minimize, maximize, close) one by one
     #[cfg(target_os = "macos")]
-    pub fn set_simple_fullscreen(&self, simple_fullscreen: bool) {
+    pub fn hide_titlebar_buttons(&self, buttonless: bool) {
+        if let RawWindowHandle::AppKit(handle) = self.raw_window_handle() {
+            let view = unsafe { handle.ns_view.cast::<NSView>().as_ref() };
+            if let Some(window) = view.window() {
+                for button in &[
+                    NSWindowButton::MiniaturizeButton,
+                    NSWindowButton::ZoomButton,
+                    NSWindowButton::CloseButton,
+                ] {
+                    if let Some(b) = window.standardWindowButton(*button) {
+                        b.setHidden(buttonless);
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn set_simple_fullscreen(&self, simple_fullscreen: bool, buttonless: bool) {
         self.window.set_simple_fullscreen(simple_fullscreen);
+        if !simple_fullscreen {
+            self.hide_titlebar_buttons(buttonless);
+        }
     }
 
     /// Set IME inhibitor state and disable IME while any are present.

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -335,7 +335,10 @@ impl<T: EventListener> Execute<T> for Action {
             Action::ToggleFullscreen => ctx.window().toggle_fullscreen(),
             Action::ToggleMaximized => ctx.window().toggle_maximized(),
             #[cfg(target_os = "macos")]
-            Action::ToggleSimpleFullscreen => ctx.window().toggle_simple_fullscreen(),
+            Action::ToggleSimpleFullscreen => {
+                let buttonless = ctx.config().window.decorations == Decorations::Buttonless;
+                ctx.window().toggle_simple_fullscreen(buttonless);
+            },
             #[cfg(target_os = "macos")]
             Action::Hide => ctx.event_loop().hide_application(),
             #[cfg(target_os = "macos")]


### PR DESCRIPTION

Fixes #3458

* Added `NSButton` and `NSControl` features to the `objc2-app-kit` dependency in `Cargo.toml` to support manipulating window buttons.
* Introduced the `hide_titlebar_buttons` method in `display/window.rs` to hide or show the titlebar buttons based on the "buttonless" setting, and updated `set_simple_fullscreen` to call this method when exiting simple fullscreen.
* Modified the fullscreen toggling logic in both `display/mod.rs` and `display/window.rs` to pass the "buttonless" setting and ensure the correct button state.

