### PR TITLE
Fix keyboard bindings missing from get-config IPC reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Fixed
 
 - Spurious "Failed to set new owner of XCB selection" warnings on X11
+- Keyboard bindings missing from `alacritty msg get-config` output
 
 ## 0.17.0
 

--- a/alacritty/src/config/bindings.rs
+++ b/alacritty/src/config/bindings.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug, Display};
 
 use bitflags::bitflags;
 use serde::de::{self, Error as SerdeError, MapAccess, Unexpected, Visitor};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::rc::Rc;
 use toml::Value as SerdeValue;
 use winit::event::MouseButton;
@@ -23,7 +23,7 @@ use crate::config::ui_config::{Hint, Program, StringVisitor};
 /// Describes a state and action to take in that state.
 ///
 /// This is the shared component of `MouseBinding` and `KeyBinding`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Binding<T> {
     /// Modifier keys required to activate binding.
     pub mods: ModifiersState,
@@ -85,7 +85,7 @@ impl<T: Eq> Binding<T> {
     }
 }
 
-#[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum Action {
     /// Write an escape sequence.
     #[config(skip)]
@@ -294,7 +294,7 @@ impl Display for Action {
 }
 
 /// Vi mode specific actions.
-#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum ViAction {
     /// Toggle normal vi selection.
     ToggleNormalSelection,
@@ -336,7 +336,7 @@ pub enum ViAction {
 
 /// Search mode specific actions.
 #[allow(clippy::enum_variant_names)]
-#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum SearchAction {
     /// Move the focus to the next search match.
     SearchFocusNext,
@@ -357,14 +357,14 @@ pub enum SearchAction {
 }
 
 /// Mouse binding specific actions.
-#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum MouseAction {
     /// Expand the selection to the current mouse cursor position.
     ExpandSelection,
 }
 
 /// Mouse binding specific events.
-#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize)]
 pub enum MouseEvent {
     Button(MouseButton),
     WheelUp,
@@ -626,14 +626,14 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
     vec![]
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum BindingKey {
     Scancode(PhysicalKey),
     Keycode { key: Key, location: KeyLocation },
 }
 
 /// Key location for matching bindings.
-#[derive(Debug, Clone, Copy, Eq)]
+#[derive(Debug, Clone, Copy, Eq, Serialize)]
 pub enum KeyLocation {
     /// The key is in its standard position.
     Standard,
@@ -786,6 +786,12 @@ impl BindingMode {
             mode.contains(TermMode::REPORT_ALL_KEYS_AS_ESC),
         );
         binding_mode
+    }
+}
+
+impl Serialize for BindingMode {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u8(self.bits())
     }
 }
 

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -412,6 +412,16 @@ mod tests {
         toml::from_str::<UiConfig>("").unwrap();
     }
 
+    #[test]
+    fn get_config_includes_keyboard_bindings() {
+        let config = UiConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let bindings =
+            value["keyboard"]["bindings"].as_array().expect("keyboard.bindings must be an array");
+        assert!(!bindings.is_empty(), "keyboard.bindings must not be empty");
+    }
+
     fn yaml_to_toml(contents: &str) -> String {
         let mut value: serde_yaml::Value = serde_yaml::from_str(contents).unwrap();
         prune_yaml_nulls(&mut value, false);

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -173,7 +173,6 @@ impl UiConfig {
 #[derive(ConfigDeserialize, Serialize, Default, Clone, Debug, PartialEq)]
 struct Keyboard {
     /// Keybindings.
-    #[serde(skip_serializing)]
     bindings: KeyBindings,
 }
 
@@ -192,6 +191,12 @@ impl<'de> Deserialize<'de> for KeyBindings {
         D: Deserializer<'de>,
     {
         Ok(Self(deserialize_bindings(deserializer, Self::default().0)?))
+    }
+}
+
+impl Serialize for KeyBindings {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
     }
 }
 


### PR DESCRIPTION
Fixes #8889

## Problem

`keyboard.bindings` was absent from `alacritty msg get-config` output.
The `bindings` field in `Keyboard` had `#[serde(skip_serializing)]` and
`KeyBindings` did not implement `Serialize`, so the field was always
serialized as an empty object `{}`.

## Solution

Add `Serialize` impls for all binding-related types:

- `Binding<T>`, `Action`, `ViAction`, `SearchAction`, `MouseAction`,
  `MouseEvent`, `BindingKey`, `KeyLocation` - via `#[derive(Serialize)]`
- `BindingMode` - manual impl serializing as `u8` bits (bitflags crate
  does not enable the serde feature here)
- `KeyBindings` - manual impl delegating to the inner `Vec`

Then remove `#[serde(skip_serializing)]` from `Keyboard.bindings`.