### PR TITLE
Add vertical scroll velocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Added the `Open Alacritty here` entry to the right-click context menu for folders on Windows
 - Minimum Rust version has been bumped to 1.88.0
 
+### Added
+
+- Inertial scrolling using `scrolling.velocity` config option
+
 ### Fixed
 
 - Spurious "Failed to set new owner of XCB selection" warnings on X11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Fixed `alacritty-escapes(7)` manpage missing from macOS install
 - Added the `Open Alacritty here` entry to the right-click context menu for folders on Windows
+- Minimum Rust version has been bumped to 1.88.0
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 
 [profile.release]
 lto = "thin"

--- a/alacritty/src/config/scrolling.rs
+++ b/alacritty/src/config/scrolling.rs
@@ -10,13 +10,14 @@ pub const MAX_SCROLLBACK_LINES: u32 = 100_000;
 #[derive(ConfigDeserialize, Serialize, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Scrolling {
     pub multiplier: u8,
+    pub velocity: Velocity,
 
     history: ScrollingHistory,
 }
 
 impl Default for Scrolling {
     fn default() -> Self {
-        Self { multiplier: 3, history: Default::default() }
+        Self { multiplier: 3, velocity: Default::default(), history: Default::default() }
     }
 }
 
@@ -48,6 +49,27 @@ impl<'de> Deserialize<'de> for ScrollingHistory {
             )))
         } else {
             Ok(Self(lines))
+        }
+    }
+}
+
+#[derive(ConfigDeserialize, Serialize, Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Velocity {
+    /// Enable velocity only for touch scrolling.
+    #[default]
+    Auto,
+    /// Enable velocity for all input sources.
+    On,
+    /// Disable velocity for all input sources.
+    Off,
+}
+
+impl Velocity {
+    pub fn unwrap_or(&self, default: bool) -> bool {
+        match self {
+            Self::Auto => default,
+            Self::On => true,
+            Self::Off => false,
         }
     }
 }

