### PR TITLE
Fix emoji presentation sequence (VS16) width handling.

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -15,11 +15,13 @@ fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(Path::new(&dest).join("gl_bindings.rs")).unwrap();
 
-    Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, [
-        "GL_ARB_blend_func_extended",
-        "GL_KHR_robustness",
-        "GL_KHR_debug",
-    ])
+    Registry::new(
+        Api::Gl,
+        (3, 3),
+        Profile::Core,
+        Fallbacks::All,
+        ["GL_ARB_blend_func_extended", "GL_KHR_robustness", "GL_KHR_debug"],
+    )
     .write_bindings(GlobalGenerator, &mut file)
     .unwrap();
 

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -9,7 +9,10 @@ use alacritty_terminal::index::{Column, Line, Point};
 use alacritty_terminal::selection::SelectionRange;
 use alacritty_terminal::term::cell::{Cell, Flags, Hyperlink};
 use alacritty_terminal::term::search::{Match, RegexSearch};
-use alacritty_terminal::term::{self, RenderableContent as TerminalContent, Term, TermMode};
+use alacritty_terminal::term::{
+    self, EMOJI_PRESENTATION_SELECTOR, RenderableContent as TerminalContent, Term, TermMode,
+    is_emoji_presentation_sequence,
+};
 use alacritty_terminal::vte::ansi::{Color, CursorShape, NamedColor};
 
 use crate::config::UiConfig;
