### PR TITLE
Limit glyph cache size to prevent unbounded growth when rendering lar…

### DIFF
--- a/alacritty/src/renderer/text/atlas.rs
+++ b/alacritty/src/renderer/text/atlas.rs
@@ -9,7 +9,11 @@ use crate::gl::types::*;
 use super::Glyph;
 
 /// Size of the Atlas.
-pub const ATLAS_SIZE: i32 = 1024;
+///
+/// Increased from 1024 to 2048 to reduce atlas fragmentation and texture switches when
+/// rendering large glyphs like CJK ideographs. This stays well within the minimum guaranteed
+/// texture size of desktop OpenGL (2048) as well as the macOS limit (16384).
+pub const ATLAS_SIZE: i32 = 2048;
 
 /// Manages a single texture atlas.
 ///

--- a/alacritty/src/renderer/text/glyph_cache.rs
+++ b/alacritty/src/renderer/text/glyph_cache.rs
@@ -14,6 +14,13 @@ use crate::gl::types::*;
 
 use super::builtin_font;
 
+/// Maximum number of glyphs to keep in the glyph cache before it is reset.
+///
+/// The cache is reset (clearing both the glyph map and the texture atlas) once this limit is
+/// reached. This prevents unbounded growth of rasterized glyphs and avoids continuously rising
+/// rasterization costs when viewing large amounts of unique characters, like long CJK text.
+const MAX_GLYPH_CACHE_SIZE: usize = 16_384;
+
 /// `LoadGlyph` allows for copying a rasterized glyph into graphics memory.
 pub trait LoadGlyph {
     /// Load the rasterized glyph into GPU memory.
@@ -76,6 +83,12 @@ pub struct GlyphCache {
 
     /// Whether to use the built-in font for box drawing characters.
     builtin_box_drawing: bool,
+
+    /// Maximum number of glyphs to keep in the cache before resetting it.
+    glyph_cache_limit: usize,
+
+    /// Whether the glyph cache should be reset at the end of the current frame.
+    needs_reset: bool,
 }
 
 impl GlyphCache {
@@ -95,6 +108,8 @@ impl GlyphCache {
             glyph_offset: font.glyph_offset,
             metrics,
             builtin_box_drawing: font.builtin_box_drawing,
+            glyph_cache_limit: MAX_GLYPH_CACHE_SIZE,
+            needs_reset: false,
         })
     }
 
@@ -206,6 +221,14 @@ impl GlyphCache {
             return *glyph;
         };
 
+        // Mark the cache for reset once it has grown past the limit, to prevent unbounded
+        // growth when rendering large amounts of unique glyphs (e.g. CJK text). The actual
+        // reset is deferred to the end of the frame, since resetting the atlas mid-frame would
+        // invalidate glyphs which have already been queued for rendering.
+        if self.cache.len() >= self.glyph_cache_limit {
+            self.needs_reset = true;
+        }
+
         // Rasterize the glyph using the built-in font for special characters or the user's font
         // for everything else.
         let rasterized = self
@@ -272,8 +295,14 @@ impl GlyphCache {
     pub fn reset_glyph_cache<L: LoadGlyph>(&mut self, loader: &mut L) {
         loader.clear();
         self.cache = Default::default();
+        self.needs_reset = false;
 
         self.load_common_glyphs(loader);
+    }
+
+    /// Check whether the glyph cache should be reset at the end of the current frame.
+    pub fn should_reset(&self) -> bool {
+        self.needs_reset
     }
 
     /// Update the inner font size.
@@ -300,6 +329,7 @@ impl GlyphCache {
         self.bold_italic_key = bold_italic;
         self.metrics = metrics;
         self.builtin_box_drawing = font.builtin_box_drawing;
+        self.needs_reset = false;
 
         Ok(())
     }
@@ -314,5 +344,97 @@ impl GlyphCache {
         self.load_glyphs_for_font(self.bold_key, loader);
         self.load_glyphs_for_font(self.italic_key, loader);
         self.load_glyphs_for_font(self.bold_italic_key, loader);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock `LoadGlyph` which tracks clears and loads without touching GL.
+    #[derive(Default)]
+    struct MockLoader {
+        clears: usize,
+        loads: usize,
+    }
+
+    impl LoadGlyph for MockLoader {
+        fn load_glyph(&mut self, _rasterized: &RasterizedGlyph) -> Glyph {
+            self.loads += 1;
+            Glyph {
+                tex_id: 0,
+                multicolor: false,
+                top: 0,
+                left: 0,
+                width: 0,
+                height: 0,
+                uv_bot: 0.,
+                uv_left: 0.,
+                uv_width: 0.,
+                uv_height: 0.,
+            }
+        }
+
+        fn clear(&mut self) {
+            self.clears += 1;
+        }
+    }
+
+    fn dummy_glyph() -> Glyph {
+        MockLoader::default().load_glyph(&RasterizedGlyph::default())
+    }
+
+    #[test]
+    fn cache_marks_reset_when_limit_reached() {
+        let rasterizer = Rasterizer::new().expect("rasterizer");
+        let font = Font::default();
+        let mut cache = GlyphCache::new(rasterizer, &font).expect("glyph cache");
+
+        // Fill the cache past the limit with synthetic entries.
+        let mut key = GlyphKey {
+            font_key: cache.font_key,
+            size: cache.font_size,
+            character: '\u{1}',
+        };
+        for i in 0..MAX_GLYPH_CACHE_SIZE {
+            key.character = char::from_u32(0x100 + i as u32).unwrap();
+            cache.cache.insert(key, dummy_glyph());
+        }
+
+        assert!(!cache.should_reset());
+
+        // A cache miss past the limit should mark the cache for reset.
+        key.character = '界';
+        let _ = cache.get(key, &mut MockLoader::default(), true);
+        assert!(cache.should_reset());
+    }
+
+    #[test]
+    fn reset_clears_cache_and_reloads_common_glyphs() {
+        let rasterizer = Rasterizer::new().expect("rasterizer");
+        let font = Font::default();
+        let mut cache = GlyphCache::new(rasterizer, &font).expect("glyph cache");
+
+        // Simulate a grown cache with the reset flag set.
+        let mut key = GlyphKey {
+            font_key: cache.font_key,
+            size: cache.font_size,
+            character: '\u{1}',
+        };
+        for i in 0..MAX_GLYPH_CACHE_SIZE {
+            key.character = char::from_u32(0x100 + i as u32).unwrap();
+            cache.cache.insert(key, dummy_glyph());
+        }
+        cache.needs_reset = true;
+
+        let mut loader = MockLoader::default();
+        cache.reset_glyph_cache(&mut loader);
+
+        // Cache should be cleared and repopulated with common (ASCII) glyphs.
+        assert!(!cache.should_reset());
+        assert!(loader.clears >= 1);
+        assert!(cache.cache.len() >= 95);
+        // Common glyphs are loaded through the loader.
+        assert!(loader.loads >= 95);
     }
 }

--- a/alacritty/src/renderer/text/mod.rs
+++ b/alacritty/src/renderer/text/mod.rs
@@ -65,7 +65,15 @@ pub trait TextRenderer<'a> {
             for cell in cells {
                 api.draw_cell(cell, glyph_cache, size_info);
             }
-        })
+
+            // Reset the glyph cache once it has outgrown its limit. The batch is flushed
+            // explicitly before the reset, since clearing the atlas would otherwise invalidate
+            // glyphs which are still queued for rendering.
+            if glyph_cache.should_reset() {
+                api.render_batch();
+                glyph_cache.reset_glyph_cache(&mut api);
+            }
+        });
     }
 
     fn with_api<'b: 'a, F, T>(&'b mut self, size_info: &'b SizeInfo, func: F) -> T


