### PR TITLE
Fix off-by-one in ParagraphUp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Spurious "Failed to set new owner of XCB selection" warnings on X11
 - Lacking permissions to launch software sending Apple events
+- Off-by-one in vi mode ParagraphUp action
 
 ## 0.17.0
 

--- a/alacritty_terminal/CHANGELOG.md
+++ b/alacritty_terminal/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Panic when the PTY could not be set to non-blocking
+- Off-by-one in ViMotion::ParagraphUp
 
 ## 0.26.0
 

--- a/alacritty_terminal/src/vi_mode.rs
+++ b/alacritty_terminal/src/vi_mode.rs
@@ -161,7 +161,7 @@ impl ViModeCursor {
                 // Skip empty lines until we find the next paragraph,
                 // then skip over the paragraph until we reach the next empty line.
                 let topmost_line = term.topmost_line();
-                self.point.line = (*topmost_line..*self.point.line)
+                self.point.line = (*topmost_line..=*self.point.line)
                     .rev()
                     .skip_while(|line| term.grid()[Line(*line)].is_clear())
                     .find(|line| term.grid()[Line(*line)].is_clear())


### PR DESCRIPTION
- [x] No LLMs were used for the creation of this patch

There's an off-by-one in ParagraphUp (but not ParagraphDown). To repro:

1. go into vi mode, and put the cursor at the top of a paragraph, something like this:
```
  text
  more text

> text here
  more text
```

2. press `{`. What you're supposed to see is the cursor move up by one line -- but what you'll see instead is:
```
>
  text
  more text

  text here
  more text
```

This should fix it. Thanks!