### PR TITLE
Address EditorConfig violations

### DIFF
--- a/.ecformat_ignore
+++ b/.ecformat_ignore
@@ -1,0 +1,5 @@
+# Binary files
+*.icns
+*.ico
+*.png
+*.rtf

--- a/.ecformat_ignore
+++ b/.ecformat_ignore
@@ -3,3 +3,9 @@
 *.ico
 *.png
 *.rtf
+
+# File types with a mixed formatting is intentional.
+# Disabling only check for some properties (like indent_size) is currently not supported.
+
+# Often mixed indentation for example due to alignment with previous line
+*.rs

--- a/alacritty/res/rect.f.glsl
+++ b/alacritty/res/rect.f.glsl
@@ -30,31 +30,31 @@ uniform float_t undercurlPosition;
 
 #if defined(DRAW_UNDERCURL)
 color_t draw_undercurl(float_t x, float_t y) {
-  // We use `undercurlPosition` as an amplitude, since it's half of the descent
-  // value.
-  //
-  // The `x` represents the left bound of pixel we should add `1/2` to it, so
-  // we compute the undercurl position for the center of the pixel.
-  float_t undercurl = undercurlPosition / 2. * cos((x + 0.5) * 2.
-                    * PI / cellWidth) + undercurlPosition - 1.;
+    // We use `undercurlPosition` as an amplitude, since it's half of the descent
+    // value.
+    //
+    // The `x` represents the left bound of pixel we should add `1/2` to it, so
+    // we compute the undercurl position for the center of the pixel.
+    float_t undercurl = undercurlPosition / 2. * cos((x + 0.5) * 2.
+                        * PI / cellWidth) + undercurlPosition - 1.;
 
-  float_t undercurlTop = undercurl + max((underlineThickness - 1.), 0.) / 2.;
-  float_t undercurlBottom = undercurl - max((underlineThickness - 1.), 0.) / 2.;
+    float_t undercurlTop = undercurl + max((underlineThickness - 1.), 0.) / 2.;
+    float_t undercurlBottom = undercurl - max((underlineThickness - 1.), 0.) / 2.;
 
-  // The distance to the curve boundary is always positive when it should
-  // be used for AA. When both `y - undercurlTop` and `undercurlBottom - y`
-  // expressions are negative, it means that the point is inside the curve
-  // and we should just use alpha 1. To do so, we max one value with 0
-  // so it'll use the alpha 1 in the end.
-  float_t dst = max(y - undercurlTop, max(undercurlBottom - y, 0.));
+    // The distance to the curve boundary is always positive when it should
+    // be used for AA. When both `y - undercurlTop` and `undercurlBottom - y`
+    // expressions are negative, it means that the point is inside the curve
+    // and we should just use alpha 1. To do so, we max one value with 0
+    // so it'll use the alpha 1 in the end.
+    float_t dst = max(y - undercurlTop, max(undercurlBottom - y, 0.));
 
-  // Doing proper SDF is complicated for this shader, so just make AA
-  // stronger by 1/x^2, which renders preserving underline thickness and
-  // being bold enough.
-  float_t alpha = 1. - dst * dst;
+    // Doing proper SDF is complicated for this shader, so just make AA
+    // stronger by 1/x^2, which renders preserving underline thickness and
+    // being bold enough.
+    float_t alpha = 1. - dst * dst;
 
-  // The result is an alpha mask on a rect, which leaves only curve opaque.
-  return vec4(color.rgb, alpha);
+    // The result is an alpha mask on a rect, which leaves only curve opaque.
+    return vec4(color.rgb, alpha);
 }
 #endif
 
