### PR TITLE
IME commit shouldn't use bracketed paste

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -2018,8 +2018,14 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     WindowEvent::Ime(ime) => match ime {
                         Ime::Commit(text) => {
                             *self.ctx.dirty = true;
-                            // Don't use bracketed paste for single char input.
-                            self.ctx.paste(&text, text.chars().count() > 1);
+                            // IME commits are user typing (e.g. a Chinese
+                            // input method committing `你好`, or a Japanese
+                            // input method committing `ありがとう` as one
+                            // chunk), not a clipboard paste — never wrap
+                            // them in a bracketed-paste sequence, which
+                            // would make the shell treat the text as a
+                            // clipboard paste.
+                            self.ctx.paste(&text, false);
                             self.ctx.update_cursor_blinking();
                         },
                         Ime::Preedit(text, cursor_offset) => {


### PR DESCRIPTION
`Ime::Commit` event for multi-char text wraps the committed string in `\x1b[200~ ... \x1b[201~`. This is semantically wrong - IME commit is user typing, not a clipboard paste - and triggers paste-mode handling in any shell or program that hooks bracketed paste.

Most environments accept this invisibly. However, plugin chains that hook paste handling
(observed: zsh + `bracketed-paste-magic` + `zsh-autosuggestions`) render the IME-committed text with visible paste-mode artifacts.

### Reproduction

Environment: zsh + oh-my-zsh + zsh-autosuggestions, with any IME that commits multi-char text in a single `insertText:` call.

1. Activate an input method that commits multi-character text in one chunk — e.g. the macOS-bundled "Pinyin - Simplified" for Chinese, or "Hiragana" / "Romaji" for Japanese.
2. Compose and confirm a multi-char string:
- Chinese: type `nihao` then space → commits `你好`.
- Japanese: type `arigatou` then space (or Enter) → commits `ありがとう`.
- Korean: needs a little more config to reproduce.
3. Observe the paste-mode visual artifact - the committed text appears highlighted until the next keypress.

### Videos

#### current behavior (broken)
The committed IME text appears wrapped in a paste-mode visual block (caused by the bracketed-paste markers triggering the zsh plugin chain).

<details>
<summary>expand to watch the video</summary>

  <img width="400" alt="asis" src="https://github.com/user-attachments/assets/bb42a8f6-77fb-4a75-b6de-abe3932e1932" />

</details>

#### Fixed behavior
(with this patch applied)
The committed IME text is inserted as ordinary typed input.

<details>
<summary>expand to watch the video</summary>

  <img width="400" alt="tobe" src="https://github.com/user-attachments/assets/75dbfb93-6a9b-4c2d-9f43-3d6c69f50cef" />

</details>