### PR DESCRIPTION
> i am a long time alacritty user, but recently i encountered a problem where when huge amount of stream output with chinese characters, alacritty becomes very laggy, i confirmed this patch fixes the problem, maybe not perfect but it does the job. 

> this patch was created by Ai model, but tested and verified by me. 

> details from Ai:


### Problem

 The GlyphCache (and with it the texture atlas) grows without bounds. Every glyph that is not yet cached is rasterized on demand and inserted into the cache, but cached entries are never evicted. The cache is only reset when the font size changes or the OpenGL context is recreated.

 In long-running interactive sessions this causes a progressive performance regression: browsing large amounts of unique glyphs — most notably CJK text, where every character has to be resolved through the font fallback chain and rasterized individually (on macOS via CoreText, creating a fresh bitmap context per glyph) — continuously adds new entries. Combined with an atlas that fills up quickly with wide, tall CJK glyphs
 (causing frequent new 1024×1024 atlas allocations and texture switches between draw batches), this leads to sustained high CPU usage and visible input/scroll stutter that gets worse the longer the session runs.

 Reproduction: render a large block of CJK text (e.g. through tmux + a TUI application) in a long-running Alacritty session and scroll through it repeatedly. CPU usage rises continuously; scrolling and input become sluggish. The same content in a freshly started session is smooth.

### Solution

 1. Bound the glyph cache size (glyph_cache.rs): a new MAX_GLYPH_CACHE_SIZE = 16_384 limit is enforced in GlyphCache::get. Once the cache reaches the limit, a needs_reset flag is set instead of resetting immediately. This is important because the cache can be queried mid-frame while glyphs are already queued in the render batch; clearing the atlas at that point would invalidate their texture coordinates.

 2. Reset at a safe point (text/mod.rs): TextRenderer::draw_cells checks the flag after all cells of the frame have been queued, explicitly flushes the batch, and then resets the glyph cache (clearing both the glyph map and the atlas, then re-caching the common ASCII glyphs). Since get() re-rasterizes on demand, the reset is self-healing and cannot cause incorrect rendering.

 3. Larger atlas (atlas.rs): ATLAS_SIZE is increased from 1024 to 2048, reducing atlas fragmentation and texture switches for large glyphs like CJK ideographs. This stays well within the minimum guaranteed desktop OpenGL texture size of 2048 and the macOS limit of 16384.

 The combination prevents unbounded growth of rasterized glyphs and flattens the sustained rasterization cost, at the price of a cheap periodic cache rebuild (~380 ASCII glyphs re-cached, other glyphs lazily re-rasterized on the next frame).

 ### Tests

 - Added unit tests with a mock LoadGlyph (no GL required):
     - cache_marks_reset_when_limit_reached — verifies the reset flag is set on a cache miss past the limit.
     - reset_clears_cache_and_reloads_common_glyphs — verifies the reset clears the cache and repopulates the common ASCII glyphs.
 - cargo test -p alacritty --bin alacritty: 82 passed
 - cargo test -p alacritty_terminal --lib: 132 passed
 - cargo build --release: passes

 ### Impact

 Verified by the reporter on macOS (aarch64): scrolling through a large CJK block in tmux + a TUI application is smooth with this patch, while the unpatched build stutters with rising CPU usage. The fix is platform-independent and also benefits any workload with a large unique-glyph footprint (e.g. heavy Unicode/emoji content), not just CJK.