### PR TITLE
Fix: Enable ConPTY handle inheritance for child processes on Windows

### DIFF
--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -143,8 +143,9 @@ pub fn new(config: &Options, window_size: WindowSize) -> Result<Pty> {
 
     startup_info_ex.StartupInfo.cb = mem::size_of::<STARTUPINFOEXW>() as u32;
 
-    // Setting this flag but leaving all the handles as default (null) ensures the
-    // PTY process does not inherit any handles from this Alacritty process.
+    // Setting STARTF_USESTDHANDLES with null handles prevents standard I/O from
+    // being inherited. ConPTY infrastructure handles are inherited separately via
+    // the thread attribute list (see UpdateProcThreadAttribute below).
     startup_info_ex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
 
     // Create the appropriately sized thread attribute list.
@@ -221,7 +222,7 @@ pub fn new(config: &Options, window_size: WindowSize) -> Result<Pty> {
             cmdline.as_ptr() as PWSTR,
             ptr::null_mut(),
             ptr::null_mut(),
-            false as i32,
+            true as i32,  // bInheritHandles: allow ConPTY infrastructure inheritance
             creation_flags,
             custom_env_block_pointer,
             cwd.as_ref().map_or_else(ptr::null, |s| s.as_ptr()),


### PR DESCRIPTION
## Problem
On Windows with Zellij terminal multiplexer, new panes fail to spawn shells. Zellij logs show 'no ConPTY terminal found for id 0' when trying to resize panes.

## Root Cause
Line 224 in alacritty_terminal/src/tty/windows/conpty.rs sets bInheritHandles to FALSE in the CreateProcessW call. This prevents child processes (Zellij panes) from inheriting ConPTY infrastructure handles, causing pane initialization to fail.

The original design (commit 9ba7c4fa, 2019) set this to FALSE to prevent Alacritty's broken stdin/stdout handles from crashing ConPTY. However, modern Windows API allows explicitly passing only the ConPTY handle via the thread attribute list (lines 189-197), enabling proper handle inheritance without the original risk.

## Solution
Change line 224 from `false as i32` to `true as i32`, enabling handle inheritance. This allows Zellij pane processes to access necessary ConPTY infrastructure while STARTUPINFO remains null (preventing stdin/stdout inheritance).

## Testing
Verified on Windows 11 with Alacritty 0.18.0-dev:
- Before patch: New Zellij panes create empty terminal windows with no shell
- After patch: New Zellij panes spawn with functional PowerShell instances

No regression on direct Alacritty usage.