@@ -203,6 +206,7 @@ pub struct RenderableCell {
 pub struct RenderableCellExtra {
     pub zerowidth: Option<Vec<char>>,
     pub hyperlink: Option<Hyperlink>,
+    pub emoji_presentation: bool,
 }
 
 impl RenderableCell {
@@ -287,11 +291,16 @@ impl RenderableCell {
 
         let zerowidth = cell.zerowidth();
         let hyperlink = cell.hyperlink();
+        let emoji_presentation = zerowidth.is_some_and(|zerowidth| {
+            zerowidth.contains(&EMOJI_PRESENTATION_SELECTOR)
+                && is_emoji_presentation_sequence(character)
+        });
 
-        let extra = (zerowidth.is_some() || hyperlink.is_some()).then(|| {
+        let extra = (zerowidth.is_some() || hyperlink.is_some() || emoji_presentation).then(|| {
             Box::new(RenderableCellExtra {
                 zerowidth: zerowidth.map(|zerowidth| zerowidth.to_vec()),
                 hyperlink,
+                emoji_presentation,
             })
         });
 

--- a/alacritty/src/display/damage.rs
+++ b/alacritty/src/display/damage.rs
@@ -361,12 +361,10 @@ mod tests {
         let width = 10;
         let size_info = SizeInfo::new(viewport_height, viewport_height, 5., 5., 0., 0., true);
         frame_damage.add_viewport_rect(&size_info, x, y, width, height);
-        assert_eq!(frame_damage.rects[0], Rect {
-            x,
-            y: viewport_height as i32 - y - height,
-            width,
-            height
-        });
+        assert_eq!(
+            frame_damage.rects[0],
+            Rect { x, y: viewport_height as i32 - y - height, width, height }
+        );
         assert_eq!(frame_damage.rects[0].y, viewport_y_to_damage_y(&size_info, y, height));
         assert_eq!(damage_y_to_viewport_y(&size_info, &frame_damage.rects[0]), y);
     }

--- a/alacritty/src/message_bar.rs
+++ b/alacritty/src/message_bar.rs
@@ -264,10 +264,10 @@ mod tests {
 
         let lines = message_buffer.message().unwrap().text(&size);
 
-        assert_eq!(lines, vec![
-            String::from("hahahahahahahahaha [X]"),
-            String::from("[MESSAGE TRUNCATED]   ")
-        ]);
+        assert_eq!(
+            lines,
+            vec![String::from("hahahahahahahahaha [X]"), String::from("[MESSAGE TRUNCATED]   ")]
+        );
     }
 
     #[test]
@@ -353,11 +353,10 @@ mod tests {
 
         let lines = message_buffer.message().unwrap().text(&size);
 
-        assert_eq!(lines, vec![
-            String::from("a [X]"),
-            String::from("bc   "),
-            String::from("defg ")
-        ]);
+        assert_eq!(
+            lines,
+            vec![String::from("a [X]"), String::from("bc   "), String::from("defg ")]
+        );
     }
 
     #[test]
@@ -369,11 +368,10 @@ mod tests {
 
         let lines = message_buffer.message().unwrap().text(&size);
 
-        assert_eq!(lines, vec![
-            String::from("ab  [X]"),
-            String::from("c 👩 d  "),
-            String::from("fgh    ")
-        ]);
+        assert_eq!(
+            lines,
+            vec![String::from("ab  [X]"), String::from("c 👩 d  "), String::from("fgh    ")]
+        );
     }
 
     #[test]

--- a/alacritty/src/migrate/mod.rs
+++ b/alacritty/src/migrate/mod.rs
@@ -107,10 +107,11 @@ fn migrate_toml(toml: String) -> Result<DocumentMut, String> {
     };
 
     // Move `draw_bold_text_with_bright_colors` to its own section.
-    move_value(&mut document, &["draw_bold_text_with_bright_colors"], &[
-        "colors",
-        "draw_bold_text_with_bright_colors",
-    ])?;
+    move_value(
+        &mut document,
+        &["draw_bold_text_with_bright_colors"],
+        &["colors", "draw_bold_text_with_bright_colors"],
+    )?;
 
     // Move bindings to their own section.
     move_value(&mut document, &["key_bindings"], &["keyboard", "bindings"])?;
@@ -300,11 +301,11 @@ not_moved = 9
         let mut document = input.parse::<DocumentMut>().unwrap();
 
         move_value(&mut document, &["root_value"], &["new_table", "root_value"]).unwrap();
-        move_value(&mut document, &["table", "table_value"], &[
-            "preexisting",
-            "subtable",
-            "new_name",
-        ])
+        move_value(
+            &mut document,
+            &["table", "table_value"],
+            &["preexisting", "subtable", "new_name"],
+        )
         .unwrap();
 
         let output = document.to_string();

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -25,6 +25,13 @@ pub trait LoadGlyph {
     fn clear(&mut self);
 }
 
+#[cfg(target_os = "macos")]
+const EMOJI_FONT_FAMILY: &str = "Apple Color Emoji";
+#[cfg(windows)]
+const EMOJI_FONT_FAMILY: &str = "Segoe UI Emoji";
+#[cfg(not(any(target_os = "macos", windows)))]
+const EMOJI_FONT_FAMILY: &str = "emoji";
+
 #[derive(Copy, Clone, Debug)]
 pub struct Glyph {
     pub tex_id: GLuint,
@@ -186,6 +193,30 @@ impl GlyphCache {
             Style::Description { slant, weight }
         };
         FontDesc::new(desc.family.clone(), style)
+    }
+
+    fn load_emoji_font(&mut self) -> Option<FontKey> {
+        let description = FontDesc::new(
+            EMOJI_FONT_FAMILY,
+            Style::Description { slant: Slant::Normal, weight: Weight::Normal },
+        );
+
+        self.rasterizer.load_font(&description, self.font_size).ok()
+    }
+
+    /// Find a font key for emoji presentation sequences.
+    pub fn emoji_font_key(&mut self, glyph_key: GlyphKey) -> FontKey {
+        let emoji_key = match self.load_emoji_font() {
+            Some(emoji_key) => emoji_key,
+            None => return glyph_key.font_key,
+        };
+
+        let emoji_key = GlyphKey { font_key: emoji_key, ..glyph_key };
+        match self.rasterizer.get_glyph(emoji_key) {
+            Ok(_) => emoji_key.font_key,
+            Err(RasterizerError::MissingGlyph(_)) => glyph_key.font_key,
+            Err(_) => glyph_key.font_key,
+        }
     }
 
     /// Get a glyph from the font.

--- a/alacritty/src/renderer/text/mod.rs
+++ b/alacritty/src/renderer/text/mod.rs
@@ -154,6 +154,9 @@ pub trait TextRenderApi<T: TextRenderBatch>: LoadGlyph {
 
         let mut glyph_key =
             GlyphKey { font_key, size: glyph_cache.font_size, character: cell.character };
+        if !hidden && cell.extra.as_ref().is_some_and(|extra| extra.emoji_presentation) {
+            glyph_key.font_key = glyph_cache.emoji_font_key(glyph_key);
+        }
 
         // Add cell to batch.
         let glyph = glyph_cache.get(glyph_key, self, true);

--- a/alacritty_config_derive/tests/config.rs
+++ b/alacritty_config_derive/tests/config.rs
@@ -126,22 +126,28 @@ fn config_deserialize() {
     // Verify all log messages are correct.
     let mut error_logs = logger.error_logs.lock().unwrap();
     error_logs.sort_unstable();
-    assert_eq!(error_logs.as_slice(), [
-        "Config error: enom_error: unknown variant `HugaBuga`, expected one of `One`, `Two`, \
+    assert_eq!(
+        error_logs.as_slice(),
+        [
+            "Config error: enom_error: unknown variant `HugaBuga`, expected one of `One`, `Two`, \
          `Three`",
-        "Config error: field1: invalid type: string \"testing\", expected usize",
-    ]);
+            "Config error: field1: invalid type: string \"testing\", expected usize",
+        ]
+    );
     let mut warn_logs = logger.warn_logs.lock().unwrap();
     warn_logs.sort_unstable();
-    assert_eq!(warn_logs.as_slice(), [
-        "Config warning: enom_error has been deprecated\nUse `alacritty migrate` to automatically \
+    assert_eq!(
+        warn_logs.as_slice(),
+        [
+            "Config warning: enom_error has been deprecated\nUse `alacritty migrate` to automatically \
          resolve it",
-        "Config warning: field1 has been deprecated; use field2 instead\nUse `alacritty migrate` \
+            "Config warning: field1 has been deprecated; use field2 instead\nUse `alacritty migrate` \
          to automatically resolve it",
-        "Config warning: gone has been removed; it's gone\nUse `alacritty migrate` to \
+            "Config warning: gone has been removed; it's gone\nUse `alacritty migrate` to \
          automatically resolve it",
-        "Unused config key: field3",
-    ]);
+            "Unused config key: field3",
+        ]
+    );
 }
 
 /// Logger storing all messages for later validation.

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -416,11 +416,10 @@ mod tests {
         let mut selection = Selection::new(SelectionType::Simple, location, Side::Left);
         selection.update(location, Side::Right);
 
-        assert_eq!(selection.to_range(&term(1, 2)).unwrap(), SelectionRange {
-            start: location,
-            end: location,
-            is_block: false
-        });
+        assert_eq!(
+            selection.to_range(&term(1, 2)).unwrap(),
+            SelectionRange { start: location, end: location, is_block: false }
+        );
     }
 
     /// Test case of single cell selection.
@@ -434,11 +433,10 @@ mod tests {
         let mut selection = Selection::new(SelectionType::Simple, location, Side::Right);
         selection.update(location, Side::Left);
 
-        assert_eq!(selection.to_range(&term(1, 2)).unwrap(), SelectionRange {
-            start: location,
-            end: location,
-            is_block: false
-        });
+        assert_eq!(
+            selection.to_range(&term(1, 2)).unwrap(),
+            SelectionRange { start: location, end: location, is_block: false }
+        );
     }
 
     /// Test adjacent cell selection from left to right.
@@ -524,11 +522,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(0)),
-            end: Point::new(Line(5), Column(4)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(0)),
+                end: Point::new(Line(5), Column(4)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -539,11 +540,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(1)),
-            end: Point::new(Line(5), Column(3)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(1)),
+                end: Point::new(Line(5), Column(3)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -554,11 +558,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(2)),
-            end: Point::new(Line(5), Column(3)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(2)),
+                end: Point::new(Line(5), Column(3)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -569,11 +576,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(0)..Line(size.0 as i32)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(0), Column(2)),
-            end: Point::new(Line(5), Column(3)),
-            is_block: true
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(0), Column(2)),
+                end: Point::new(Line(5), Column(3)),
+                is_block: true
+            }
+        );
     }
 
     #[test]