@@ -62,77 +62,77 @@ color_t draw_undercurl(float_t x, float_t y) {
 // When the dot size increases we can use AA to make spacing look even and the
 // dots rounded.
 color_t draw_dotted_aliased(float_t x, float_t y) {
-  float_t dotNumber = floor(x / underlineThickness);
+    float_t dotNumber = floor(x / underlineThickness);
 
-  float_t radius = underlineThickness / 2.;
-  float_t centerY = underlinePosition - 1.;
+    float_t radius = underlineThickness / 2.;
+    float_t centerY = underlinePosition - 1.;
 
-  float_t leftCenter = (dotNumber - mod(dotNumber, 2.)) * underlineThickness + radius;
-  float_t rightCenter = leftCenter + 2. * underlineThickness;
+    float_t leftCenter = (dotNumber - mod(dotNumber, 2.)) * underlineThickness + radius;
+    float_t rightCenter = leftCenter + 2. * underlineThickness;
 
-  float_t distanceLeft = sqrt(pow(x - leftCenter, 2.) + pow(y - centerY, 2.));
-  float_t distanceRight = sqrt(pow(x - rightCenter, 2.) + pow(y - centerY, 2.));
+    float_t distanceLeft = sqrt(pow(x - leftCenter, 2.) + pow(y - centerY, 2.));
+    float_t distanceRight = sqrt(pow(x - rightCenter, 2.) + pow(y - centerY, 2.));
 
-  float_t alpha = max(1. - (min(distanceLeft, distanceRight) - radius), 0.);
-  return vec4(color.rgb, alpha);
+    float_t alpha = max(1. - (min(distanceLeft, distanceRight) - radius), 0.);
+    return vec4(color.rgb, alpha);
 }
 
 /// Draw dotted line when dot is just a single pixel.
 color_t draw_dotted(float_t x, float_t y) {
-  float_t cellEven = 0.;
+    float_t cellEven = 0.;
 
-  // Since the size of the dot and its gap combined is 2px we should ensure that
-  // spacing will be even. If the cellWidth is even it'll work since we start
-  // with dot and end with gap. However if cellWidth is odd, the cell will start
-  // and end with a dot, creating a dash. To resolve this issue, we invert the
-  // pattern every two cells.
-  if (int(mod(cellWidth, 2.)) != 0) {
-    cellEven = mod((gl_FragCoord.x - paddingX) / cellWidth, 2.);
-  }
+    // Since the size of the dot and its gap combined is 2px we should ensure that
+    // spacing will be even. If the cellWidth is even it'll work since we start
+    // with dot and end with gap. However if cellWidth is odd, the cell will start
+    // and end with a dot, creating a dash. To resolve this issue, we invert the
+    // pattern every two cells.
+    if (int(mod(cellWidth, 2.)) != 0) {
+        cellEven = mod((gl_FragCoord.x - paddingX) / cellWidth, 2.);
+    }
 
-  // Since we use the entire descent area for dotted underlines, we limit its
-  // height to a single pixel so we don't draw bars instead of dots.
-  float_t alpha = 1. - abs(floor(underlinePosition) - y);
-  if (int(mod(x, 2.)) != int(cellEven)) {
-    alpha = 0.;
-  }
+    // Since we use the entire descent area for dotted underlines, we limit its
+    // height to a single pixel so we don't draw bars instead of dots.
+    float_t alpha = 1. - abs(floor(underlinePosition) - y);
+    if (int(mod(x, 2.)) != int(cellEven)) {
+        alpha = 0.;
+    }
 
-  return vec4(color.rgb, alpha);
+    return vec4(color.rgb, alpha);
 }
 #endif
 
 #if defined(DRAW_DASHED)
 color_t draw_dashed(float_t x) {
-  // Since dashes of adjacent cells connect with each other our dash length is
-  // half of the desired total length.
-  float_t halfDashLen = floor(cellWidth / 4. + 0.5);
+    // Since dashes of adjacent cells connect with each other our dash length is
+    // half of the desired total length.
+    float_t halfDashLen = floor(cellWidth / 4. + 0.5);
 
-  float_t alpha = 1.;
+    float_t alpha = 1.;
 
-  // Check if `x` coordinate is where we should draw gap.
-  if (x > halfDashLen - 1. && x < cellWidth - halfDashLen) {
-    alpha = 0.;
-  }
+    // Check if `x` coordinate is where we should draw gap.
+    if (x > halfDashLen - 1. && x < cellWidth - halfDashLen) {
+        alpha = 0.;
+    }
 
-  return vec4(color.rgb, alpha);
+    return vec4(color.rgb, alpha);
 }
 #endif
 
 void main() {
-  float_t x = floor(mod(gl_FragCoord.x - paddingX, cellWidth));
-  float_t y = floor(mod(gl_FragCoord.y - paddingY, cellHeight));
+    float_t x = floor(mod(gl_FragCoord.x - paddingX, cellWidth));
+    float_t y = floor(mod(gl_FragCoord.y - paddingY, cellHeight));
 
 #if defined(DRAW_UNDERCURL)
-  FRAG_COLOR = draw_undercurl(x, y);
+    FRAG_COLOR = draw_undercurl(x, y);
 #elif defined(DRAW_DOTTED)
-  if (underlineThickness < 2.) {
-    FRAG_COLOR = draw_dotted(x, y);
-  } else {
-    FRAG_COLOR = draw_dotted_aliased(x, y);
-  }
+    if (underlineThickness < 2.) {
+        FRAG_COLOR = draw_dotted(x, y);
+    } else {
+        FRAG_COLOR = draw_dotted_aliased(x, y);
+    }
 #elif defined(DRAW_DASHED)
-  FRAG_COLOR = draw_dashed(x);
+    FRAG_COLOR = draw_dashed(x);
 #else
-  FRAG_COLOR = color;
+    FRAG_COLOR = color;
 #endif
 }

--- a/alacritty_terminal/tests/ref/.editorconfig
+++ b/alacritty_terminal/tests/ref/.editorconfig
@@ -1,0 +1,9 @@
+# The automated generated .json and .recording files here have no final newline.
+[*]
+insert_final_newline = false
+
+# The automated .recording files have different line endings.
+# Some have CRLF and some LF. Furthermore, trimming could lead to removal of CR.
+[*.recording]
+end_of_line = unset
+trim_trailing_whitespace = false


### PR DESCRIPTION
This Pull Request is part of an academic research project. More preciously it is for my master's thesis, more background information [here](https://codeberg.org/BaumiCoder/Masterthesis).

- [x] No LLMs were used for the creation of this patch

## Definition: EditorConfig violations

The goal of this Pull Request is to address all [EditorConfig](https://editorconfig.org) violations in the project. With EditorConfig you have set for example `insert_final_newline = true` for most files, but there are files without final newlines. I call this an EditorConfig violation as a file content violates the respective EditorConfig property. They can have different kind of impacts. For example trailing spaces, which get remove with the next save, may make the next diff / Pull Request to this file less readable. However, wrong line endings for example may even cause bugs when processing a file.

## How to address them?

To check for such violations and fix them I developed the CLI tool [ecformat](https://codeberg.org/BaumiCoder/ecformat). However, there are different ways to address the violations:

1. **Adjust EditorConfig:** The EditorConfig properties for a file can be wrong. For example most of the JSON files for the ref tests have no final newline, as you create them automatically (If I understand correctly) this is the expected format.
   Therefore, it is wrong to add them. The correct way to address that is to set `insert_final_newline = false` for them, which avoids automatic insertion on save.
2. **Fix file content:** Another way is to fix the content of the file. Which means for example for `trim_trailing_whitespace = true` to remove trailing spaces. To do so `ecformat fix` can be helpful.
3. **Ignore files:** For some files it is not meaningful to consider the EditorConfig violations, which `ecformat check` finds. I added a `.ecformat_ignore` file for this. It has the common ignore syntax such as a `.gitignore`. To use such ignore files, provide the name of them with an CLI switch, `ecformat check --ignore-file .ecformat_ignore`. (The `.gitignore` files are automatically considered inside a git repository.) There are different reasons to ignore files:
   1. As EditorConfig is only for text files, considering binary files does not make sense.
   2. EditorConfig supports to set the property on the file level. However, there can be files with intentional differences inside. Such files need to be ignored fully by `ecformat` as it currently (version 0.2.0) has no support to ignore only a single property for some files.

## Changes in this Pull Request

For this Pull Request, I addressed all violations in the project in the way, which looks the most correct one to me. (I focused on the Properties of the current [EditorConfig specification](https://spec.editorconfig.org/#supported-pairs) 0.17.2.) If I fixed file contents, I manually reviewed all of them, making adjustments in the `ecformat fix` changes were necessary.

If I picked the wrong way to address the violations for some files, please let me know with a respective Review comment.
Then I will address it in the correct way. I add Review comments myself for special parts, which are especially worthy of discussion. To support the Review of this Pull Request, I tried to group the changes in meaningful commits with respective commit messages. Therefore, may take a look at the commit history.

## Avoid EditorConfig violations in the future

Such EditorConfig violations can creep in again. Possible reasons can be that the editor of some contributors has no EditorConfig support, or it would be required to install a respective plugin for the support.

If you want to avoid them in the future, I would suggest integrating a respective utility. For example as part of the CI. One possibility is to use `ecformat` with `ecformat check --ignore-file .ecformat_ignore`. Another one is [editorconfig-checker](https://editorconfig-checker.github.io), which is a more sophisticated tool without the possibility to fix violations. It provides more configuration options, such as ignoring violations in single lines with marker comments.

Let me know if you are interested using one of them. I could add one in this Pull Request or a follow-up Pull Request. If you not consider to use `ecformat` in your project, the `.ecformat_ignore` file is maybe not worth to merge into the master branch. I can remove it if desired.