--- a/alacritty/src/daemon.rs
+++ b/alacritty/src/daemon.rs
@@ -126,7 +126,7 @@ pub fn foreground_process_path(
     #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
     let link_path = format!("/proc/{pid}/cwd");
     #[cfg(target_os = "freebsd")]
-    let link_path = format!("/compat/linux/proc/{}/cwd", pid);
+    let link_path = format!("/compat/linux/proc/{pid}/cwd");
 
     #[cfg(not(target_os = "macos"))]
     let cwd = fs::read_link(link_path)?;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1869,7 +1869,7 @@ pub struct Velocity {
     last_sample: Option<Instant>,
     samples: [f64; VELOCITY_SAMPLES],
     sample_count: usize,
-    direction: f64,
+    direction: Option<f64>,
 
     active_velocity: Option<(Instant, f64)>,
 }
@@ -1879,9 +1879,9 @@ impl Velocity {
     pub fn update(&mut self, mut y_delta: f64) {
         // Cancel velocity when direction changes.
         let direction = y_delta.signum();
-        if self.direction != direction {
+        if direction != 0. && self.direction.is_some_and(|d| d != direction) {
             self.cancel();
-            self.direction = direction;
+            self.direction = Some(direction);
         }
 
         // Get elapsed time since last velocity update.

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -80,6 +80,15 @@ const TOUCH_ZOOM_FACTOR: f32 = 0.01;
 /// Cooldown between invocations of the bell command.
 const BELL_CMD_COOLDOWN: Duration = Duration::from_millis(100);
 
+/// Number of samples used for velocity calculation.
+///
+/// Since the latest sample is always ignored (see [`Velocity::velocity`]),
+/// this should be 1 more than the desired number of samples.
+const VELOCITY_SAMPLES: usize = 4;
+
+/// Rate of decceleration for velocity calculation.
+const VELOCITY_DAMPING: f64 = 5.;
+
 /// The event processor.
 ///
 /// Stores some state from received events and dispatches actions when they are
@@ -545,6 +554,7 @@ pub enum EventType {
     ConfigReload(PathBuf),
     Message(Message),
     Scroll(Scroll),
+    Velocity(f64),
     CreateWindow(WindowOptions),
     #[cfg(unix)]
     IpcConfig(IpcConfig),
@@ -685,6 +695,7 @@ pub struct ActionContext<'a, N, T> {
     pub master_fd: RawFd,
     #[cfg(not(windows))]
     pub shell_pid: u32,
+    pub velocity: &'a mut Velocity,
 }
 
 impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionContext<'a, N, T> {
@@ -733,6 +744,11 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         // Scrolling inside Vi mode moves the cursor, so start typing.
         if vi_mode {
             self.on_typing_start();
+        }
+
+        // Cancel velocity when receiving scroll events triggered bindings.
+        if !matches!(scroll, Scroll::Delta(_)) {
+            self.cancel_velocity();
         }
 
         // Update dirty if actually scrolled or moved Vi cursor in Vi mode.
@@ -1477,6 +1493,17 @@ impl<'a, N: Notify + 'a, T: EventListener> input::ActionContext<T> for ActionCon
         self.inline_search_next();
     }
 
+    /// Update vertical velocity based on the delta to the last touch point.
+    fn update_velocity(&mut self, y_delta: f64) {
+        self.velocity.update(y_delta);
+        *self.dirty = true;
+    }
+
+    /// Cancel all vertical velocity.
+    fn cancel_velocity(&mut self) {
+        self.velocity.cancel();
+    }
+
     fn message(&self) -> Option<&Message> {
         self.message_buffer.message()
     }
@@ -1836,6 +1863,118 @@ pub struct AccumulatedScroll {
     pub y: f64,
 }
 
+/// Input velocity tracking.
+#[derive(Default)]
+pub struct Velocity {
+    last_sample: Option<Instant>,
+    samples: [f64; VELOCITY_SAMPLES],
+    sample_count: usize,
+    direction: f64,
+
+    active_velocity: Option<(Instant, f64)>,
+}
+
+impl Velocity {
+    /// Update the active touch velocity.
+    pub fn update(&mut self, mut y_delta: f64) {
+        // Cancel velocity when direction changes.
+        let direction = y_delta.signum();
+        if self.direction != direction {
+            self.cancel();
+            self.direction = direction;
+        }
+
+        // Get elapsed time since last velocity update.
+        let now = Instant::now();
+        let elapsed = match self.last_sample.take() {
+            Some(last_sample) => now - last_sample,
+            // Use first sample solely to initialize the reference timestamp.
+            None => {
+                self.last_sample = Some(now);
+                return;
+            },
+        };
+
+        // Normalize touch polling rate to 1 second.
+        //
+        // This ensures that devices with different touch polling rates still have a
+        // consistent velocity.
+        y_delta *= 1_000_000. / elapsed.as_micros() as f64;
+
+        // Update tracked velocity samples.
+        self.samples.rotate_right(1);
+        self.samples[0] = y_delta;
+        self.sample_count += 1;
+
+        self.last_sample = Some(now);
+        self.active_velocity = None;
+    }
+
+    /// Clear the active touch velocity.
+    pub fn cancel(&mut self) {
+        *self = Default::default();
+    }
+
+    /// Update the remaining velocity and get its pending changes.
+    pub fn apply(&mut self) -> Option<f64> {
+        // Short-circuit when there's no velocity active.
+        if !self.is_active() {
+            return None;
+        }
+
+        // Get or initialize the active velocity.
+        let (last_tick, y_velocity) = match &mut self.active_velocity {
+            Some(velocity) => velocity,
+            None => {
+                let last_tick = self.last_sample?;
+                let y = self.velocity()?;
+                self.active_velocity.insert((last_tick, y))
+            },
+        };
+
+        // Get the fractional number of 1 second intervals passed since the last tick.
+        let now = Instant::now();
+        let interval = (now - *last_tick).as_micros() as f64 / 1_000_000.;
+
+        // Update velocity and calculate the expected delta.
+        let damping_exp = f64::exp(-VELOCITY_DAMPING * interval);
+        let delta = *y_velocity * (1. - damping_exp) / VELOCITY_DAMPING;
+        *y_velocity *= damping_exp;
+
+        // Stop velocity once delta is insignificant.
+        //
+        // This assumes the tick rate is somewhat constant, extrapolating that all future
+        // ticks would be insignificant if the current tick is. A tick interval length of 0
+        // would always stop the velocity.
+        if delta.abs() > 1. {
+            *last_tick = now;
+        } else {
+            self.cancel();
+        }
+
+        Some(delta)
+    }
+
+    /// Check whether a velocity is pending.
+    pub fn is_active(&self) -> bool {
+        self.sample_count != 0
+    }
+
+    /// Get the average recorded velocity.
+    ///
+    /// We ignore the latest sample, since it corresponds to the touch release event and
+    /// is always zero (at least on Wayland).
+    fn velocity(&self) -> Option<f64> {
+        if self.sample_count < 2 {
+            return None;
+        }
+
+        let count = self.sample_count.min(VELOCITY_SAMPLES);
+        let sum: f64 = self.samples[1..count].iter().sum();
+        Some(sum / (count - 1) as f64)
+    }
+}
+
 impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
     /// Handle events from winit.
     pub fn handle_event(&mut self, event: WinitEvent<Event>) {
@@ -1843,6 +1982,7 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
             WinitEvent::UserEvent(Event { payload, .. }) => match payload {
                 EventType::SearchNext => self.ctx.goto_match(None),
                 EventType::Scroll(scroll) => self.ctx.scroll(scroll),
+                EventType::Velocity(velocity) => self.apply_velocity(velocity),
                 EventType::BlinkCursor => {
                     // Only change state when timeout isn't reached, since we could get
                     // BlinkCursor and BlinkCursorTimeout events at the same time.

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -138,6 +138,8 @@ pub trait ActionContext<T: EventListener> {
     fn semantic_word(&self, point: Point) -> String;
     fn on_terminal_input_start(&mut self) {}
     fn paste(&mut self, _text: &str, _bracketed: bool) {}
+    fn update_velocity(&mut self, _y_delta: f64) {}
+    fn cancel_velocity(&mut self) {}
     fn spawn_daemon<I, S>(&self, _program: &str, _args: I)
     where
         I: IntoIterator<Item = S> + Debug + Copy,
@@ -615,6 +617,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     }
 
     fn on_mouse_press(&mut self, button: MouseButton) {
+        // Cancel velocity when a mouse button is pressed.
+        self.ctx.cancel_velocity();
+
         // Handle mouse mode.
         if !self.ctx.modifiers().state().shift_key() && self.ctx.mouse_mode() {
             self.ctx.mouse_mut().click_state = ClickState::None;
@@ -723,7 +728,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
     }
 
     pub fn mouse_wheel_input(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
+        let velocity = self.ctx.config().scrolling.velocity.unwrap_or(false);
         let multiplier = self.ctx.config().scrolling.multiplier;
+
         match delta {
             MouseScrollDelta::LineDelta(columns, lines) => {
                 let new_scroll_px_x = columns * self.ctx.size_info().cell_width();
@@ -732,6 +739,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                     new_scroll_px_x as f64,
                     new_scroll_px_y as f64,
                     multiplier as f64,
+                    velocity,
                 );
             },
             MouseScrollDelta::PixelDelta(mut lpos) => {
@@ -749,7 +757,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                             lpos.x = 0.;
                         }
 
-                        self.scroll_terminal(lpos.x, lpos.y, multiplier as f64);
+                        self.scroll_terminal(lpos.x, lpos.y, multiplier as f64, velocity);
                     },
                     _ => (),
                 }
@@ -757,11 +765,23 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
         }
     }
 
-    fn scroll_terminal(&mut self, new_scroll_x_px: f64, new_scroll_y_px: f64, multiplier: f64) {
+    /// Handle horizontal and vertical scroll events.
+    fn scroll_terminal(
+        &mut self,
+        new_scroll_x_px: f64,
+        new_scroll_y_px: f64,
+        multiplier: f64,
+        velocity: bool,
+    ) {
         const MOUSE_WHEEL_UP: u8 = 64;
         const MOUSE_WHEEL_DOWN: u8 = 65;
         const MOUSE_WHEEL_LEFT: u8 = 66;
         const MOUSE_WHEEL_RIGHT: u8 = 67;
+
+        // Add scroll delta to velocity samples.
+        if velocity {
+            self.ctx.update_velocity(new_scroll_y_px * multiplier);
+        }
 
         let width = f64::from(self.ctx.size_info().cell_width());
         let height = f64::from(self.ctx.size_info().cell_height());
@@ -852,6 +872,9 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             self.ctx.window().set_ime_inhibitor(ImeInhibitor::TOUCH, true);
         }
 
+        // Cancel velocity when a new touch slot appears.
+        self.ctx.cancel_velocity();
+
         let touch_purpose = self.ctx.touch_purpose();
         *touch_purpose = match mem::take(touch_purpose) {
             TouchPurpose::None => TouchPurpose::Tap(touch),
@@ -916,7 +939,8 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 *touch_purpose = TouchPurpose::Scroll(touch);
 
                 // Use a fixed scroll factor for touchscreens, to accurately track finger motion.
-                self.scroll_terminal(0., delta_y, 1.0);
+                let velocity = self.ctx.config().scrolling.velocity.unwrap_or(true);
+                self.scroll_terminal(0., delta_y, 1.0, velocity);
             },
             TouchPurpose::Select(_) => self.mouse_moved(touch.location),
             TouchPurpose::ZoomPendingSlot(_) | TouchPurpose::Invalid(_) => (),
@@ -964,6 +988,11 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
             TouchPurpose::Scroll(_) => *touch_purpose = Default::default(),
             TouchPurpose::None => (),
         }
+    }
+
+    /// Apply scroll velocity delta.
+    pub fn apply_velocity(&mut self, y_delta: f64) {
+        self.scroll_terminal(0., y_delta, 1.0, false);
     }
 
     /// Reset mouse cursor based on modifier and terminal state.

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -107,7 +107,7 @@ impl Logger {
         #[cfg(not(windows))]
         let env_var = format!("${ALACRITTY_LOG_ENV}");
         #[cfg(windows)]
-        let env_var = format!("%{}%", ALACRITTY_LOG_ENV);
+        let env_var = format!("%{ALACRITTY_LOG_ENV}%");
 
         let message = format!(
             "[{}] {}\nSee log at {} ({})",

--- a/alacritty/src/macos/locale.rs
+++ b/alacritty/src/macos/locale.rs
@@ -18,7 +18,7 @@ pub fn set_locale_environment() {
 
         // Assume `C` locale means unchanged, since it is the default anyways.
         if env_locale != "C" {
-            debug!("Using environment locale: {}", env_locale);
+            debug!("Using environment locale: {env_locale}");
             return;
         }
     }
@@ -32,7 +32,7 @@ pub fn set_locale_environment() {
     // Check if system locale was valid or not.
     if lc_all.is_null() {
         // Use fallback locale.
-        debug!("Using fallback locale: {}", FALLBACK_LOCALE);
+        debug!("Using fallback locale: {FALLBACK_LOCALE}");
 
         let fallback_locale_c = CString::new(FALLBACK_LOCALE).unwrap();
         unsafe { setlocale(LC_CTYPE, fallback_locale_c.as_ptr()) };
@@ -40,7 +40,7 @@ pub fn set_locale_environment() {
         unsafe { env::set_var("LC_CTYPE", FALLBACK_LOCALE) };
     } else {
         // Use system locale.
-        debug!("Using system locale: {}", system_locale);
+        debug!("Using system locale: {system_locale}");
 
         unsafe { env::set_var("LC_ALL", system_locale) };
     }
@@ -63,7 +63,7 @@ fn system_locale() -> String {
         let language_code = locale.languageCode();
         #[allow(deprecated)]
         if let Some(country_code) = locale.countryCode() {
-            format!("{}_{}.UTF-8", language_code, country_code)
+            format!("{language_code}_{country_code}.UTF-8")
         } else {
             // Fall back to en_US in case the country code is not available.
             "en_US.UTF-8".into()

--- a/alacritty/src/macos/proc.rs
+++ b/alacritty/src/macos/proc.rs
@@ -31,9 +31,9 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Error::InvalidSize => write!(f, "Invalid proc_pidinfo return size"),
-            Error::Io(err) => write!(f, "Error getting current working directory: {}", err),
+            Error::Io(err) => write!(f, "Error getting current working directory: {err}"),
             Error::IntoString(err) => {
-                write!(f, "Error when parsing current working directory: {}", err)
+                write!(f, "Error when parsing current working directory: {err}")
             },
         }
     }

--- a/alacritty/src/panic.rs
+++ b/alacritty/src/panic.rs
@@ -11,8 +11,8 @@ use alacritty_terminal::tty::windows::win32_string;
 // dialog box as well as writes the panic to STDERR.
 pub fn attach_handler() {
     panic::set_hook(Box::new(|panic_info| {
-        let _ = writeln!(io::stderr(), "{}", panic_info);
-        let msg = format!("{}\n\nPress Ctrl-C to Copy", panic_info);
+        let _ = writeln!(io::stderr(), "{panic_info}");
+        let msg = format!("{panic_info}\n\nPress Ctrl-C to Copy");
         unsafe {
             MessageBoxW(
                 ptr::null_mut(),

--- a/alacritty/src/window_context.rs
+++ b/alacritty/src/window_context.rs
@@ -36,7 +36,8 @@ use crate::config::UiConfig;
 use crate::display::Display;
 use crate::display::window::Window;
 use crate::event::{
-    ActionContext, Event, EventProxy, InlineSearchState, Mouse, SearchState, TouchPurpose,
+    ActionContext, Event, EventProxy, EventType, InlineSearchState, Mouse, SearchState,
+    TouchPurpose, Velocity,
 };
 #[cfg(unix)]
 use crate::logging::LOG_TARGET_IPC_CONFIG;
@@ -67,6 +68,7 @@ pub struct WindowContext {
     shell_pid: u32,
     window_config: ParsedOptions,
     config: Rc<UiConfig>,
+    velocity: Velocity,
 }
 
 impl WindowContext {
@@ -251,6 +253,7 @@ impl WindowContext {
             event_queue: Default::default(),
             modifiers: Default::default(),
             occluded: Default::default(),
+            velocity: Default::default(),
             mouse: Default::default(),
             touch: Default::default(),
             dirty: Default::default(),
@@ -375,8 +378,8 @@ impl WindowContext {
         // Force the display to process any pending display update.
         self.display.process_renderer_update();
 
-        // Request immediate re-draw if visual bell animation is not finished yet.
-        if !self.display.visual_bell.completed() {
+        // Request immediate re-draw if visual bell animation or velocity are not finished yet.
+        if !self.display.visual_bell.completed() || self.velocity.is_active() {
             // We can get an OS redraw which bypasses alacritty's frame throttling, thus
             // marking the window as dirty when we don't have frame yet.
             if self.display.window.has_frame {
@@ -410,7 +413,7 @@ impl WindowContext {
             WinitEvent::AboutToWait
             | WinitEvent::WindowEvent { event: WindowEvent::RedrawRequested, .. } => {
                 // Skip further event handling with no staged updates.
-                if self.event_queue.is_empty() {
+                if self.event_queue.is_empty() && !self.velocity.is_active() {
                     return;
                 }
 
@@ -422,6 +425,7 @@ impl WindowContext {
             },
         }
 
+        let window_id = self.id();
         let mut terminal = self.terminal.lock();
 
         let old_is_searching = self.search_state.history_index.is_some();
@@ -446,6 +450,7 @@ impl WindowContext {
             shell_pid: self.shell_pid,
             preserve_title: self.preserve_title,
             config: &self.config,
+            velocity: &mut self.velocity,
             event_proxy,
             #[cfg(target_os = "macos")]
             event_loop,
@@ -453,6 +458,22 @@ impl WindowContext {
             scheduler,
         };
         let mut processor = input::Processor::new(context);
+
+        // Schedule velocity update event before redraw.
+        //
+        // We do this here since a timer based event would lead to a velocity interval
+        // that doesn't match the display's refresh rate, but we still have access to the
+        // event processor context.
+        let is_redraw =
+            matches!(event, WinitEvent::WindowEvent { event: WindowEvent::RedrawRequested, .. });
+        if is_redraw
+            && !*processor.ctx.occluded
+            && matches!(processor.ctx.touch, TouchPurpose::None)
+            && let Some(velocity) = processor.ctx.velocity.apply()
+        {
+            let event = Event::new(EventType::Velocity(velocity), window_id);
+            self.event_queue.push(event.into());
+        }
 
         for event in self.event_queue.drain(..) {
             processor.handle_event(event);
@@ -482,13 +503,9 @@ impl WindowContext {
             self.mouse.hint_highlight_dirty = false;
         }
 
-        // Don't call `request_redraw` when event is `RedrawRequested` since the `dirty` flag
-        // represents the current frame, but redraw is for the next frame.
-        if self.dirty
-            && self.display.window.has_frame
-            && !self.occluded
-            && !matches!(event, WinitEvent::WindowEvent { event: WindowEvent::RedrawRequested, .. })
-        {
+        // If it's time for a new frame (`has_frame`) and we're `dirty` and visible (`!occluded`),
+        // but not about to redraw (`!is_redraw`), then request a redraw.
+        if self.dirty && self.display.window.has_frame && !self.occluded && !is_redraw {
             self.display.window.request_redraw();
         }
     }

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -172,7 +172,7 @@ fn default_shell_command(shell: &str, user: &str, home: &str) -> Command {
 
     // Exec the shell with argv[0] prepended by '-' so it becomes a login shell.
     // `login` normally does this itself, but `-l` disables this.
-    let exec = format!("exec -a -{} {}", shell_name, shell);
+    let exec = format!("exec -a -{shell_name} {shell}");
 
     // Since we use -l, `login` will not change directory to the user's home. However,
     // `login` only checks the current working directory for a .hushlogin file, causing

--- a/alacritty_terminal/src/tty/windows/blocking.rs
+++ b/alacritty_terminal/src/tty/windows/blocking.rs
@@ -78,13 +78,13 @@ impl<R: Read + Send + 'static> UnblockedReader<R> {
                         continue;
                     },
 
-                    Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+                    Poll::Ready(Err(err)) if err.kind() == io::ErrorKind::Interrupted => {
                         // We were interrupted; continue.
                         continue;
                     },
 
-                    Poll::Ready(Err(e)) => {
-                        log::error!("error writing to pipe: {}", e);
+                    Poll::Ready(Err(err)) => {
+                        log::error!("error writing to pipe: {err}");
                         return;
                     },
 
@@ -176,13 +176,13 @@ impl<W: Write + Send + 'static> UnblockedWriter<W> {
                         continue;
                     },
 
-                    Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::Interrupted => {
+                    Poll::Ready(Err(err)) if err.kind() == io::ErrorKind::Interrupted => {
                         // We were interrupted; continue.
                         continue;
                     },
 
-                    Poll::Ready(Err(e)) => {
-                        log::error!("error writing to pipe: {}", e);
+                    Poll::Ready(Err(err)) => {
+                        log::error!("error writing to pipe: {err}");
                         return;
                     },
 

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -215,7 +215,7 @@ mod test {
         for (input, expected) in test_set {
             let mut escaped_arg = String::new();
             push_escaped_arg(&mut escaped_arg, input);
-            assert_eq!(escaped_arg, expected, "Failed for input: {}", input);
+            assert_eq!(escaped_arg, expected, "Failed for input: {input}");
         }
     }
 

--- a/extra/man/alacritty.5.scd
+++ b/extra/man/alacritty.5.scd
@@ -232,6 +232,17 @@ Limited to _100000_.
 
 	Default: _3_
 
+*velocity* = _"Auto"_ | _"On"_ | _"Off"_
+
+	*Auto*
+		Enable velocity only for touch scrolling
+	*On*
+		Enable velocity for all input sources
+	*Off*
+		Disable velocity for all input sources
+
+	Default: _"Auto"_
+
 # FONT
 
 This section documents the *[font]* table of the configuration file.


### PR DESCRIPTION
This patch adds support for momentum-based vertical scrolling, keeping the inertia of the active scroll sequence until a new input event is received.

Whether scroll velocity is enabled is based on the `scrolling.velocity` option. By default (`"Auto"`), it will only be enabled for touch input, but can be enabled for mouse and touchpad scroll events too.

Closes: #4175