@@ -612,11 +622,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(1)..Line(size.0 as i32 - 1)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(1), Column(0)),
-            end: Point::new(Line(3), Column(3)),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(1), Column(0)),
+                end: Point::new(Line(3), Column(3)),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -627,11 +640,14 @@ mod tests {
         selection.update(Point::new(Line(1), Column(1)), Side::Left);
         selection = selection.rotate(&size, &(Line(1)..Line(size.0 as i32 - 1)), -5).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(6), Column(1)),
-            end: Point::new(Line(8), size.last_column()),
-            is_block: false,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(6), Column(1)),
+                end: Point::new(Line(8), size.last_column()),
+                is_block: false,
+            }
+        );
     }
 
     #[test]
@@ -642,11 +658,14 @@ mod tests {
         selection.update(Point::new(Line(4), Column(1)), Side::Right);
         selection = selection.rotate(&size, &(Line(1)..Line(size.0 as i32 - 1)), 4).unwrap();
 
-        assert_eq!(selection.to_range(&term(size.0, size.1)).unwrap(), SelectionRange {
-            start: Point::new(Line(1), Column(2)),
-            end: Point::new(Line(3), Column(3)),
-            is_block: true,
-        });
+        assert_eq!(
+            selection.to_range(&term(size.0, size.1)).unwrap(),
+            SelectionRange {
+                start: Point::new(Line(1), Column(2)),
+                end: Point::new(Line(3), Column(3)),
+                is_block: true,
+            }
+        );
     }
 
     #[test]

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -2337,11 +2337,7 @@ enum ModeState {
 
 impl From<bool> for ModeState {
     fn from(value: bool) -> Self {
-        if value {
-            Self::Set
-        } else {
-            Self::Reset
-        }
+        if value { Self::Set } else { Self::Reset }
     }
 }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -50,6 +50,20 @@ const KEYBOARD_MODE_STACK_MAX_DEPTH: usize = TITLE_STACK_MAX_DEPTH;
 /// Default tab interval, corresponding to terminfo `it` value.
 const INITIAL_TABSTOPS: usize = 8;
 
+/// Emoji presentation variation selector.
+pub const EMOJI_PRESENTATION_SELECTOR: char = '\u{FE0F}';
+
+/// Check if a character followed by VS16 forms an emoji presentation sequence.
+#[inline]
+pub fn is_emoji_presentation_sequence(c: char) -> bool {
+    let mut buf = [0; 8];
+    let len = c.encode_utf8(&mut buf).len();
+    let selector_len = EMOJI_PRESENTATION_SELECTOR.encode_utf8(&mut buf[len..]).len();
+    let sequence = str::from_utf8(&buf[..len + selector_len]).unwrap();
+
+    UnicodeWidthStr::width(sequence) == 2
+}
+
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct TermMode: u32 {
@@ -953,6 +967,39 @@ impl<T> Term<T> {
         &self.colors
     }
 
+    /// Promote the cell at the given point to a wide emoji presentation sequence.
+    fn promote_emoji_presentation(&mut self, line: Line, column: Column) {
+        if self.grid[line][column].flags.contains(Flags::WIDE_CHAR)
+            || !is_emoji_presentation_sequence(self.grid[line][column].c)
+        {
+            return;
+        }
+
+        if column < self.last_column() {
+            let spacer_column = column + 1;
+
+            // Write spacer through the normal cell writer so overwriting existing wide cells
+            // properly clears all related wide cell metadata.
+            self.grid.cursor.point = Point::new(line, spacer_column);
+            self.grid.cursor.template.flags.insert(Flags::WIDE_CHAR_SPACER);
+            self.write_at_cursor(' ');
+            self.grid.cursor.template.flags.remove(Flags::WIDE_CHAR_SPACER);
+
+            self.grid[line][column].flags.insert(Flags::WIDE_CHAR);
+
+            if spacer_column < self.last_column() {
+                self.grid.cursor.point.column = spacer_column + 1;
+                self.grid.cursor.input_needs_wrap = false;
+            } else {
+                self.grid.cursor.point.column = spacer_column;
+                self.grid.cursor.input_needs_wrap = true;
+            }
+        } else {
+            self.grid[line][column].flags.insert(Flags::WIDE_CHAR);
+            self.grid.cursor.input_needs_wrap = true;
+        }
+    }
+
     /// Insert a linebreak at the current cursor position.
     #[inline]
     fn wrapline(&mut self)
@@ -1082,34 +1129,8 @@ impl<T: EventListener> Handler for Term<T> {
 
             self.grid[line][column].push_zerowidth(c);
 
-            if c == '\u{FE0F}' && !self.grid[line][column].flags.contains(Flags::WIDE_CHAR) {
-                let base = self.grid[line][column].c;
-                let mut buf = [0u8; 8];
-                let s = {
-                    let len = base.encode_utf8(&mut buf).len();
-                    let vlen = '\u{FE0F}'.encode_utf8(&mut buf[len..]).len();
-                    core::str::from_utf8(&buf[..len + vlen]).unwrap()
-                };
-                if UnicodeWidthStr::width(s) == 2 {
-                    let columns = self.columns();
-                    self.grid[line][column].flags.insert(Flags::WIDE_CHAR);
-                    let spacer_col = column.0 + 1;
-                    if spacer_col < columns {
-                        let cell = &mut self.grid[line][Column(spacer_col)];
-                        cell.c = ' ';
-                        cell.flags.insert(Flags::WIDE_CHAR_SPACER);
-                        let next_col = spacer_col + 1;
-                        if next_col < columns {
-                            self.grid.cursor.point.column = Column(next_col);
-                            self.grid.cursor.input_needs_wrap = false;
-                        } else {
-                            self.grid.cursor.point.column = Column(spacer_col);
-                            self.grid.cursor.input_needs_wrap = true;
-                        }
-                    } else {
-                        self.grid.cursor.input_needs_wrap = true;
-                    }
-                }
+            if c == EMOJI_PRESENTATION_SELECTOR {
+                self.promote_emoji_presentation(line, column);
             }
 
             return;
@@ -2316,7 +2337,11 @@ enum ModeState {
 
 impl From<bool> for ModeState {
     fn from(value: bool) -> Self {
-        if value { Self::Set } else { Self::Reset }
+        if value {
+            Self::Set
+        } else {
+            Self::Reset
+        }
     }
 }
 
@@ -2786,6 +2811,44 @@ mod tests {
         term.input('a');
 
         assert_eq!(term.grid()[cursor].c, '▒');
+    }
+
+    #[test]
+    fn input_emoji_presentation_selector_widens_cell() {
+        let size = TermSize::new(5, 1);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        term.input('❤');
+        term.input(EMOJI_PRESENTATION_SELECTOR);
+        term.input('x');
+
+        let line = Line(0);
+        let cell = &term.grid()[line][Column(0)];
+        assert_eq!(cell.c, '❤');
+        assert!(cell.flags.contains(Flags::WIDE_CHAR));
+        assert_eq!(cell.zerowidth(), Some(&[EMOJI_PRESENTATION_SELECTOR][..]));
+
+        assert!(term.grid()[line][Column(1)].flags.contains(Flags::WIDE_CHAR_SPACER));
+        assert_eq!(term.grid()[line][Column(2)].c, 'x');
+    }
+
+    #[test]
+    fn input_text_presentation_selector_keeps_cell_narrow() {
+        let size = TermSize::new(5, 1);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        term.input('a');
+        term.input(EMOJI_PRESENTATION_SELECTOR);
+        term.input('x');
+
+        let line = Line(0);
+        let cell = &term.grid()[line][Column(0)];
+        assert_eq!(cell.c, 'a');
+        assert!(!cell.flags.contains(Flags::WIDE_CHAR));
+        assert_eq!(cell.zerowidth(), Some(&[EMOJI_PRESENTATION_SELECTOR][..]));
+
+        assert!(!term.grid()[line][Column(1)].flags.contains(Flags::WIDE_CHAR_SPACER));
+        assert_eq!(term.grid()[line][Column(1)].c, 'x');
     }
 
     #[test]

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -11,7 +11,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as Base64;
 use bitflags::bitflags;
 use log::{debug, trace};
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::event::{Event, EventListener};
 use crate::grid::{Dimensions, Grid, GridIterator, Scroll};
@@ -1081,6 +1081,37 @@ impl<T: EventListener> Handler for Term<T> {
             }
 
             self.grid[line][column].push_zerowidth(c);
+
+            if c == '\u{FE0F}' && !self.grid[line][column].flags.contains(Flags::WIDE_CHAR) {
+                let base = self.grid[line][column].c;
+                let mut buf = [0u8; 8];
+                let s = {
+                    let len = base.encode_utf8(&mut buf).len();
+                    let vlen = '\u{FE0F}'.encode_utf8(&mut buf[len..]).len();
+                    core::str::from_utf8(&buf[..len + vlen]).unwrap()
+                };
+                if UnicodeWidthStr::width(s) == 2 {
+                    let columns = self.columns();
+                    self.grid[line][column].flags.insert(Flags::WIDE_CHAR);
+                    let spacer_col = column.0 + 1;
+                    if spacer_col < columns {
+                        let cell = &mut self.grid[line][Column(spacer_col)];
+                        cell.c = ' ';
+                        cell.flags.insert(Flags::WIDE_CHAR_SPACER);
+                        let next_col = spacer_col + 1;
+                        if next_col < columns {
+                            self.grid.cursor.point.column = Column(next_col);
+                            self.grid.cursor.input_needs_wrap = false;
+                        } else {
+                            self.grid.cursor.point.column = Column(spacer_col);
+                            self.grid.cursor.input_needs_wrap = true;
+                        }
+                    } else {
+                        self.grid.cursor.input_needs_wrap = true;
+                    }
+                }
+            }
+
             return;
         }
 


### PR DESCRIPTION
VS16 (U+FE0F) is received as a zero-width combining character, after the base glyph has already been written using the base character's width.

When the base character plus VS16 forms an emoji presentation sequence (`UnicodeWidthStr::width == 2`), promote the existing cell to `WIDE_CHAR`, reserve the following spacer through the normal wide-cell write path, and advance the cursor past it so subsequent input does not clear the widened cell.

This also propagates emoji-presentation sequence metadata to rendering and prefers the platform emoji font fallback for these cells when available, falling back to the normal glyph lookup otherwise.

Regression tests cover both emoji presentation widening and non-emoji VS16 sequences staying narrow.