### PR TITLE
Track OSC 133 Prompts and Clear on Resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -639,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1661,7 +1661,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2119,8 +2119,7 @@ dependencies = [
 [[package]]
 name = "vte"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+source = "git+https://github.com/nixpulvis/vte.git?branch=osc-133#c100d1c31d986e08eb76a09910a84058e063ff5d"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.4",
@@ -2387,7 +2386,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ toml_edit = "0.24.0"
 # TODO: Validation of fix for #6978. Remove before next release and use released `x11-clipboard`.
 [patch.crates-io]
 x11-clipboard = { git = "https://github.com/quininer/x11-clipboard.git", rev = "19ab2163cf0bd0db607e827a5214571990307866" }
+vte = { git = "https://github.com/nixpulvis/vte.git", branch = "osc-133" }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -133,6 +133,23 @@ pub fn viewport_to_point(display_offset: usize, point: Point<usize>) -> Point {
     Point::new(line, point.column)
 }
 
+/// Shift a tracked point so it follows its grid content across a scroll.
+fn rotate_prompt_mark(mark: &mut Option<Point>, region: &Range<Line>, delta: i32) {
+    let Some(point) = mark.as_mut() else { return };
+
+    if !((point.line >= region.start || region.start == 0) && point.line < region.end) {
+        return;
+    }
+
+    let new_line = point.line - delta;
+    if new_line >= region.end || (new_line < region.start && region.start != 0) {
+        *mark = None;
+        return;
+    }
+
+    point.line = new_line;
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LineDamageBounds {
     /// Damaged line number.
@@ -325,6 +342,9 @@ pub struct Term<T> {
     /// Information about damaged cells.
     damage: TermDamageState,
 
+    /// Position recorded by "prompt start" on the primary screen.
+    prompt_mark: Option<Point>,
+
     /// Config directly for the terminal.
     config: Config,
 }
@@ -441,6 +461,7 @@ impl<T> Term<T> {
             selection: Default::default(),
             title: Default::default(),
             mode: Default::default(),
+            prompt_mark: None,
         }
     }
 
@@ -651,6 +672,47 @@ impl<T> Term<T> {
         &mut self.grid
     }
 
+    /// Record the cursor position as the start of the active prompt.
+    pub fn mark_prompt_start(&mut self) {
+        if self.mode.contains(TermMode::ALT_SCREEN) {
+            return;
+        }
+        self.prompt_mark = Some(self.grid.cursor.point);
+    }
+
+    /// Forget the active prompt mark.
+    pub fn clear_prompt_mark(&mut self) {
+        self.prompt_mark = None;
+    }
+
+    /// Erase from the active prompt mark to the end of the viewport.
+    ///
+    /// Called before grid resize so prompt chrome (e.g. fish's right prompt) is
+    /// discarded. The shell should redraw the prompt after SIGWINCH on a clean
+    /// grid.
+    fn clear_active_prompt(&mut self) {
+        let Some(mark) = self.prompt_mark.take() else { return };
+        let screen_lines = self.screen_lines() as i32;
+        if mark.line.0 < 0 || mark.line.0 >= screen_lines {
+            return;
+        }
+
+        let bg = self.grid.cursor.template.bg;
+        let columns = Column(self.columns());
+        let start_col = cmp::min(mark.column, columns);
+        for cell in &mut self.grid[mark.line][start_col..columns] {
+            *cell = bg.into();
+        }
+        if mark.line.0 + 1 < screen_lines {
+            self.grid.reset_region((mark.line + 1)..);
+        }
+
+        self.damage.damage_line(mark.line.0 as usize, mark.column.0, columns.0 - 1);
+        for line in (mark.line.0 + 1)..screen_lines {
+            self.damage.damage_line(line as usize, 0, columns.0.saturating_sub(1));
+        }
+    }
+
     /// Resize terminal to new dimensions.
     pub fn resize<S: Dimensions>(&mut self, size: S) {
         let old_cols = self.columns();
@@ -665,6 +727,9 @@ impl<T> Term<T> {
         }
 
         debug!("New num_cols is {num_cols} and num_lines is {num_lines}");
+
+        // Clear the active prompt before resizing so the shell redraw lands on an empty area.
+        self.clear_active_prompt();
 
         // Move vi mode cursor with the content.
         let history_size = self.history_size();
@@ -731,6 +796,7 @@ impl<T> Term<T> {
         mem::swap(&mut self.grid, &mut self.inactive_grid);
         self.mode ^= TermMode::ALT_SCREEN;
         self.selection = None;
+        self.prompt_mark = None;
         self.mark_fully_damaged();
     }
 
@@ -750,6 +816,9 @@ impl<T> Term<T> {
         // Scroll selection.
         self.selection =
             self.selection.take().and_then(|s| s.rotate(self, &region, -(lines as i32)));
+
+        // Scroll prompt mark along with its content.
+        rotate_prompt_mark(&mut self.prompt_mark, &region, -(lines as i32));
 
         // Scroll vi mode cursor.
         let line = &mut self.vi_mode_cursor.point.line;
@@ -776,6 +845,9 @@ impl<T> Term<T> {
 
         // Scroll selection.
         self.selection = self.selection.take().and_then(|s| s.rotate(self, &region, lines as i32));
+
+        // Scroll prompt mark along with its content.
+        rotate_prompt_mark(&mut self.prompt_mark, &region, lines as i32);
 
         self.grid.scroll_up(&region, lines);
 
@@ -1845,6 +1917,7 @@ impl<T: EventListener> Handler for Term<T> {
         self.title_stack = Vec::new();
         self.title = None;
         self.selection = None;
+        self.prompt_mark = None;
         self.vi_mode_cursor = Default::default();
         self.keyboard_mode_stack = Default::default();
         self.inactive_keyboard_mode_stack = Default::default();
@@ -1874,6 +1947,18 @@ impl<T: EventListener> Handler for Term<T> {
     fn set_hyperlink(&mut self, hyperlink: Option<Hyperlink>) {
         trace!("Setting hyperlink: {hyperlink:?}");
         self.grid.cursor.template.set_hyperlink(hyperlink.map(|e| e.into()));
+    }
+
+    /// Record the prompt position so a later resize can clear it.
+    #[inline]
+    fn prompt_start(&mut self) {
+        self.mark_prompt_start();
+    }
+
+    /// Command output begins, the prompt is no longer active.
+    #[inline]
+    fn command_start(&mut self) {
+        self.clear_prompt_mark();
     }
 
     /// Set a terminal attribute.
@@ -2911,6 +2996,98 @@ mod tests {
 
         assert_eq!(term.history_size(), 0);
         assert_eq!(term.grid.cursor.point, Point::new(Line(19), Column(0)));
+    }
+
+    #[test]
+    fn prompt_mark_clears_to_end_of_viewport_on_resize() {
+        // Simulates fish's right-prompt layout. A prompt sits on its own line
+        // with content placed to the far right via cursor positioning, plus
+        // stale content below it. After OSC 133 ;A and a resize, the region
+        // from the prompt mark to the end of the viewport must be erased so the
+        // shell's SIGWINCH redraw lands on a clean grid.
+        let mut size = TermSize::new(8, 3);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Left prompt at col 0, right prompt at col 7.
+        term.grid[Line(0)][Column(0)].c = '$';
+        term.grid[Line(0)][Column(7)].c = 'R';
+        // Some leftover content on the line below.
+        term.grid[Line(1)][Column(0)].c = 'x';
+        term.grid[Line(1)][Column(1)].c = 'y';
+
+        // Cursor sits at the prompt input position, record the mark there.
+        term.grid.cursor.point = Point::new(Line(0), Column(2));
+        term.mark_prompt_start();
+        assert_eq!(term.prompt_mark, Some(Point::new(Line(0), Column(2))));
+
+        // Shrink columns, then resize triggers prompt-area clearing.
+        size.columns = 4;
+        term.resize(size);
+
+        // Prompt mark consumed.
+        assert_eq!(term.prompt_mark, None);
+
+        // The left prompt (left of the mark) survives.
+        assert_eq!(term.grid[Line(0)][Column(0)].c, '$');
+        // Cells from the mark column to end-of-row are cleared (the right prompt is gone).
+        for col in 2..4 {
+            assert_eq!(term.grid[Line(0)][Column(col)].c, ' ');
+        }
+        // All rows below the mark are cleared.
+        for col in 0..4 {
+            assert_eq!(term.grid[Line(1)][Column(col)].c, ' ');
+            assert_eq!(term.grid[Line(2)][Column(col)].c, ' ');
+        }
+    }
+
+    #[test]
+    fn prompt_mark_dropped_on_alt_screen_swap() {
+        let size = TermSize::new(8, 3);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+        term.grid.cursor.point = Point::new(Line(0), Column(0));
+        term.mark_prompt_start();
+        assert!(term.prompt_mark.is_some());
+
+        term.set_private_mode(NamedPrivateMode::SwapScreenAndSetRestoreCursor.into());
+        assert_eq!(term.prompt_mark, None);
+    }
+
+    #[test]
+    fn mark_prompt_start_ignored_on_alt_screen() {
+        let size = TermSize::new(8, 3);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+        term.set_private_mode(NamedPrivateMode::SwapScreenAndSetRestoreCursor.into());
+        term.mark_prompt_start();
+        assert_eq!(term.prompt_mark, None);
+    }
+
+    #[test]
+    fn prompt_mark_follows_content_through_scroll() {
+        let size = TermSize::new(4, 4);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        term.grid.cursor.point = Point::new(Line(2), Column(0));
+        term.mark_prompt_start();
+        assert_eq!(term.prompt_mark, Some(Point::new(Line(2), Column(0))));
+
+        // Linefeed at the bottom row scrolls the grid; the mark rotates with the content.
+        term.grid.cursor.point = Point::new(Line(3), Column(0));
+        term.linefeed();
+        assert_eq!(term.prompt_mark, Some(Point::new(Line(1), Column(0))));
+    }
+
+    #[test]
+    fn osc_133_sequences_drive_prompt_mark() {
+        let size = TermSize::new(8, 3);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+        let mut parser: ansi::Processor = ansi::Processor::new();
+
+        term.grid.cursor.point = Point::new(Line(0), Column(2));
+        parser.advance(&mut term, b"\x1b]133;A\x07");
+        assert_eq!(term.prompt_mark, Some(Point::new(Line(0), Column(2))));
+
+        parser.advance(&mut term, b"\x1b]133;C\x07");
+        assert_eq!(term.prompt_mark, None);
     }
 
     #[test]


### PR DESCRIPTION
Wire `OSC 133 ;A` and `;C` through to `Term`. `;A` records the prompt's cursor position as an active mark, `;C` clears it. Before resizing the grid, erase from the active mark to the end of the viewport and damage the affected lines. This is not active in the alt-grid.

## Why

In shells like Fish, we can now enable `fish_handle_reflow` and avoid this:
<img width="702" height="145" alt="Screenshot 2026-05-29 at 6 54 52 PM" src="https://github.com/user-attachments/assets/c9b39be2-428d-4930-b3a9-fab0070337bd" />
Fish disabled reflow for alacritty, which causes right prompts to wrap incorrectly on resize.

## Details

Shells (notably fish) draw right-prompts with absolute cursor positioning, producing a sparse line of `[left prompt][gap][right prompt]`. `shrink_columns` reflows that detached tail onto a stray continuation row on horizontal shrink. The grid has no structural way to distinguish that gap from typed interior whitespace (`shrink_reflow_empty_cell_inside_line` deliberately reflows the latter), so any pure-grid fix would change that contract.

Erasing the grid after a OSC 133 mark instead and letting the shell repaint sidesteps the ambiguity and follows from what kitty (`screen.c`'s `prevent_current_prompt_from_rewrapping` plus its blank-and-repaint on resize) and ghostty (`Terminal.resize` checking `cursor.semantic_content != .output`) already do to some degree. I looked a bit at various implementations of this and there are major differences across the board, but clearing after the prompt and relying on shells to redrawn on `SIGWINCH` is a theme. Some terminals wrap the shell to help facilitate the OSC 133 integration, which I don't think is a good idea for Alacritty.

This approach says, if you emit OSC 133, you agree to redraw your prompt completely. Simple as that.

Technically, kitty's approach of using the OSC 133 regions to save the prompt and reflow around it without clearing it in a visible draw frame avoids some flickering, but I'm personally not bothered by the flicker whie redrawing, and it's a lot more complexity to do things that way. The goal here is just to allow the end state to be consistent after a resize.

## Shell Cooperation

Fish sets `fish_handle_reflow=0` when `$TERM` matches `alacritty*`, predating this work. It can be overridden with `set --global fish_handle_reflow 1` until fish drops the alacritty exclusion upstream. With `fish_handle_reflow 1` on `SIGWINCH` the prompt will be redrawn completely and now correctly.

Users of bash or zsh don't get OSC 133 built in, but can be enabled by writing the escape sequence themselves.

It should be noted that bash only redraws the last line, so users who implement OSC 133 for themselves in bash **and** have multi-line prompts, will see their top line of the prompt cleared on resize, but not redrawn. I believe this is a valid tradeoff though, since most bash users are A) unlikely to be implementing OSC 133 I'd imagine, and B) also unlikely to be using multi-line prompts. I don't believe there's any other way for bash to show a regression.

Depends on https://github.com/alacritty/vte/pull/152 for the new `Handler` methods. If/when that's released, this PR can be updated to use the released version, however the best way to do that is.