### PR TITLE
deps(home): replace deprecated `home` dep with std function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,6 @@ dependencies = [
  "embed-resource",
  "gl_generator",
  "glutin",
- "home",
  "libc",
  "log",
  "notify",
@@ -99,7 +98,6 @@ version = "0.26.1-dev"
 dependencies = [
  "base64",
  "bitflags 2.9.4",
- "home",
  "libc",
  "log",
  "miow",
@@ -858,15 +856,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "indexmap"

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -29,7 +29,6 @@ clap = { version = "4.2.7", features = ["derive", "env"] }
 copypasta = { version = "0.10.1", default-features = false }
 crossfont = "0.8.1"
 glutin = { version = "0.32.2", default-features = false, features = ["egl", "wgl"] }
-home = "0.5.5"
 libc = "0.2"
 log = { version = "0.4", features = ["std", "serde"] }
 notify = "8.0.0"

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -319,7 +319,7 @@ pub fn normalize_import(base_config_path: &Path, import_path: impl Into<PathBuf>
     let mut import_path = import_path.into();
 
     // Resolve paths relative to user's home directory.
-    if let (Ok(stripped), Some(home_dir)) = (import_path.strip_prefix("~/"), home::home_dir()) {
+    if let (Ok(stripped), Some(home_dir)) = (import_path.strip_prefix("~/"), env::home_dir()) {
         import_path = home_dir.join(stripped);
     }
 

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -176,7 +176,7 @@ fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
 
     // Switch to home directory.
     #[cfg(target_os = "macos")]
-    env::set_current_dir(home::home_dir().unwrap()).unwrap();
+    env::set_current_dir(env::home_dir().unwrap()).unwrap();
 
     // Set macOS locale.
     #[cfg(target_os = "macos")]

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -17,7 +17,6 @@ serde = ["dep:serde", "bitflags/serde", "vte/serde"]
 [dependencies]
 base64 = "0.22.0"
 bitflags = "2.4.1"
-home = "0.5.5"
 libc = "0.2"
 log = "0.4"
 parking_lot = "0.12.0"

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -127,7 +127,7 @@ fn terminfo_exists(terminfo: &str) -> bool {
 
     if let Some(dir) = env::var_os("TERMINFO") {
         check_path!(PathBuf::from(&dir));
-    } else if let Some(home) = home::home_dir() {
+    } else if let Some(home) = env::home_dir() {
         check_path!(home.join(".terminfo"));
     }
 


### PR DESCRIPTION
According to the crates.io README, the `home` crate is deprecated and the standard library function should be used instead:

> **Note:** This has been fixed in Rust 1.85 to no longer use the `HOME` environment variable on Windows. If you are still using this crate for the purpose of getting a home directory, you are strongly encouraged to switch to using the standard library's [`home_dir`](https://doc.rust-lang.org/nightly/std/env/fn.home_dir.html) instead. It is planned to have the deprecation notice removed in 1.87.

No breaking change: MSRV is already at 1.85.