### PR TITLE
Handle PTY non-blocking failure gracefully

### DIFF
--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.26.1-dev
 
+### Fixed
+
+- Panic when the PTY could not be set to non-blocking
+
 ## 0.26.0
 
 ### Added

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -290,7 +290,7 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
             unsafe {
                 // Maybe this should be done outside of this function so nonblocking
                 // isn't forced upon consumers. Although maybe it should be?
-                set_nonblocking(master_fd);
+                set_nonblocking(master_fd)?;
             }
 
             Ok(Pty { child, file: File::from(master), signals, sig_id })
@@ -436,9 +436,9 @@ impl ToWinsize for WindowSize {
     }
 }
 
-unsafe fn set_nonblocking(fd: c_int) {
+unsafe fn set_nonblocking(fd: c_int) -> Result<()> {
     let res = unsafe { fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK) };
-    assert_eq!(res, 0);
+    if res == 0 { Ok(()) } else { Err(Error::last_os_error()) }
 }
 
 #[test]


### PR DESCRIPTION
We ran in to a application-wide panic from an `assert` in the terminal, this PR makes `set_nonblocking` fallible and propagates the error rather than using an assert.

- [X] No LLMs were used for the creation of this patch
