### PR TITLE
Add X-ExecArg for xdg-terminal-exec

### DIFF
--- a/extra/linux/Alacritty.desktop
+++ b/extra/linux/Alacritty.desktop
@@ -5,6 +5,7 @@ Exec=alacritty
 Icon=Alacritty
 Terminal=false
 Categories=System;TerminalEmulator;
+X-ExecArg=--command
 
 Name=Alacritty
 GenericName=Terminal


### PR DESCRIPTION
xdg-terminal-exec requires this param to consider using Alacritty.destop as a valid entry in xdg-terminals.list

This will allow nautilus to use Alacritty.desktop to host terminal apps.

- [x] No LLMs were used for the creation of this patch
