### PR TITLE
Allow rebinding default macOS menu key bindings

### DIFF
--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -135,7 +135,18 @@ impl Drop for TemporaryFiles {
 /// config change monitor, and runs the main display loop.
 fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
     // Setup winit event loop.
-    let window_event_loop = EventLoop::<Event>::with_user_event().build()?;
+    let mut event_loop = EventLoop::<Event>::with_user_event();
+
+    // Disable winit's default macOS menubar, since its menu items register key
+    // equivalents (like Cmd+Q) that are consumed by AppKit before they reach the
+    // window. Without it these keys arrive as regular input and can be rebound.
+    #[cfg(target_os = "macos")]
+    {
+        use winit::platform::macos::EventLoopBuilderExtMacOS;
+        event_loop.with_default_menu(false);
+    }
+
+    let window_event_loop = event_loop.build()?;
 
     // Initialize the logger as soon as possible as to capture output from other subsystems.
     let log_file = logging::initialize(&options, window_event_loop.create_proxy())


### PR DESCRIPTION
  ## Summary

  On macOS, `Cmd+Q`, `Cmd+H` and `Cmd+Option+H` cannot be rebound or
  disabled via `keyboard.bindings`, even though `Cmd+W` and every other
  binding can. This makes the binding system behave inconsistently on
  macOS and prevents users from, for example, disabling accidental
  `Cmd+Q` quits. Closes #8890.

  ## Root cause

  winit installs a default macOS menubar whose items register key
  equivalents: Quit (`Cmd+Q`), Hide (`Cmd+H`) and Hide Others
  (`Cmd+Option+H`). AppKit dispatches these through the menu before they
  reach the window, so they never arrive as keyboard input and cannot be
  matched against the user's configured bindings. `Cmd+W` has no menu
  item, which is why it alone is currently rebindable.

  ## Fix

  Disable winit's default menu with `with_default_menu(false)` so these
  keys are delivered as normal keyboard input. Alacritty already defines
  its own bindings for Quit, Hide and Hide Others, so default behavior is
  unchanged. The keys are now simply remappable like any other.

  ## Tradeoff

  `with_default_menu(false)` removes the entire menubar, including the
  About panel and Services menu, not only the three shortcuts. An
  alternative is to keep the menu and clear the key equivalents on just
  those items via objc2. Happy to switch approaches based on feedback.

  ## Testing

  - `cargo build` succeeds.
  - Launching with `{ key = "Q", mods = "Command", action = "None" }`
    starts cleanly. `Cmd+Q` no longer quits, and removing the binding
    restores the default quit behavior.