### PR TITLE
fix: strip layout-consumed SHIFT for character key bindings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          sudo apt-get install cmake pkg-config libfreetype6-dev libfontconfig1-dev \
+          sudo apt update
+          sudo apt install cmake pkg-config libfreetype6-dev libfontconfig1-dev \
             libxcb-xfixes0-dev libxkbcommon-dev python3 scdoc
       - name: Test
         run: cargo test --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
-## 0.17.0-rc2
+## 0.17.0
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
-## 0.17.0-dev
+## 0.17.0-rc1
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
-## 0.17.0-rc1
+## 0.17.0-rc2
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
+## Unreleased
+
+### Added
+
+- `SelectAll` keyboard action to select all terminal content from scrollback start to cursor
+
 ## 0.17.0
 
 ### Packaging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty"
-version = "0.17.0-rc1"
+version = "0.17.0-rc2"
 dependencies = [
  "ahash",
  "alacritty_config",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.26.0-rc1"
+version = "0.26.0-rc2"
 dependencies = [
  "base64",
  "bitflags 2.9.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty"
-version = "0.17.0-rc2"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "alacritty_config",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.26.0-rc2"
+version = "0.26.0"
 dependencies = [
  "base64",
  "bitflags 2.9.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty"
-version = "0.17.0-dev"
+version = "0.17.0-rc1"
 dependencies = [
  "ahash",
  "alacritty_config",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_config"
-version = "0.2.4-dev"
+version = "0.2.3"
 dependencies = [
  "alacritty_config_derive",
  "log",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_config_derive"
-version = "0.2.6-dev"
+version = "0.2.5"
 dependencies = [
  "alacritty_config",
  "log",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.25.2-dev"
+version = "0.26.0-rc1"
 dependencies = [
  "base64",
  "bitflags 2.9.4",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.17.0-rc2"
+version = "0.17.0"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"
@@ -12,7 +12,7 @@ rust-version.workspace = true
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.26.0-rc2"
+version = "0.26.0"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.17.0-rc1"
+version = "0.17.0-rc2"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"
@@ -12,7 +12,7 @@ rust-version.workspace = true
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.26.0-rc1"
+version = "0.26.0-rc2"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.17.0-dev"
+version = "0.17.0-rc1"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"
@@ -12,15 +12,15 @@ rust-version.workspace = true
 
 [dependencies.alacritty_terminal]
 path = "../alacritty_terminal"
-version = "0.25.2-dev"
+version = "0.26.0-rc1"
 
 [dependencies.alacritty_config_derive]
 path = "../alacritty_config_derive"
-version = "0.2.6-dev"
+version = "0.2.5"
 
 [dependencies.alacritty_config]
 path = "../alacritty_config"
-version = "0.2.4-dev"
+version = "0.2.3"
 
 [dependencies]
 ahash = { version = "0.8.6", features = ["no-rng"] }

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -247,6 +247,9 @@ pub enum Action {
     /// Start a backward buffer search.
     SearchBackward,
 
+    /// Select all terminal content including scrollback and copy to clipboard.
+    SelectAll,
+
     /// No action.
     None,
 }

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -204,6 +204,21 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             key.logical_key.clone()
         };
 
+        // For character bindings, strip SHIFT from the modifier state when SHIFT was consumed
+        // by the keyboard layout to produce the character (e.g. Shift+7 → '/' on Spanish
+        // keyboards). This allows layout-dependent bindings like '/' to trigger correctly
+        // without requiring users to add an explicit `mods = "Shift"` workaround.
+        let char_binding_mods = if mods.shift_key() {
+            match &logical_key {
+                Key::Character(_) if logical_key != key.key_without_modifiers() => {
+                    mods & !ModifiersState::SHIFT
+                },
+                _ => mods,
+            }
+        } else {
+            mods
+        };
+
         // Get the action of a key binding.
         let mut binding_action = |binding: &KeyBinding| {
             let key = match (&binding.trigger, &logical_key) {
@@ -213,7 +228,12 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 },
             };
 
-            if binding.is_triggered_by(mode, mods, &key) {
+            // Scancode bindings use full mods; character bindings use mods with any
+            // layout-consumed SHIFT stripped.
+            let effective_mods =
+                if matches!(binding.trigger, BindingKey::Scancode(_)) { mods } else { char_binding_mods };
+
+            if binding.is_triggered_by(mode, effective_mods, &key) {
                 // Pass through the key if any of the bindings has the `ReceiveChar` action.
                 *suppress_chars.get_or_insert(true) &= binding.action != Action::ReceiveChar;
 

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -29,7 +29,7 @@ use winit::window::CursorIcon;
 use alacritty_terminal::event::EventListener;
 use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Boundary, Column, Direction, Point, Side};
-use alacritty_terminal::selection::SelectionType;
+use alacritty_terminal::selection::{Selection, SelectionType};
 use alacritty_terminal::term::search::Match;
 use alacritty_terminal::term::{ClipboardType, Term, TermMode};
 use alacritty_terminal::vi_mode::ViMotion;
@@ -320,6 +320,14 @@ impl<T: EventListener> Execute<T> for Action {
             Action::Mouse(MouseAction::ExpandSelection) => ctx.expand_selection(),
             Action::SearchForward => ctx.start_search(Direction::Right),
             Action::SearchBackward => ctx.start_search(Direction::Left),
+            Action::SelectAll => {
+                let start = Point::new(ctx.terminal().topmost_line(), Column(0));
+                let cursor = ctx.terminal().grid().cursor.point;
+                let mut selection = Selection::new(SelectionType::Simple, start, Side::Left);
+                selection.update(cursor, Side::Right);
+                ctx.terminal_mut().selection = Some(selection);
+                ctx.mark_dirty();
+            },
             Action::Copy => ctx.copy_selection(ClipboardType::Clipboard),
             #[cfg(not(any(target_os = "macos", windows)))]
             Action::CopySelection => ctx.copy_selection(ClipboardType::Selection),

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.17.0-rc1" Manufacturer="Alacritty" InstallerVersion="200">
+   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.17.0-rc2" Manufacturer="Alacritty" InstallerVersion="200">
       <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
       <Icon Id="AlacrittyIco" SourceFile=".\alacritty\windows\alacritty.ico" />
       <WixVariable Id="WixUILicenseRtf" Value=".\alacritty\windows\wix\license.rtf" />

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.17.0-dev" Manufacturer="Alacritty" InstallerVersion="200">
+   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.17.0-rc1" Manufacturer="Alacritty" InstallerVersion="200">
       <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
       <Icon Id="AlacrittyIco" SourceFile=".\alacritty\windows\alacritty.ico" />
       <WixVariable Id="WixUILicenseRtf" Value=".\alacritty\windows\wix\license.rtf" />

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.17.0-rc2" Manufacturer="Alacritty" InstallerVersion="200">
+   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.17.0" Manufacturer="Alacritty" InstallerVersion="200">
       <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
       <Icon Id="AlacrittyIco" SourceFile=".\alacritty\windows\alacritty.ico" />
       <WixVariable Id="WixUILicenseRtf" Value=".\alacritty\windows\wix\license.rtf" />

--- a/alacritty_config/Cargo.toml
+++ b/alacritty_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_config"
-version = "0.2.4-dev"
+version = "0.2.3"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT OR Apache-2.0"
 description = "Alacritty configuration abstractions"
@@ -15,5 +15,5 @@ serde = "1.0.163"
 toml.workspace = true
 
 [dev-dependencies]
-alacritty_config_derive = { version = "0.2.6-dev", path = "../alacritty_config_derive" }
+alacritty_config_derive = { version = "0.2.5", path = "../alacritty_config_derive" }
 serde = { version = "1.0.163", features = ["derive"] }

--- a/alacritty_config_derive/Cargo.toml
+++ b/alacritty_config_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_config_derive"
-version = "0.2.6-dev"
+version = "0.2.5"
 authors = ["Christian Duerr <contact@christianduerr.com>"]
 license = "MIT OR Apache-2.0"
 description = "Failure resistant deserialization derive"
@@ -19,7 +19,7 @@ syn = { version = "2.0.16", features = ["derive", "parsing", "proc-macro", "prin
 
 [dev-dependencies.alacritty_config]
 path = "../alacritty_config"
-version = "0.2.4-dev"
+version = "0.2.3"
 
 [dev-dependencies]
 log = "0.4.11"

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -8,7 +8,7 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.25.1-dev
+## 0.26.0-rc1
 
 ### Added
 

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -8,7 +8,7 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.26.0-rc1
+## 0.26.0-rc2
 
 ### Added
 

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -8,7 +8,7 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.26.0-rc2
+## 0.26.0
 
 ### Added
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.26.0-rc1"
+version = "0.26.0-rc2"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.26.0-rc2"
+version = "0.26.0"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.25.2-dev"
+version = "0.26.0-rc1"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -853,6 +853,8 @@ _https://docs.rs/winit/latest/winit/keyboard/enum.Key.html#variant.Dead_
 			Start a forward buffer search.
 		*SearchBackward*
 			Start a backward buffer search.
+		*SelectAll*
+			Select all terminal content including scrollback and copy to clipboard.
 
 		_Vi mode actions:_
 

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.17.0-rc1</string>
+  <string>0.17.0-rc2</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.17.0-dev</string>
+  <string>0.17.0-rc1</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.17.0-rc2</string>
+  <string>0.17.0</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>


### PR DESCRIPTION
Fixes #8846

## Problem

On non-US keyboards, characters may require `Shift` to produce. For example on a Spanish keyboard, `Shift+7` produces `/`. When Alacritty matches key bindings it uses the full modifier state including `Shift`, so a binding like `{key = "/"}` (no explicit mods) fails to trigger because `Shift` is present but the binding expects no modifiers.

## Fix

After computing `logical_key`, check if `Shift` was consumed by the keyboard layout by comparing `logical_key` to `key.key_without_modifiers()`. If they differ and `Shift` is active, `Shift` was consumed by the layout — strip it from the effective modifier state used for character binding matching. Scancode bindings continue to use the full modifier state unchanged.

This correctly handles:
- `Shift+7 → '/'` on Spanish layout: SHIFT stripped, binding `"/"` matches ✓  
- `Shift+A → 'a'` on US layout: lowercased == `key_without_modifiers()`, SHIFT kept ✓
- Scancode bindings: always use full mods ✓

## Test plan

- [ ] Spanish keyboard (or similar): Vi mode `/` search triggers without needing `{mods = "Shift"}` workaround
- [ ] US keyboard: existing bindings involving `Shift` still work correctly
- [ ] Custom `{key = "/", mods = "Shift"}` bindings on non-US layouts no longer needed but don't break anything else