### PR TITLE
Improve temp file cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Unbounded per-cell memory usage for zero-width cells
 - IPC socket and log file left behind when quitting Alacritty on macOS
 - IPC socket and log file not being removed on `SIGHUP`
+- Stale IPC socket files persisting after Alacritty was killed
 
 ## 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Off-by-one in vi mode ParagraphUp action
 - Unbounded per-cell memory usage for zero-width cells
 - IPC socket and log file left behind when quitting Alacritty on macOS
+- IPC socket and log file not being removed on `SIGHUP`
 
 ## 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 - Lacking permissions to launch software sending Apple events
 - Off-by-one in vi mode ParagraphUp action
 - Unbounded per-cell memory usage for zero-width cells
+- IPC socket and log file left behind when quitting Alacritty on macOS
 
 ## 0.17.0
 

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -44,6 +44,7 @@ use alacritty_terminal::term::search::{Match, RegexSearch};
 use alacritty_terminal::term::{self, ClipboardType, Term, TermMode};
 use alacritty_terminal::vte::ansi::NamedColor;
 
+use crate::TemporaryFiles;
 #[cfg(unix)]
 use crate::cli::{IpcConfig, ParsedOptions};
 use crate::cli::{Options as CliOptions, WindowOptions};
@@ -98,6 +99,7 @@ pub struct Processor {
     global_ipc_options: ParsedOptions,
     cli_options: CliOptions,
     config: Rc<UiConfig>,
+    temporary_files: TemporaryFiles,
 }
 
 impl Processor {
@@ -105,6 +107,7 @@ impl Processor {
     pub fn new(
         config: UiConfig,
         cli_options: CliOptions,
+        temporary_files: TemporaryFiles,
         event_loop: &EventLoop<Event>,
     ) -> Processor {
         let proxy = event_loop.create_proxy();
@@ -141,6 +144,7 @@ impl Processor {
             #[cfg(unix)]
             global_ipc_options: Default::default(),
             config_monitor,
+            temporary_files,
         }
     }
 
@@ -513,6 +517,8 @@ impl ApplicationHandler<Event> for Processor {
         // SAFETY: The clipboard must be dropped before the event loop, so use the nop clipboard
         // as a safe placeholder.
         self.clipboard = Clipboard::new_nop();
+
+        self.temporary_files.cleanup();
     }
 }
 

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -199,6 +199,10 @@ fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
     #[cfg(target_os = "macos")]
     macos::disable_autofill();
 
+    // Remove sockets of old instances which did not clean up after themselves.
+    #[cfg(unix)]
+    ipc::remove_dead_sockets();
+
     // Spawn the Unix I/O event polling thread.
     #[cfg(unix)]
     let socket_path = match IoListener::spawn(&config, &options, window_event_loop.create_proxy()) {

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -12,6 +12,7 @@
 #[cfg(not(any(feature = "x11", feature = "wayland", target_os = "macos", windows)))]
 compile_error!(r#"at least one of the "x11"/"wayland" features must be enabled"#);
 
+use std::cell::Cell;
 use std::error::Error;
 use std::fmt::Write as _;
 use std::io::{self, Write};
@@ -105,15 +106,22 @@ fn msg(mut options: MessageOptions) -> Result<(), Box<dyn Error>> {
 
 /// Temporary files stored for Alacritty.
 ///
-/// This stores temporary files to automate their destruction through its `Drop` implementation.
-struct TemporaryFiles {
+/// The files are deleted in `Processor::exiting`, which is reached on every exit path that shuts
+/// down the event loop and with `Drop` as a fallback.
+pub struct TemporaryFiles {
     #[cfg(unix)]
     socket_path: Option<PathBuf>,
     log_file: Option<PathBuf>,
+    /// Whether the log file removal was already reported.
+    log_reported: Cell<bool>,
 }
 
-impl Drop for TemporaryFiles {
-    fn drop(&mut self) {
+impl TemporaryFiles {
+    /// Delete all temporary files.
+    ///
+    /// Since the files are gone afterwards, repeating this only removes files which were
+    /// recreated in the meantime, like a log file written to while shutting down.
+    pub fn cleanup(&self) {
         // Clean up the IPC socket file.
         #[cfg(unix)]
         if let Some(socket_path) = self.socket_path.as_deref() {
@@ -122,10 +130,16 @@ impl Drop for TemporaryFiles {
 
         // Clean up logfile.
         if let Some(log_file) = &self.log_file {
-            if fs::remove_file(log_file).is_ok() {
+            if fs::remove_file(log_file).is_ok() && !self.log_reported.replace(true) {
                 let _ = writeln!(io::stdout(), "Deleted log file at \"{}\"", log_file.display());
             }
         }
+    }
+}
+
+impl Drop for TemporaryFiles {
+    fn drop(&mut self) {
+        self.cleanup();
     }
 }
 
@@ -196,16 +210,17 @@ fn alacritty(mut options: Options) -> Result<(), Box<dyn Error>> {
         },
     };
 
-    // Setup automatic RAII cleanup for our files.
+    // Setup cleanup for our temporary files.
     let log_cleanup = log_file.filter(|_| !config.debug.persistent_logging);
-    let _files = TemporaryFiles {
+    let temporary_files = TemporaryFiles {
         #[cfg(unix)]
         socket_path,
         log_file: log_cleanup,
+        log_reported: Cell::new(false),
     };
 
     // Event processor.
-    let mut processor = Processor::new(config, options, &window_event_loop);
+    let mut processor = Processor::new(config, options, temporary_files, &window_event_loop);
 
     // Start event loop and block until shutdown.
     let result = processor.run(window_event_loop);

--- a/alacritty/src/polling/ipc.rs
+++ b/alacritty/src/polling/ipc.rs
@@ -186,33 +186,53 @@ fn find_socket(socket_path: Option<PathBuf>) -> IoResult<UnixStream> {
     }
 
     // Search for sockets files.
-    for entry in fs::read_dir(socket_dir())?.filter_map(|entry| entry.ok()) {
-        let path = entry.path();
+    socket_paths()?
+        .find_map(|path| try_connect(&path))
+        .ok_or_else(|| IoError::new(ErrorKind::NotFound, "no socket found"))
+}
 
-        // Skip files that aren't Alacritty sockets.
-        let socket_prefix = socket_prefix();
-        if path
-            .file_name()
+/// Iterate over the IPC sockets of all instances sharing this display server.
+fn socket_paths() -> IoResult<impl Iterator<Item = PathBuf>> {
+    let socket_prefix = socket_prefix();
+    let entries = fs::read_dir(socket_dir())?;
+
+    Ok(entries.filter_map(|entry| entry.ok()).map(|entry| entry.path()).filter(move |path| {
+        path.file_name()
             .and_then(OsStr::to_str)
-            .filter(|file| file.starts_with(&socket_prefix) && file.ends_with(".sock"))
-            .is_none()
-        {
-            continue;
-        }
+            .is_some_and(|file| file.starts_with(&socket_prefix) && file.ends_with(".sock"))
+    }))
+}
 
-        // Attempt to connect to the socket.
-        match UnixStream::connect(&path) {
-            Ok(socket) => return Ok(socket),
-            // Delete orphan sockets.
-            Err(error) if error.kind() == ErrorKind::ConnectionRefused => {
-                let _ = fs::remove_file(&path);
-            },
-            // Ignore other errors like permission issues.
-            Err(_) => (),
-        }
+/// Remove sockets of instances which aren't running.
+///
+/// If an instance was closed without properly cleaning itself up (i.e. via SIGKILL) then IPC
+/// sockets are left behind. This will clean them up.
+pub fn remove_dead_sockets() {
+    let socket_paths = match socket_paths() {
+        Ok(socket_paths) => socket_paths,
+        Err(err) => {
+            warn!("Unable to iterate old IPC sockets: {err}");
+            return;
+        },
+    };
+
+    for path in socket_paths {
+        let _ = try_connect(&path);
     }
+}
 
-    Err(IoError::new(ErrorKind::NotFound, "no socket found"))
+/// Connect to a socket or remove it if no instance is listening.
+fn try_connect(path: &Path) -> Option<UnixStream> {
+    match UnixStream::connect(path) {
+        Ok(socket) => Some(socket),
+        // Delete orphan sockets.
+        Err(err) if err.kind() == ErrorKind::ConnectionRefused => {
+            let _ = fs::remove_file(path);
+            None
+        },
+        // Ignore other errors like permission issues.
+        Err(_) => None,
+    }
 }
 
 /// File prefix matching all available sockets.

--- a/alacritty/src/polling/signal.rs
+++ b/alacritty/src/polling/signal.rs
@@ -1,9 +1,11 @@
 //! Unix signal listener.
 
 use std::io::{Error as IoError, Read};
+use std::mem::MaybeUninit;
 use std::os::unix::net::UnixStream;
+use std::ptr;
 
-use signal_hook::consts::{SIGINT, SIGTERM};
+use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
 use signal_hook::low_level::pipe;
 use winit::event_loop::EventLoopProxy;
 
@@ -19,7 +21,11 @@ impl SignalListener {
     pub fn new(event_proxy: EventLoopProxy<Event>) -> Result<Self, IoError> {
         let (pipe, write) = UnixStream::pair()?;
         pipe::register(SIGINT, write.try_clone()?)?;
-        pipe::register(SIGTERM, write)?;
+        pipe::register(SIGTERM, write.try_clone()?)?;
+        if !is_ignored(SIGHUP) {
+            pipe::register(SIGHUP, write)?;
+        }
+
         Ok(Self { event_proxy, pipe })
     }
 
@@ -34,4 +40,27 @@ impl SignalListener {
 
         Ok(())
     }
+}
+
+/// Check a signal's ignore disposition.
+///
+/// Returns true when the given signal is ignored by this process. A signal whose disposition
+/// cannot be queried is reported as not ignored.
+fn is_ignored(signal: libc::c_int) -> bool {
+    let mut action = MaybeUninit::<libc::sigaction>::uninit();
+
+    // SAFETY: `libc::sigaction` is an FFI declaration, so the contract comes from sigaction(2). A
+    // NULL `act` installs no action and leaves the current disposition unmodified, `oact` receives
+    // that disposition, and a rejected signal number is reported through the return value without
+    // writing to `oact`.
+    let queried = unsafe { libc::sigaction(signal, ptr::null(), action.as_mut_ptr()) };
+
+    if queried != 0 {
+        return false;
+    }
+
+    // SAFETY: `sigaction` returned success, so it wrote a whole `struct sigaction` to `action`.
+    let action = unsafe { action.assume_init() };
+
+    action.sa_sigaction == libc::SIG_IGN
 }


### PR DESCRIPTION
3 main fixes:

1. Cleanup inside `Processor::exiting` since macOS never reaches `Drop` on exit
2. Cleanup on `SIGHUP`
3. Cleaning up old sockets on startup

- [x] No LLMs were used for the creation of this patch
