### PR TITLE
Add a config to toggle requesting attention

### DIFF
--- a/alacritty/src/config/bell.rs
+++ b/alacritty/src/config/bell.rs
@@ -18,6 +18,9 @@ pub struct BellConfig {
     /// Visual bell flash color.
     pub color: Rgb,
 
+    /// If enabled, a bell will cause an unfocused window to request attention.
+    pub request_attention: bool,
+
     /// Visual bell duration in milliseconds.
     duration: u16,
 }
@@ -28,6 +31,7 @@ impl Default for BellConfig {
             color: Rgb::new(255, 255, 255),
             animation: Default::default(),
             command: Default::default(),
+            request_attention: true,
             duration: Default::default(),
         }
     }

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1879,7 +1879,10 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                     TerminalEvent::Bell => {
                         // Set window urgency hint when window is not focused.
                         let focused = self.ctx.terminal.is_focused;
-                        if !focused && self.ctx.terminal.mode().contains(TermMode::URGENCY_HINTS) {
+                        if !focused
+                            && self.ctx.config.bell.request_attention
+                            && self.ctx.terminal.mode().contains(TermMode::URGENCY_HINTS)
+                        {
                             self.ctx.window().set_urgent(true);
                         }
 


### PR DESCRIPTION
# Feature

Adds a new boolean config: `bell.request_attention`. If disabled, Alacritty will not request attention from the user. This defaults to `true`, as that matches the existing behavior.

# Motivation

I usually have a handful of Alacritty windows open on my laptop, mostly in the background, and I tend to be in spotty wifi. When one of those windows disconnects from SSH, I really don't want to be notified about it. I also just prefer to have the bell disabled in general, and so it'd be nice if the app didn't start bouncing in the dock while I'm doing something else.
