### PR TITLE
Add context menus for folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Packaging
 
 - Fixed `alacritty-escapes(7)` manpage missing from macOS install
+- Added the `Open Alacritty here` entry to the right-click context menu for folders on Windows
 
 ### Fixed
 

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -11,6 +11,7 @@
          <ComponentRef Id="AlacrittyShortcut" />
          <ComponentRef Id="ModifyPathEnv" />
          <ComponentRef Id="ContextMenu" />
+         <ComponentRef Id="ContextMenuFolder" />
       </Feature>
       <!-- Application binaries -->
       <DirectoryRef Id="AlacrittyProgramFiles">
@@ -44,6 +45,14 @@
             <RegistryValue Type="string" Value='[AlacrittyProgramFiles]alacritty.exe --working-directory "%v"' KeyPath="yes" />
          </RegistryKey>
          <RegistryKey Root="HKCU" Key="Software\Classes\Directory\Background\shell\Open Alacritty here">
+            <RegistryValue Type="string" Name="Icon" Value="[AlacrittyProgramFiles]alacritty.exe" />
+         </RegistryKey>
+      </Component>
+      <Component Id="ContextMenuFolder" Guid="69483b38-a267-433f-9395-60827963347a" Directory="TARGETDIR">
+         <RegistryKey Root="HKCU" Key="Software\Classes\Directory\shell\Open Alacritty here\command">
+            <RegistryValue Type="string" Value='[AlacrittyProgramFiles]alacritty.exe --working-directory "%v"' KeyPath="yes" />
+         </RegistryKey>
+         <RegistryKey Root="HKCU" Key="Software\Classes\Directory\shell\Open Alacritty here">
             <RegistryValue Type="string" Name="Icon" Value="[AlacrittyProgramFiles]alacritty.exe" />
          </RegistryKey>
       </Component>


### PR DESCRIPTION
- [x] No LLMs were used for the creation of this patch
I PROMISE

Previously, the Windows right-click context menu would only show `Open Alacritty here` when you right clicked somewhere on the background while browsing a folder. This change adds a registry key that also adds the `Open Alacritty here` context menu entry when you select and right click a folder.

Before:
<img width="508" height="400" alt="image" src="https://github.com/user-attachments/assets/87f58bc2-3333-4046-b74e-c931f1431c60" />

After: 
<img width="549" height="432" alt="image" src="https://github.com/user-attachments/assets/71d8290a-af07-4759-9b59-6e4e82aeaebe" />
